### PR TITLE
Customize GitBook Sidebar Title

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,4 @@
+root: ./README.md
+navigation:
+  - title: Wallet Development Kit (WDK)
+    file: README.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,3 +1,0 @@
-# Wallet Development Kit Documentation
-
-* [Overview](README.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,3 @@
+# Wallet Development Kit Documentation
+
+* [Overview](README.md)


### PR DESCRIPTION
### Problem

By default, GitBook displays the root `README.md` with the title “README” in the sidebar, which is not informative or aligned with the product identity.

### Action

This PR introduces a `.gitbook.yaml `configuration file to override the default sidebar behavior on the GitBook documentation site: 
- Set README.md as the root entry
- Rename the sidebar entry from “README” to “Wallet Development Kit (WDK)”