### PR TITLE
Add exit to quickstart

### DIFF
--- a/start-building/nodejs-bare-quickstart.md
+++ b/start-building/nodejs-bare-quickstart.md
@@ -110,6 +110,7 @@ async function main() {
     // Your code will go here
   } catch (error) {
     console.error('Application error:', error.message)
+    process.exit(1)
   }
 }
 
@@ -250,9 +251,11 @@ async function main() {
     }
 
     console.log('Application completed successfully!')
+    process.exit(0)
 
   } catch (error) {
     console.error('Application error:', error.message)
+    process.exit(1)
   }
 }
 

--- a/start-building/nodejs-bare-quickstart.md
+++ b/start-building/nodejs-bare-quickstart.md
@@ -72,7 +72,7 @@ and run the command `npm i -g bare`
 First, we need to create a folder and initialize the project
 
 ```bash
-mkdir wdk-quickstart && cd wdk-quickstart && npm init -y
+mkdir wdk-quickstart && cd wdk-quickstart && npm init -y && npm pkg set type=module
 ```
 
 Then install necessary WDK modules


### PR DESCRIPTION
### Summary

This PR updates the Node.js Quickstart documentation to improve compatibility and clarity for new projects.

### Changes

- **Ensured Modern ES Module Support:**  
  Updated the project initialization command to:
  ```bash
  mkdir wdk-quickstart && cd wdk-quickstart && npm init -y && npm pkg set type=module
  ```
  This ensures `"type": "module"` is set in `package.json` by default, so `import`/`export` works out of the box—avoiding ESM-related Node warnings and keeping the setup step concise.

- **Explicit Process Exit Calls:**  
  Added `process.exit(0)` on success and kept `process.exit(1)` on error in the quickstart’s example `main()` function. This ensures clear script termination and expected process status codes, particularly useful in CI or scripting environments.

### Rationale

- Having `"type": "module"` set during setup saves users an extra manual step, especially for those new to Node.js ECMAScript Modules.
- Explicit termination with `process.exit` prevents lingering processes and provides clear success/failure signals.

---

**No breaking changes.**  
Documentation is now easier to follow and more robust for both manual and automated use.