### PR TITLE
Add Plasma network and Sepolia testnet support with comprehensive documentation

### DIFF
--- a/sdk/wallet-modules/README.md
+++ b/sdk/wallet-modules/README.md
@@ -43,7 +43,7 @@ This package works with multiple blockchain networks through wallet registration
     <tr>
       <td><img src="../../assets/logos/ethereum-logo.png" alt="Ethereum logo" width="20" height="20" style="object-fit:contain;" /></td>
       <td><strong>EVM Chains</strong></td>
-      <td>Ethereum, L2s, etc.</td>
+      <td>Ethereum, Sepolia Testnet, L2s, etc.</td>
       <td>
         <a href="../wallet-modules/wallet-evm/">wallet-evm</a>, 
         <a href="../wallet-modules/wallet-evm-erc-4337/">wallet-evm-erc-4337</a>

--- a/sdk/wallet-modules/wallet-evm-erc-4337/README.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/README.md
@@ -41,7 +41,7 @@ A simple and secure package to manage ERC-4337 compliant wallets for EVM-compati
 This package works with any EVM-compatible blockchain, including:
 
 - **Ethereum Mainnet**
-- **Ethereum Testnets** (Sepolia, etc.)
+- **Ethereum Testnets** (Sepolia)
 - **Other EVM Chains** (Polygon, Arbitrum, Avalanche C-chain, Plasma etc.)
 
 ## Next Steps

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -325,6 +325,82 @@ const avalancheConfig = {
 }
 ```
 
+### Plasma
+
+```javascript
+// Plasma (example Layer 2)
+const plasmaConfig = {
+  chainId: 9745,
+  blockchain: 'plasma',
+  provider: 'https://plasma.drpc.org',
+  // For ERC-4337 support, optional fields:
+  bundlerUrl: 'https://api.candide.dev/public/v3/9745',
+  paymasterUrl: 'https://api.candide.dev/public/v3/9745',
+  paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
+  entrypointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+  safeModulesVersion: '0.3.0',
+  paymasterToken: {
+    address: '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb' // USDT
+  },
+  transferMaxFee: 100000 // 100,000 paymaster token units (e.g., 0.1 USDT if 6 decimals)
+}
+```
+
+### Sepolia Testnet (USDt ERC-20)
+
+> **Legal Notice:**
+> 
+> The Sepolia deployment of USDt (0xd077a400968890eacc75cdc901f0356c943e4fdb) is only a testnet mock token:
+> - It has zero value and is only for testing purposes. 
+> - This token is not listed on Tether's transparency page and does not represent official recognition.
+> - All faucets for test USDt are third-party and not run or endorsed by Tether.
+> - Tether makes no warranties about any tokens or faucets. Support for tokens by the indexer is not an endorsement—future versions may index unrelated tokens or tokens on mainnets.
+> - The goal is to let developers test account abstraction with WDK on Sepolia with no value at stake.
+
+#### USDt ERC-20 on Sepolia (mock/testnet only)
+
+````javascript
+const usdtSepolia = {
+  address: '0xd077a400968890eacc75cdc901f0356c943e4fdb',
+  name: 'USDt (Testnet Sepolia)',
+  decimals: 6 // As on production
+}
+
+// Pimlico
+const sepoliaConfigPimlico = {
+  chainId: 11155111,
+  blockchain: 'ethereum',
+  provider: 'https://sepolia.drpc.org',
+  bundlerUrl: 'https://public.pimlico.io/v2/11155111/rpc',
+  paymasterUrl: 'https://public.pimlico.io/v2/11155111/rpc',
+  paymasterAddress: '0x777777777777AeC03fd955926DbF81597e66834C',
+  entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+  safeModulesVersion: '0.3.0',
+  paymasterToken: usdtSepolia,
+  transferMaxFee: 100000 // 0.1 USDt (6 decimals)
+}
+
+// Candide
+const sepoliaConfigCandide = {
+  chainId: 11155111,
+  blockchain: 'ethereum',
+  provider: 'https://sepolia.drpc.org',
+  bundlerUrl: 'https://api.candide.dev/public/v3/11155111',
+  paymasterUrl: 'https://api.candide.dev/public/v3/11155111',
+  paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
+  entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+  safeModulesVersion: '0.3.0',
+  paymasterToken: usdtSepolia,
+  transferMaxFee: 100000
+}
+````
+
+**USDt on Sepolia contract:** [0xd077a400968890eacc75cdc901f0356c943e4fdb](https://sepolia.etherscan.io/address/0xd077a400968890eacc75cdc901f0356c943e4fdb)
+
+**Get test USDt:**
+- [Pimlico USDt (Sepolia) Faucet](https://faucet.pimlico.io/)
+- Candide faucet: _link coming soon_
+
 <table data-card-size="large" data-view="cards">
 	<thead>
 		<tr>

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -389,8 +389,8 @@ Ethereum Sepolia is a testnet. The USDt tokens available at the links below are 
 **USDt on Sepolia contract:** [0xd077a400968890eacc75cdc901f0356c943e4fdb](https://sepolia.etherscan.io/address/0xd077a400968890eacc75cdc901f0356c943e4fdb)
 
 **Get test USDt:**
-- [Pimlico Faucet](https://dashboard.pimlico.io/test-erc20-faucet )
-- [Candide faucet]: (https://dashboard.candide.dev/faucet)
+- [Pimlico faucet](https://dashboard.pimlico.io/test-erc20-faucet)
+- [Candide faucet](https://dashboard.candide.dev/faucet)
 
 <table data-card-size="large" data-view="cards">
 	<thead>

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -346,18 +346,7 @@ const plasmaConfig = {
 }
 ```
 
-### Sepolia Testnet (USDt ERC-20)
-
-> **Legal Notice:**
-> 
-> The Sepolia deployment of USDt (0xd077a400968890eacc75cdc901f0356c943e4fdb) is only a testnet mock token:
-> - It has zero value and is only for testing purposes. 
-> - This token is not listed on Tether's transparency page and does not represent official recognition.
-> - All faucets for test USDt are third-party and not run or endorsed by Tether.
-> - Tether makes no warranties about any tokens or faucets. Support for tokens by the indexer is not an endorsement—future versions may index unrelated tokens or tokens on mainnets.
-> - The goal is to let developers test account abstraction with WDK on Sepolia with no value at stake.
-
-#### USDt ERC-20 on Sepolia (mock/testnet only)
+### Sepolia Testnet (USDt ERC-20 mock/testnet only)
 
 ````javascript
 
@@ -389,6 +378,9 @@ const sepoliaConfigCandide = {
   transferMaxFee: 100000
 }
 ````
+
+**Important**
+Ethereum Sepolia is a testnet. The USDt tokens available at the links below are not real and do not entitle the holder to anything. In particular, they cannot be redeemed with Tether International, S.A. de C.V. ("Tether International") and are not Tether Tokens as described in [Tether International's Terms of Service](https://tether.to/en/legal). The USDt tokens available at the links below on this testnet are intended for testing WDK on Ethereum Sepolia. The links below are links to third-party websites and are Third-Party Information as described in Tether Operations, S.A. de [C.V.'s Website Terms](https://tether.io/terms/)
 
 **USDt on Sepolia contract:** [0xd077a400968890eacc75cdc901f0356c943e4fdb](https://sepolia.etherscan.io/address/0xd077a400968890eacc75cdc901f0356c943e4fdb)
 

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -398,7 +398,7 @@ const sepoliaConfigCandide = {
 **USDt on Sepolia contract:** [0xd077a400968890eacc75cdc901f0356c943e4fdb](https://sepolia.etherscan.io/address/0xd077a400968890eacc75cdc901f0356c943e4fdb)
 
 **Get test USDt:**
-- [Pimlico USDt (Sepolia) Faucet](https://faucet.pimlico.io/)
+- [Pimlico USDt (Sepolia) Faucet](https://dashboard.pimlico.io/test-erc20-faucet )
 - Candide faucet: _link coming soon_
 
 <table data-card-size="large" data-view="cards">

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -360,11 +360,6 @@ const plasmaConfig = {
 #### USDt ERC-20 on Sepolia (mock/testnet only)
 
 ````javascript
-const usdtSepolia = {
-  address: '0xd077a400968890eacc75cdc901f0356c943e4fdb',
-  name: 'USDt (Testnet Sepolia)',
-  decimals: 6 // As on production
-}
 
 // Pimlico
 const sepoliaConfigPimlico = {
@@ -376,7 +371,7 @@ const sepoliaConfigPimlico = {
   paymasterAddress: '0x777777777777AeC03fd955926DbF81597e66834C',
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
-  paymasterToken: usdtSepolia,
+  paymasterToken: '0xd077a400968890eacc75cdc901f0356c943e4fdb', // USDT Sepolia
   transferMaxFee: 100000 // 0.1 USDt (6 decimals)
 }
 
@@ -390,7 +385,7 @@ const sepoliaConfigCandide = {
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
-  paymasterToken: usdtSepolia,
+  paymasterToken: '0xd077a400968890eacc75cdc901f0356c943e4fdb', // USDT Sepolia
   transferMaxFee: 100000
 }
 ````

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -340,9 +340,9 @@ const plasmaConfig = {
   entrypointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    address: '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb' // USDT
+    address: '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb' // USDt
   },
-  transferMaxFee: 100000 // 100,000 paymaster token units (e.g., 0.1 USDT if 6 decimals)
+  transferMaxFee: 100000 // 100,000 paymaster token units (e.g., 0.1 USDt if 6 decimals)
 }
 ```
 
@@ -361,7 +361,7 @@ const sepoliaConfigPimlico = {
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDT Sepolia
+    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDt Sepolia
   }, 
   transferMaxFee: 100000 // 0.1 USDt (6 decimals)
 }
@@ -377,7 +377,7 @@ const sepoliaConfigCandide = {
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDT Sepolia
+    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDt Sepolia
   },   
   transferMaxFee: 100000
 }
@@ -389,8 +389,8 @@ Ethereum Sepolia is a testnet. The USDt tokens available at the links below are 
 **USDt on Sepolia contract:** [0xd077a400968890eacc75cdc901f0356c943e4fdb](https://sepolia.etherscan.io/address/0xd077a400968890eacc75cdc901f0356c943e4fdb)
 
 **Get test USDt:**
-- [Pimlico USDt (Sepolia) Faucet](https://dashboard.pimlico.io/test-erc20-faucet )
-- Candide faucet: _link coming soon_
+- [Pimlico Faucet](https://dashboard.pimlico.io/test-erc20-faucet )
+- [Candide faucet]: (https://dashboard.candide.dev/faucet)
 
 <table data-card-size="large" data-view="cards">
 	<thead>

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -360,7 +360,9 @@ const sepoliaConfigPimlico = {
   paymasterAddress: '0x777777777777AeC03fd955926DbF81597e66834C',
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
-  paymasterToken: '0xd077a400968890eacc75cdc901f0356c943e4fdb', // USDT Sepolia
+  paymasterToken: {
+    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDT Sepolia
+  }, 
   transferMaxFee: 100000 // 0.1 USDt (6 decimals)
 }
 
@@ -374,7 +376,9 @@ const sepoliaConfigCandide = {
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
-  paymasterToken: '0xd077a400968890eacc75cdc901f0356c943e4fdb', // USDT Sepolia
+  paymasterToken: {
+    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDT Sepolia
+  },   
   transferMaxFee: 100000
 }
 ````

--- a/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
@@ -38,6 +38,12 @@ npm install @tetherto/wdk-wallet-evm-erc-4337
 
 ### Creating a New Wallet
 
+{% hint style="info" %}
+> To use Sepolia, Plasma, or any test/mock tokens, see the [Testnet & Mock Token configuration section in configuration.md](./configuration.md#sepolia-testnet-usdt-erc-20).
+
+{% endhint %}
+
+
 ```javascript
 import WalletManagerEvmErc4337, { 
   WalletAccountEvmErc4337, 
@@ -399,23 +405,6 @@ async function transferTokensGasless(account) {
   }
 }
 ```
-
-## Testnet & Mock Token Quickstart
-
-You can develop and test account abstraction (ERC-4337) on Sepolia using a mock USDt token. Both Pimlico and Candide paymaster integrations are supported:
-
-```javascript
-const usdtSepolia = {
-  address: '0xd077a400968890eacc75cdc901f0356c943e4fdb',
-  name: 'USDt (Testnet Sepolia)',
-  decimals: 6
-};
-
-const sepoliaConfigPimlico = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
-const sepoliaConfigCandide = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
-```
-
-> **Legal Notice:** Sepolia USDt is a mock testnet token with zero value, not issued/endorsed by Tether, and is for dev/test only. Faucets are third party. See [configuration.md](./configuration.md) for full legal details and warnings.
 
 
 <table data-card-size="large" data-view="cards">

--- a/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
@@ -38,12 +38,6 @@ npm install @tetherto/wdk-wallet-evm-erc-4337
 
 ### Creating a New Wallet
 
-{% hint style="info" %}
-> To use Sepolia, Plasma, or any test/mock tokens, see the [Testnet & Mock Token configuration section in configuration.md](./configuration.md#sepolia-testnet-usdt-erc-20).
-
-{% endhint %}
-
-
 ```javascript
 import WalletManagerEvmErc4337, { 
   WalletAccountEvmErc4337, 
@@ -86,6 +80,11 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', { // Smart 
   }
 })
 ```
+
+{% hint style="info" %}
+> To use test/mock tokens instead of real funds, see the Testnet [configuration section](./configuration.md#sepolia-testnet-usdt-erc-20).
+
+{% endhint %}
 
 ### Managing Multiple Accounts
 

--- a/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
@@ -400,6 +400,23 @@ async function transferTokensGasless(account) {
 }
 ```
 
+## Testnet & Mock Token Quickstart
+
+You can develop and test account abstraction (ERC-4337) on Sepolia using a mock USDt token. Both Pimlico and Candide paymaster integrations are supported:
+
+```javascript
+const usdtSepolia = {
+  address: '0xd077a400968890eacc75cdc901f0356c943e4fdb',
+  name: 'USDt (Testnet Sepolia)',
+  decimals: 6
+};
+
+const sepoliaConfigPimlico = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
+const sepoliaConfigCandide = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
+```
+
+> **Legal Notice:** Sepolia USDt is a mock testnet token with zero value, not issued/endorsed by Tether, and is for dev/test only. Faucets are third party. See [configuration.md](./configuration.md) for full legal details and warnings.
+
 
 <table data-card-size="large" data-view="cards">
 	<thead>

--- a/sdk/wallet-modules/wallet-evm/README.md
+++ b/sdk/wallet-modules/wallet-evm/README.md
@@ -41,7 +41,7 @@ A simple and secure package to manage BIP-44 wallets for EVM (Ethereum Virtual M
 
 This package works with any EVM-compatible blockchain, including:
 
-- **Ethereum**: Mainnet, Goerli, Sepolia
+- **Ethereum**: Mainnet, Sepolia
 - **Polygon**: Mainnet, Mumbai
 - **Binance Smart Chain (BSC)**: Mainnet, Testnet
 - **Arbitrum**: One, Nova

--- a/sdk/wallet-modules/wallet-evm/configuration.md
+++ b/sdk/wallet-modules/wallet-evm/configuration.md
@@ -159,6 +159,22 @@ const arbitrumConfig = {
 const bscConfig = {
   provider: 'https://bsc-dataseed.binance.org'
 }
+
+// Avalanche C-Chain
+const avalancheConfig = {
+  provider: 'https://avalanche-c-chain-rpc.publicnode.com',
+}
+
+// Plasma 
+const plasmaConfig = {
+  provider: 'https://plasma.drpc.org',
+}
+
+// Sepolia Testnet
+const sepoliaConfig = {
+  provider: 'https://sepolia.drpc.org',
+}
+
 ```
 
 

--- a/sdk/wallet-modules/wallet-evm/usage.md
+++ b/sdk/wallet-modules/wallet-evm/usage.md
@@ -31,11 +31,6 @@ npm install @tetherto/wdk-wallet-evm
 
 ### Creating a New Wallet
 
-{% hint style="info" %}
-> To use Sepolia, Plasma, or any test/mock tokens, see the [Testnet & Mock Token configuration section in configuration.md](./configuration.md#sepolia-testnet-usdt-erc-20).
-
-{% endhint %}
-
 ```javascript
 import WalletManagerEvm, { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
 
@@ -63,6 +58,10 @@ const account = await wallet.getAccount(0)
 // Convert to a read-only account
 const readOnlyAccount = await account.toReadOnlyAccount()
 ```
+{% hint style="info" %}
+> To use test/mock tokens instead of real funds, see the Testnet [configuration section](./configuration.md#sepolia-testnet-usdt-erc-20).
+
+{% endhint %}
 
 ### Managing Multiple Accounts
 

--- a/sdk/wallet-modules/wallet-evm/usage.md
+++ b/sdk/wallet-modules/wallet-evm/usage.md
@@ -381,6 +381,23 @@ try {
 }
 ``` 
 
+## Testnet & Mock Token Quickstart
+
+You can develop and test account abstraction (ERC-4337) on Sepolia using a mock USDt token. Both Pimlico and Candide paymaster integrations are supported:
+
+```javascript
+const usdtSepolia = {
+  address: '0xd077a400968890eacc75cdc901f0356c943e4fdb',
+  name: 'USDt (Testnet Sepolia)',
+  decimals: 6
+};
+
+const sepoliaConfigPimlico = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
+const sepoliaConfigCandide = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
+```
+
+> **Legal Notice:** Sepolia USDt is a mock testnet token with zero value, not issued/endorsed by Tether, and is for dev/test only. Faucets are third party. See [configuration.md](./configuration.md) for full legal details and warnings.
+
 
 
 <table data-card-size="large" data-view="cards">

--- a/sdk/wallet-modules/wallet-evm/usage.md
+++ b/sdk/wallet-modules/wallet-evm/usage.md
@@ -31,6 +31,11 @@ npm install @tetherto/wdk-wallet-evm
 
 ### Creating a New Wallet
 
+{% hint style="info" %}
+> To use Sepolia, Plasma, or any test/mock tokens, see the [Testnet & Mock Token configuration section in configuration.md](./configuration.md#sepolia-testnet-usdt-erc-20).
+
+{% endhint %}
+
 ```javascript
 import WalletManagerEvm, { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
 
@@ -380,23 +385,6 @@ try {
   }
 }
 ``` 
-
-## Testnet & Mock Token Quickstart
-
-You can develop and test account abstraction (ERC-4337) on Sepolia using a mock USDt token. Both Pimlico and Candide paymaster integrations are supported:
-
-```javascript
-const usdtSepolia = {
-  address: '0xd077a400968890eacc75cdc901f0356c943e4fdb',
-  name: 'USDt (Testnet Sepolia)',
-  decimals: 6
-};
-
-const sepoliaConfigPimlico = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
-const sepoliaConfigCandide = {/* ...see configuration.md for full config */ paymasterToken: usdtSepolia };
-```
-
-> **Legal Notice:** Sepolia USDt is a mock testnet token with zero value, not issued/endorsed by Tether, and is for dev/test only. Faucets are third party. See [configuration.md](./configuration.md) for full legal details and warnings.
 
 
 

--- a/start-building/nodejs-bare-quickstart.md
+++ b/start-building/nodejs-bare-quickstart.md
@@ -64,11 +64,11 @@ and run the command `npm i -g bare`
 {% endtabs %}
 
 {% hint style="info" %}
-You can try all features using the Sepolia testnet for development—no real funds required. You can use the Pimlico Faucet to get some Sepolia USDt. 
+You can try all features using the Sepolia testnet for development — no real funds required. You can use the Pimlico Faucet to get some Sepolia USDt. 
 
 <a class="button primary" href="https://dashboard.pimlico.io/test-erc20-faucet"> Sepolia testnet USDt</a>
 
-See the [configuration.md](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md) for quick setup and Sepolia testnet configuration.
+See the [configuration](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md) for quick setup and Sepolia testnet configuration.
 {% endhint %}
 
 ***

--- a/start-building/nodejs-bare-quickstart.md
+++ b/start-building/nodejs-bare-quickstart.md
@@ -63,7 +63,13 @@ and run the command `npm i -g bare`
 {% endtab %}
 {% endtabs %}
 
-<!-- **Note**: We'll use testnets for this tutorial, so you don't need real funds to get started! -->
+{% hint style="info" %}
+You can try all features using the Sepolia testnet for development—no real funds required. You can use the Pimlico Faucet to get some Sepolia USDt. 
+
+<a class="button primary" href="https://dashboard.pimlico.io/test-erc20-faucet"> Sepolia testnet USDt</a>
+
+See the [configuration.md](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md) for quick setup and Sepolia testnet configuration.
+{% endhint %}
 
 ***
 

--- a/start-building/nodejs-bare-quickstart.md
+++ b/start-building/nodejs-bare-quickstart.md
@@ -64,9 +64,10 @@ and run the command `npm i -g bare`
 {% endtabs %}
 
 {% hint style="info" %}
-You can try all features using the Sepolia testnet for development — no real funds required. You can use the Pimlico Faucet to get some Sepolia USDt. 
+You can try all features without real funds required. You can use the Pimlico or Candide faucets to get some Sepolia USDt. 
 
-<a class="button primary" href="https://dashboard.pimlico.io/test-erc20-faucet"> Sepolia testnet USDt</a>
+<a class="button primary" href="https://dashboard.pimlico.io/test-erc20-faucet"> Get mock/test USDt on Pimlico </a>
+<a class="button primary" href="https://dashboard.candide.dev/faucet"> Get mock/test USDt on Candide </a>
 
 See the [configuration](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md) for quick setup and Sepolia testnet configuration.
 {% endhint %}

--- a/start-building/react-native-quickstart.md
+++ b/start-building/react-native-quickstart.md
@@ -31,9 +31,10 @@ In this quickstart, you'll run a production-ready multi-chain wallet app that:
 * [ ] Includes QR code scanning and send/receive flows
 
 {% hint style="info" %}
-You can try all features using the Sepolia testnet for development—no real funds required. You can use the Pimlico Faucet to get some Sepolia USDt. 
+You can try all features without real funds required. You can use the Pimlico or Candide faucets to get some Sepolia USDt. 
 
-<a class="button primary" href="https://dashboard.pimlico.io/test-erc20-faucet"> Sepolia testnet USDt</a>
+<a class="button primary" href="https://dashboard.pimlico.io/test-erc20-faucet"> Get mock/test USDt on Pimlico </a>
+<a class="button primary" href="https://dashboard.candide.dev/faucet"> Get mock/test USDt on Candide </a>
 
 See the [configuration.md](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md) for quick setup and Sepolia testnet configuration.
 {% endhint %}

--- a/start-building/react-native-quickstart.md
+++ b/start-building/react-native-quickstart.md
@@ -30,6 +30,14 @@ In this quickstart, you'll run a production-ready multi-chain wallet app that:
 * [ ] Shows real-time balances and transaction history
 * [ ] Includes QR code scanning and send/receive flows
 
+{% hint style="info" %}
+You can try all features using the Sepolia testnet for development—no real funds required. You can use the Pimlico Faucet to get some Sepolia USDt. 
+
+<a class="button primary" href="https://dashboard.pimlico.io/test-erc20-faucet"> Sepolia testnet USDt</a>
+
+See the [configuration.md](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md) for quick setup and Sepolia testnet configuration.
+{% endhint %}
+
 ***
 
 ## Prerequisites


### PR DESCRIPTION
  ## Summary
  - Add Plasma network configuration and integration for wallet-evm and wallet-evm-erc-4337 modules
  - Add Sepolia testnet configuration with USDt ERC-20 mock/test token support
  - Update quickstart guides with testnet options for developers to test without real funds
  - Include faucet links (Pimlico and Candide) for obtaining test USDt on Sepolia
  - Add legal notices clarifying testnet tokens are for testing only

  ## Changes
  ### Network Support
  - **Plasma**: Added configuration with Candide bundler/paymaster support (chain ID: 9745)
  - **Sepolia**: Added testnet configurations for both Pimlico and Candide paymasters (chain ID: 11155111)

  ### Documentation Updates
  - Updated `wallet-evm` and `wallet-evm-erc-4337` configuration guides with Plasma and Sepolia examples
  - Added testnet usage notes to wallet module usage documentation
  - Updated network compatibility lists across README files
  - Added provider configurations for Avalanche C-Chain, Plasma, and Sepolia

  ### Developer Experience
  - Added prominent testnet information in quickstart guides (Node.js and React Native)
  - Included direct links to Pimlico and Candide faucets for obtaining test USDt
  - Added disclaimers about testnet tokens
  - Provided USDt Sepolia contract address and Etherscan links