### PR TITLE
fix: react native + starter wallet improvements

### DIFF
--- a/examples-and-starters/react-native-starter.md
+++ b/examples-and-starters/react-native-starter.md
@@ -25,12 +25,71 @@ The React Native Starter Alpha is an Expo + React Native app showing how to buil
 
 ***
 
+{% hint style="warning" %}
+**Prerequisites:** Node.js 22+, and either Xcode (iOS) or Android SDK API 29+ (Android). See the [React Native Quickstart](../start-building/react-native-quickstart.md#prerequisites) for details.
+{% endhint %}
+
+### Quick Start
+
+Get your React Native wallet running in minutes with these simple steps:
+
+{% stepper %}
+{% step %}
+#### Clone and Install
+
+```bash
+git clone https://github.com/tetherto/wdk-starter-react-native.git && cd wdk-starter-react-native && npm install
+```
+{% endstep %}
+
+{% step %}
+#### Configure Environment
+
+```bash
+cp .env.example .env
+```
+
+Get your free WDK Indexer API key [here](../tools/indexer-api/get-started.md) and add it to your `.env` file:
+
+```bash
+EXPO_PUBLIC_WDK_INDEXER_BASE_URL=https://wdk-api.tether.io
+EXPO_PUBLIC_WDK_INDEXER_API_KEY=your_actual_api_key_here
+# Optional: For Tron network support
+EXPO_PUBLIC_TRON_API_KEY=your_tron_api_key
+EXPO_PUBLIC_TRON_API_SECRET=your_tron_api_secret
+```
+
+{% endstep %}
+
+{% step %}
+#### Run Your App
+
+For first-time setup, generate native project files:
+
+```bash
+npx expo prebuild
+```
+
+Then run the app:
+
+```bash
+npm run ios     # iOS Simulator
+npm run android # Android Emulator
+```
+{% endstep %}
+{% endstepper %}
+
+***
+
+{% hint style="info" %}
+**Need detailed instructions?** Check out the complete [React Native Quickstart](../start-building/react-native-quickstart.md) guide for step-by-step setup, configuration, and troubleshooting.
+{% endhint %}
+
 ### Features
 
 **Multi-Token & Chain Support**
-
 * **BTC**: Native SegWit transfers on Bitcoin network
-* **USD₮**: Gasless transactions on EVM networks (Ethereum, Polygon, Arbitrum) and native transfers on TON
+* **USD₮**: Gasless transactions on EVM (Ethereum, Polygon, Arbitrum), native transfers on TON and Tron
 * **XAU₮**: Gasless transactions on Ethereum network
 
 **Wallet Management**
@@ -56,54 +115,6 @@ The React Native Starter Alpha is an Expo + React Native app showing how to buil
 
 ***
 
-### Quick Start
-
-Get your React Native wallet running in minutes with these simple steps:
-
-{% stepper %}
-{% step %}
-#### Clone Repository
-
-```bash
-git clone https://github.com/tetherto/wdk-starter-react-native.git
-cd wdk-starter-react-native
-npm install
-```
-{% endstep %}
-
-{% step %}
-#### Configure Environment
-
-```bash
-cp .env.example .env
-# Edit .env and add your WDK Indexer API key
-```
-{% endstep %}
-
-{% step %}
-#### Generate Bundle
-
-```bash
-npm run gen:bundle
-```
-{% endstep %}
-
-{% step %}
-#### Run Your App
-
-```bash
-npm run ios    # iOS Simulator
-npm run android # Android Emulator
-```
-{% endstep %}
-{% endstepper %}
-
-{% hint style="info" %}
-**Need detailed instructions?** Check out the complete [React Native Quickstart](../start-building/react-native-quickstart.md) guide for step-by-step setup, configuration, and troubleshooting.
-{% endhint %}
-
-***
-
 ### Project Structure
 
 The starter includes a modular architecture designed for scalability and maintainability:
@@ -111,17 +122,21 @@ The starter includes a modular architecture designed for scalability and maintai
 {% code title="Project Structure" lineNumbers="true" %}
 ```
 src/
-├── app/                         # Screens (Expo Router)
-├── components/                  # UI components
-├── config/                      # Chains/networks config
-├── contexts/                    # React contexts
-├── services/
-│   └── wdk-service/             # Worklet + HRPC + wallet orchestration
-├── spec/                        # HRPC/schema (copied for reference)
-├── worklet/                     # Secret manager worklet entry
-└── wdk-secret-manager-worklet.bundle.js  # Generated bundle
+├── app/                    # Expo Router screens (file-based routing)
+│   ├── onboarding/         # First-time user flows
+│   ├── wallet-setup/       # Create/import wallet screens
+│   ├── send/ & receive/    # Transaction flows
+│   ├── settings.tsx        # Configuration & preferences
+│   └── token-details.tsx   # Individual asset views
+├── components/             # Reusable UI components
+├── config/                 # Network, asset, and chain settings
+├── services/               # Business logic (pricing integration)
+├── hooks/                  # Custom React hooks
+└── utils/                  # Formatting & helper functions
 ```
 {% endcode %}
+
+Detailed project structure can be found in the [Github Repository](https://github.com/tetherto/wdk-starter-react-native/tree/main?tab=readme-ov-file#-project-structure).
 
 ***
 
@@ -133,13 +148,13 @@ src/
 | `npm run android`        | Run on Android emulator/device                |
 | `npm run ios`            | Run on iOS simulator                          |
 | `npm run web`            | Start web development server                  |
-| `npm run gen:bundle`     | Build secret manager worklet bundle           |
 | `npm run prebuild`       | Generate native project files                 |
 | `npm run prebuild:clean` | Clean and regenerate native project files     |
 | `npm run lint`           | Run ESLint                                    |
 | `npm run lint:fix`       | Fix ESLint errors                             |
 | `npm run format`         | Format code with Prettier                     |
 | `npm run format:check`   | Check code formatting                         |
+| `npm run typecheck`      | Run TypeScript type checking                  |
 
 ***
 
@@ -147,10 +162,11 @@ src/
 
 #### Core Technologies
 
-* **Expo**: \~54 with development client
+* **Expo**: \~54.0.8 with development client
 * **React Native**: 0.81.4
-* **React**: 19
-* **Reanimated**: \~4.1
+* **React**: 19.1.0
+* **TypeScript**: \~5.9.2
+* **Reanimated**: \~4.1.0
 * **New Architecture**: Enabled
 
 #### Build Configuration
@@ -159,16 +175,6 @@ src/
 * **iOS**: Latest Xcode toolchain
 * **Build Properties**: Configured via `expo-build-properties`
 
-#### Polyfills
-
-See `metro.config.js` for comprehensive polyfills:
-
-* **Stream, Buffer, Crypto**: Node.js compatibility
-* **Net/TLS, URL, HTTP/HTTPS/HTTP2**: Network compatibility
-* **Zlib, Path**: File system compatibility
-* **Nice-gRPC → Web**: gRPC web compatibility
-* **Sodium-universal → JavaScript**: Cryptographic compatibility
-* **Querystring, Events**: Node.js event system
 
 ***
 

--- a/start-building/react-native-quickstart.md
+++ b/start-building/react-native-quickstart.md
@@ -24,7 +24,7 @@ layout:
 
 In this quickstart, you'll integrate WDK into a React Native app to create a multi-chain wallet that:
 
-- [ ] Supports multiple blockchains (Bitcoin, Ethereum, Polygon, Arbitrum, TON, Tron, Solana)
+- [ ] Supports multiple blockchains (Bitcoin, Ethereum, Polygon, Arbitrum, TON, Tron)
 - [ ] Manages multiple tokens (BTC, USD₮, XAU₮, and more)
 - [ ] Provides secure seed generation and encrypted storage
 - [ ] Shows real-time balances and transaction history
@@ -62,7 +62,7 @@ You have 2 options for using WDK in a React Native. Choose your preferred starti
 {% tab title="Use Starter Template (Fastest)" %}
 Get up and running in 3 minutes with our pre-configured starter template.
 
-[**→ Jump to Starter Template Setup**](#option-1-starter-template-recommended)
+[**→ Jump to Starter Template Setup**](#option-1-starter-template)
 {% endtab %}
 
 {% tab title="Add to Existing App" %}
@@ -102,9 +102,11 @@ cp .env.example .env
 Edit `.env` and add your WDK Indexer API key:
 
 ```bash
-# Replace with your actual API key
+EXPO_PUBLIC_WDK_INDEXER_BASE_URL=https://wdk-api.tether.io
 EXPO_PUBLIC_WDK_INDEXER_API_KEY=your_actual_api_key_here
-EXPO_PUBLIC_WDK_INDEXER_URL=https://your-indexer-url.com
+# Optional: For Tron network support
+EXPO_PUBLIC_TRON_API_KEY=your_tron_api_key
+EXPO_PUBLIC_TRON_API_SECRET=your_tron_api_secret
 ```
 
 {% hint style="info" %}
@@ -317,7 +319,7 @@ export const CHAINS_CONFIG = {
 ```
 
 {% hint style="info" %}
-See the [Chain Configuration Guide](../core-concepts/chain-configuration.md) for complete configuration options for all supported chains.
+See the [Chain Configuration Guide](../sdk/core-module/configuration.md) for complete configuration options for all supported chains.
 {% endhint %}
 
 ### Step 6: Add WalletProvider
@@ -340,7 +342,7 @@ export default function RootLayout() {
       config={{
         indexer: {
           apiKey: process.env.EXPO_PUBLIC_WDK_INDEXER_API_KEY!,
-          url: process.env.EXPO_PUBLIC_WDK_INDEXER_URL!,
+          url: process.env.EXPO_PUBLIC_WDK_INDEXER_BASE_URL!,
         },
         chains: CHAINS_CONFIG,
         enableCaching: true,
@@ -371,7 +373,7 @@ export default function App() {
       config={{
         indexer: {
           apiKey: process.env.EXPO_PUBLIC_WDK_INDEXER_API_KEY!,
-          url: process.env.EXPO_PUBLIC_WDK_INDEXER_URL!,
+          url: process.env.EXPO_PUBLIC_WDK_INDEXER_BASE_URL!,
         },
         chains: CHAINS_CONFIG,
         enableCaching: true,
@@ -442,7 +444,6 @@ export function WalletScreen() {
       <View>
         <Text>Create or Import a Wallet</Text>
         <Button title="Create New Wallet" onPress={handleCreateWallet} />
-        <Button title="Import Wallet" onPress={handleImportWallet} />
       </View>
     );
   }
@@ -661,7 +662,7 @@ Ready to dive deeper? Check out these resources:
 
 - [**Chain Configuration**](../sdk/core-module/configuration.md#wallet-configuration) - Configure blockchain networks
 - [**Wallet Management**](../sdk/core-module/usage.md#account-management) - Create, import, and manage wallets
-- [**Transaction Handling**](../sdk/core-module/usage#transaction-operations) - Send and track transactions
+- [**Transaction Handling**](../sdk/core-module/usage.md#transaction-operations) - Send and track transactions
 
 ### Examples & Starters
 

--- a/tools/indexer-api/get-started.md
+++ b/tools/indexer-api/get-started.md
@@ -49,7 +49,7 @@ Here's a quick example of how to query a token balance.
 {% tab title="curl" %}
 {% code lineNumbers="true" %}
 ```bash
-curl -X GET "https://wdk-api.tether.io/api/v1/ethereum/usdt/0x742d35cc.../token-balances" \
+curl -X GET "https://wdk-api.tether.io/api/v1/ethereum/usdt/0xdac17f958d2ee523a2206206994597c13d831ec7/token-balances" \
      -H "x-api-key: your-api-key-here"
 ```
 {% endcode %}
@@ -73,7 +73,7 @@ async function getTokenBalance(blockchain, token, address) {
   return response.data.tokenBalance;
 }
 
-const balance = await getTokenBalance('ethereum', 'usdt', '0x742d35cc...');
+const balance = await getTokenBalance('ethereum', 'usdt', '0xdac17f958d2ee523a2206206994597c13d831ec7');
 console.log(`Balance: ${balance.amount} ${balance.token.toUpperCase()}`);
 ```
 {% endcode %}

--- a/ui-kits/react-native-ui-kit/README.md
+++ b/ui-kits/react-native-ui-kit/README.md
@@ -1,2 +1,5 @@
 # React Native UI Kit
 
+The WDK React Native UI Kit provides ready-made, themeable components for building wallet applications.
+
+**[Get Started →](get-started.md)**

--- a/ui-kits/react-native-ui-kit/get-started.md
+++ b/ui-kits/react-native-ui-kit/get-started.md
@@ -77,62 +77,54 @@ export default function App() {
 
 ## Integration with WDK
 
-Components are designed to work seamlessly with WDK data models. Here's an example of how to wire WDK data into the UI components:
+Components are designed to work seamlessly with the WDK React Native Provider. Here's an example of how to wire WDK data into the UI components:
 
 {% code title="WDK Integration Example" lineNumbers="true" %}
 ```tsx
 import * as React from 'react'
-import WDK from '@tetherto/wdk'
-import WalletManagerEvm from '@tetherto/wdk-wallet-evm'
-import WalletManagerBtc from '@tetherto/wdk-wallet-btc'
-import { 
-  ThemeProvider, 
-  lightTheme, 
-  Balance, 
-  CryptoAddressInput, 
-  AmountInput 
+import { useWallet } from '@tetherto/wdk-react-native-provider'
+import {
+  ThemeProvider,
+  lightTheme,
+  Balance,
+  CryptoAddressInput,
+  AmountInput
 } from '@tetherto/wdk-uikit-react-native'
 
-export function WalletScreen() {
-  const [balance, setBalance] = React.useState<number | null>(null)
+export function SendScreen() {
+  const { balances, isInitialized } = useWallet()
   const [amount, setAmount] = React.useState('')
-  const [error, setError] = React.useState<string | null>(null)
+  const [address, setAddress] = React.useState('')
 
-  React.useEffect(() => {
-    async function bootstrap() {
-      try {
-        const wdkWithWallets = new WDK('your seed phrase')
-          .registerWallet('bitcoin', WalletManagerBtc, { 
-            provider: 'https://blockstream.info/api' 
-          })
+  // Get USD₮ balance from the balances list
+  const usdtBalance = balances.list.find(b => b.denomination === 'USDT')
 
-        const account = await wdkWithWallets.getAccount('bitcoin', 0)
-        const balance = await account.getBalance()
-
-        setBalance(balance)
-      } catch (e: any) {
-        setError(e?.message ?? 'Unknown error')
-      }
-    }
-
-    bootstrap()
-  }, [])
+  if (!isInitialized) {
+    return <Text>Loading...</Text>
+  }
 
   return (
     <ThemeProvider initialTheme={lightTheme}>
-      <CryptoAddressInput 
-        onQRScan={() => {/* Handle QR scan */}} 
+      <CryptoAddressInput
+        value={address}
+        onChangeText={setAddress}
+        onQRScan={() => {/* Handle QR scan */}}
       />
       <AmountInput
         label="Enter Amount"
-        tokenSymbol="BTC"
+        tokenSymbol="USDT"
         value={amount}
         onChangeText={setAmount}
-        tokenBalance={balance?.toString() ?? '0'}
+        tokenBalance={usdtBalance?.value ?? '0'}
+        tokenBalanceUSD={usdtBalance?.valueUSD ?? '$0.00'}
         inputMode={'token'}
-        onUseMax={() => setAmount(balance?.toString() ?? '0')}
+        onToggleInputMode={() => {/* Toggle fiat/token */}}
+        onUseMax={() => setAmount(usdtBalance?.value ?? '0')}
       />
-      <Balance value={balance ?? 0} currency="BTC" />
+      <Balance
+        value={parseFloat(usdtBalance?.valueUSD ?? '0')}
+        currency="USD"
+      />
     </ThemeProvider>
   )
 }
@@ -190,7 +182,7 @@ export function SendScreen() {
 ## Next Steps
 
 * [Components List](./api-reference.md) - Complete API reference for all components
-* [Theming Guide](theming.md) - Deep dive into theming capabilities
+* [Theming Guide](./theming.md) - Deep dive into theming capabilities
 * [React Native Starter](../../start-building/react-native-quickstart.md) - See a complete implementation
 
 ***


### PR DESCRIPTION
 Summary

  - Fix incorrect scripts, environment variables, and broken links in React Native documentation
  - Update code examples to use current @tetherto/wdk-react-native-provider API
  - Improve developer experience with clearer quick start instructions

  Changes

  react-native-starter.md
  - Remove non-existing gen:bundle script from Quick Start
  - Fix env variable name: EXPO_PUBLIC_WDK_INDEXER_URL → EXPO_PUBLIC_WDK_INDEXER_BASE_URL
  - Add Tron environment variables
  - Update Available Scripts table (remove gen:bundle, add typecheck)
  - Update Project Structure to match actual repository
  - Update Technology Stack versions to match package.json
  - Add prerequisites hint with link to quickstart
  - Combine clone/install into single copyable command
  - Add npx expo prebuild step for first-time setup

  react-native-quickstart.md
  - Remove Solana from supported blockchains list
  - Fix env variable name and add Tron variables
  - Fix broken link to chain configuration guide
  - Fix broken link missing .md extension
  - Remove reference to undefined handleImportWallet function

  ui-kits/react-native-ui-kit/
  - Add content to empty README.md
  - Update integration example to use useWallet hook from @tetherto/wdk-react-native-provider instead of outdated direct WDK API