### PR TITLE
fix: add missing GitBook icons to fiat-moonpay module and changelog

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,9 +5,9 @@
 * [Welcome](README.md)
 * [About WDK](overview/about.md)
 * [Our Vision](overview/vision.md)
-* [Changelog](overview/changelog.md)
 * [Partner Program](overview/partner-program.md)
 * [Get Support](overview/support.md)
+* [Changelog](overview/changelog.md)
 
 ## Start Building
 

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -25,7 +25,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ---
 
 
-### December 23, 2024
+### December 23, 2025
 
 **What's New**
 - Added [MoonPay Fiat Module](../sdk/fiat-modules/fiat-moonpay/) for on-ramp and off-ramp functionality
@@ -37,13 +37,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 - Introduced [All Modules](../sdk/all-modules.md) page in docs for comprehensive module listings
 - Reorganized documentation structure for better navigation
 
-### December 17, 2024
+### December 17, 2025
 
 **What's New**
 - **wdk-core**: Added fiat protocol support for on-ramp integrations ([v1.0.0-beta.5](https://github.com/tetherto/wdk-core/releases/tag/v1.0.0-beta.5))
 - **wdk-wallet**: Added fiat protocol integration ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.6))
 
-### December 3, 2024
+### December 3, 2025
 
 **What's New**
 - **wallet-ton**: Added integration tests ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-ton/releases/tag/v1.0.0-beta.6))
@@ -61,12 +61,12 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
-### November 14, 2024
+### November 14, 2025
 
 **Changes**
 - **wdk-wallet**: Runtime updates and dependency synchronization ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.5))
 
-### November 12, 2024
+### November 12, 2025
 
 **What's New**
 - **wallet-solana**: Added `sendTransaction` support with unit tests ([v1.0.0-beta.3](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.3))
@@ -75,12 +75,12 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 - **wallet-solana**: Fixed `punycode` module resolution issue
 - **lending-aave-evm**: Runtime compatibility updates ([v1.0.0-beta.3](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.3))
 
-### November 11, 2024
+### November 11, 2025
 
 **Changes**
 - **swap-velora-evm**: Runtime compatibility updates ([v1.0.0-beta.4](https://github.com/tetherto/wdk-protocol-swap-velora-evm/releases/tag/v1.0.0-beta.4))
 
-### November 9-10, 2024
+### November 9-10, 2025
 
 **What's New**
 - **wallet-ton-gasless**: Added unit tests ([v1.0.0-beta.3](https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.3))
@@ -92,13 +92,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 - **wallet-evm**: Runtime updates ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.4))
 - **wallet-tron**: Dependency and runtime updates ([v1.0.0-beta.3](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.3))
 
-### November 8, 2024
+### November 8, 2025
 
 **Changes**
 - **wdk-core**: Updated `bare-node-runtime` for improved compatibility ([v1.0.0-beta.4](https://github.com/tetherto/wdk-core/releases/tag/v1.0.0-beta.4))
 - **wallet-spark**: Updated Spark dependencies and improved `dispose` method ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.5))
 
-### November 7, 2024
+### November 7, 2025
 
 **Changes**
 - **wallet-evm-erc-4337**: Fixed destructuring of user operation in `getTransactionReceipt()` ([v1.0.0-beta.3](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.3))

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -1,6 +1,7 @@
 ---
 title: Changelog
 description: Updates and improvements to the Wallet Development Kit (WDK) modules and tools.
+icon: clock-rotate-left
 layout:
   width: default
   title:

--- a/sdk/fiat-modules/fiat-moonpay/api-reference.md
+++ b/sdk/fiat-modules/fiat-moonpay/api-reference.md
@@ -1,6 +1,7 @@
 ---
 title: Fiat MoonPay API Reference
 description: API Reference for the @tetherto/wdk-protocol-fiat-moonpay module
+icon: code
 layout:
   width: default
   title:

--- a/sdk/fiat-modules/fiat-moonpay/configuration.md
+++ b/sdk/fiat-modules/fiat-moonpay/configuration.md
@@ -1,6 +1,7 @@
 ---
 title: Fiat MoonPay Configuration
 description: Configuration options for the @tetherto/wdk-protocol-fiat-moonpay module
+icon: gear
 layout:
   width: default
   title:

--- a/sdk/fiat-modules/fiat-moonpay/usage.md
+++ b/sdk/fiat-modules/fiat-moonpay/usage.md
@@ -1,6 +1,7 @@
 ---
 title: Fiat MoonPay Usage
 description: How to use the @tetherto/wdk-protocol-fiat-moonpay module
+icon: book-open
 layout:
   width: default
   title:


### PR DESCRIPTION
## Summary
- Add missing GitBook-compatible icons to fiat-moonpay module pages to match other modules like wallet-btc
- Add changelog icon for better navigation visibility
- Fix dates in changelog

## Changes
- `sdk/fiat-modules/fiat-moonpay/configuration.md` → `icon: gear`
- `sdk/fiat-modules/fiat-moonpay/usage.md` → `icon: book-open`
- `sdk/fiat-modules/fiat-moonpay/api-reference.md` → `icon: code`
- `overview/changelog.md` → `icon: clock-rotate-left`
