### PR TITLE
Update Spark Configuration and Remove Testnet (DOC-240)

### DIFF
--- a/sdk/wallet-modules/wallet-spark/README.md
+++ b/sdk/wallet-modules/wallet-spark/README.md
@@ -40,15 +40,20 @@ A simple and secure package to manage BIP-32 wallets for the Spark blockchain. T
 - **Message Signing**: Sign and verify messages using Spark identity keys
 - **Memory Safety**: Secure private key management with automatic memory cleanup
 - **TypeScript Support**: Full TypeScript definitions included
-- **Network Support**: Support for Spark [mainnet](../../../resources/concepts.md#mainnet), [testnet](../../../resources/concepts.md#testnet), and [regtest](../../../resources/concepts.md#regtest) networks
+- **Network Support**: Support for Spark [mainnet](../../../resources/concepts.md#mainnet) and [regtest](../../../resources/concepts.md#regtest) networks
 
 ## Supported Networks
 
 This package supports the following Spark networks:
 
 - **Spark Mainnet**: Production Spark network
-- **Spark Testnet**: Spark test network for development
 - **Spark Regtest**: Local Spark network for testing
+
+{% hint style="info" %}
+**Regtest Faucet**
+
+You can obtain test funds for your Regtest environment from the [Lightspark Regtest Faucet](https://app.lightspark.com/regtest-faucet).
+{% endhint %}
 
 ## Next Steps
 

--- a/sdk/wallet-modules/wallet-spark/api-reference.md
+++ b/sdk/wallet-modules/wallet-spark/api-reference.md
@@ -40,7 +40,7 @@ new WalletManagerSpark(seed, config)
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (object, optional): Configuration object
-  - `network` (string, optional): 'MAINNET', 'TESTNET', or 'REGTEST' (default: 'MAINNET')
+  - `network` (string, optional): 'MAINNET' or 'REGTEST' (default: 'MAINNET')
 
 ### Methods
 
@@ -64,7 +64,7 @@ const account = await wallet.getAccount(0)
 const account1 = await wallet.getAccount(1)
 ```
 
-**Note:** Uses derivation path pattern `m/44'/998'/{networkNumber}'/0/{index}` where 998 is the coin type for Spark and networkNumber is 0 for MAINNET, 1 for TESTNET, 2 for SIGNET, or 3 for REGTEST.
+**Note:** Uses derivation path pattern `m/44'/998'/{networkNumber}'/0/{index}` where 998 is the coin type for Spark and networkNumber is 0 for MAINNET, 2 for SIGNET, or 3 for REGTEST.
 
 ##### `getFeeRates()`
 Returns current fee rates for transactions. On Spark network, transactions have zero fees.
@@ -663,7 +663,7 @@ account.dispose()
 
 ```typescript
 interface SparkWalletConfig {
-  network?: 'MAINNET' | 'TESTNET' | 'REGTEST'  // The network (default: "MAINNET")
+  network?: 'MAINNET' | 'REGTEST'  // The network (default: "MAINNET")
   sparkScanApiKey?: string                      // Optional API key for SparkScan requests
 }
 ```

--- a/sdk/wallet-modules/wallet-spark/configuration.md
+++ b/sdk/wallet-modules/wallet-spark/configuration.md
@@ -24,7 +24,7 @@ layout:
 
 ```javascript
 const config = {
-  network: 'MAINNET' // 'MAINNET', 'TESTNET', or 'REGTEST'
+  network: 'MAINNET' // 'MAINNET' or 'REGTEST'
 }
 
 const wallet = new WalletManagerSpark(seedPhrase, config)
@@ -48,9 +48,8 @@ The `network` option specifies which Spark network to use.
 
 **Values:**
 - `"MAINNET"` - Spark mainnet (production)
-- `"TESTNET"` - Spark testnet (development)
 - `"SIGNET"` - Spark signet (testing)
-- `"REGTEST"` - Spark regtest (local development)
+- `"REGTEST"` - Spark regtest (local development) - [Get test funds](https://app.lightspark.com/regtest-faucet)
 
 **Default:** `"MAINNET"`
 
@@ -85,10 +84,7 @@ const mainnetConfig = {
   network: 'MAINNET'
 }
 
-// Testnet configuration  
-const testnetConfig = {
-  network: 'TESTNET'
-}
+
 
 // Regtest configuration
 const regtestConfig = {
@@ -101,13 +97,12 @@ const regtestConfig = {
 Spark uses the [BIP-44](../../../resources/concepts.md#bip-44-multi-account-hierarchy) coin type 998, resulting in derivation paths like:
 - `m/44'/998'/0'/0/0` for MAINNET account index 0
 - `m/44'/998'/0'/0/1` for MAINNET account index 1
-- `m/44'/998'/1'/0/0` for TESTNET account index 0
 - `m/44'/998'/2'/0/0` for SIGNET account index 0
 - `m/44'/998'/3'/0/0` for REGTEST account index 0
 
 The path follows the pattern `m/44'/998'/{networkNumber}'/0/{index}` where:
 - `998` is the coin type for Spark
-- `networkNumber` is 0 for MAINNET, 1 for TESTNET, 2 for SIGNET, or 3 for REGTEST
+- `networkNumber` is 0 for MAINNET, 2 for SIGNET, or 3 for REGTEST
 - `index` is the account index
 
 This ensures compatibility with standard [BIP-44](../../../resources/concepts.md#bip-44-multi-account-hierarchy) wallets while using Spark's unique coin type identifier.

--- a/sdk/wallet-modules/wallet-spark/usage.md
+++ b/sdk/wallet-modules/wallet-spark/usage.md
@@ -52,12 +52,6 @@ const wallet = new WalletManagerSpark(seedPhrase, {
   network: 'MAINNET' // 'MAINNET' or 'REGTEST'
 })
 
-{% hint style="info" %}
-**Need Test Funds?**
-
-For development on **REGTEST**, you can get test funds from the [Lightspark Regtest Faucet](https://app.lightspark.com/regtest-faucet).
-{% endhint %}
-
 // Get a full access account
 const account = await wallet.getAccount(0)
 
@@ -65,6 +59,12 @@ const account = await wallet.getAccount(0)
 const address = await account.getAddress()
 console.log('Account address:', address)
 ```
+
+{% hint style="info" %}
+**Need Test Funds?**
+
+For development on **REGTEST**, you can get test funds from the [Lightspark Regtest Faucet](https://app.lightspark.com/regtest-faucet).
+{% endhint %}
 
 **Note**: The Spark wallet integrates with the Spark network using the `@buildonspark/spark-sdk`. Network configuration is limited to predefined networks, and there's no custom RPC provider option.
 

--- a/sdk/wallet-modules/wallet-spark/usage.md
+++ b/sdk/wallet-modules/wallet-spark/usage.md
@@ -49,8 +49,14 @@ const wallet = new WalletManagerSpark(seedPhrase)
 
 // Or with custom network configuration
 const wallet = new WalletManagerSpark(seedPhrase, {
-  network: 'MAINNET' // 'MAINNET', 'TESTNET', or 'REGTEST'
+  network: 'MAINNET' // 'MAINNET' or 'REGTEST'
 })
+
+{% hint style="info" %}
+**Need Test Funds?**
+
+For development on **REGTEST**, you can get test funds from the [Lightspark Regtest Faucet](https://app.lightspark.com/regtest-faucet).
+{% endhint %}
 
 // Get a full access account
 const account = await wallet.getAccount(0)
@@ -85,7 +91,7 @@ console.log('Account 2 address:', address2)
 
 // Note: All accounts use BIP-44 derivation paths with pattern:
 // m/44'/998'/{networkNumber}'/0/{index} where 998 is the coin type for Spark
-// and networkNumber is 0 for MAINNET, 1 for TESTNET, 2 for SIGNET, or 3 for REGTEST
+// and networkNumber is 0 for MAINNET, 2 for SIGNET, or 3 for REGTEST
 ```
 
 **Important Note**: Custom derivation paths via `getAccountByPath()` are not supported on the Spark blockchain. Only indexed accounts using the standard BIP-44 pattern are available.
@@ -333,7 +339,7 @@ async function setupSparkWallet() {
 
   // Create Spark wallet manager
   const wallet = new WalletManagerSpark(seedPhrase, {
-    network: 'MAINNET' // 'MAINNET', 'TESTNET', or 'REGTEST'
+    network: 'MAINNET' // 'MAINNET' or 'REGTEST'
   })
   
   // Get first account


### PR DESCRIPTION
This PR updates the Spark Wallet documentation to reflect the deprecation of `TESTNET` and provides clear instructions on how to obtain test funds for `REGTEST`.

## Changes
- **Removed `TESTNET`**: Removed all references to "Spark Testnet" and the `TESTNET` configuration option across [configuration.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/configuration.md), [usage.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/usage.md), [README.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/README.md), and [api-reference.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/api-reference.md).
- **Added Faucet Links**: Added visible callouts and links to the [Lightspark Regtest Faucet](https://app.lightspark.com/regtest-faucet) in [configuration.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/configuration.md), [usage.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/usage.md), and [README.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/README.md) to help developers easily fund their local testing environments.
- **Cleanup**: Updated code examples and BIP-44 derivation path documentation to list only `MAINNET`, `SIGNET`, and `REGTEST`.

## Ticket
[DOC-240](https://app.asana.com/1/45238840754660/project/1210603136530746/task/1212857390512233?focus=true)

## Verification
- **Configuration**: Verified [configuration.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/configuration.md) to ensure `TESTNET` is removed from values and examples, and the faucet link is present.
- **Usage & README**: Verified callouts for the Regtest Faucet appear in [usage.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/usage.md) and [README.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/README.md).
- **API Reference**: Verified [api-reference.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-spark/api-reference.md) to ensure `TESTNET` is removed from constructor parameters and type definitions.

<img width="794" height="441" alt="image" src="https://github.com/user-attachments/assets/2419f57c-5ae2-4ed8-b61b-61aa8e4a1563" />
<img width="1137" height="188" alt="image" src="https://github.com/user-attachments/assets/4371b80c-6f5d-40fe-8acc-a4d04b95793a" />

