### PR TITLE
Add USA₮ and XAU₮ as supported paymaster tokens (DOC-241)

### DIFF
--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -257,9 +257,9 @@ try {
 
 The following tokens are supported for gas payments on Ethereum Mainnet:
 
-*   **USDT**: `0xdAC17F958D2ee523a2206206994597C13D831ec7`
+*   **USD₮**: `0xdAC17F958D2ee523a2206206994597C13D831ec7`
 *   **USA₮**: `0x07041776f5007aca2a54844f50503a18a72a8b68`
-*   **XAUT**: `0x68749665ff8d2d112fa859aa293f07a622782f38`
+*   **XAU₮**: `0x68749665ff8d2d112fa859aa293f07a622782f38`
 {% endhint %}
 
 ```javascript
@@ -274,10 +274,10 @@ const ethereumConfig = {
   safeModulesVersion: '0.3.0',
   paymasterToken: {
     // Supported Paymaster Tokens:
-    // USDT: 0xdAC17F958D2ee523a2206206994597C13D831ec7
+    // USD₮: 0xdAC17F958D2ee523a2206206994597C13D831ec7
     // USA₮: 0x07041776f5007aca2a54844f50503a18a72a8b68
-    // XAUT: 0x68749665ff8d2d112fa859aa293f07a622782f38
-    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDT
+    // XAU₮: 0x68749665ff8d2d112fa859aa293f07a622782f38
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USD₮
   },
   transferMaxFee: 100000 // 100,000 paymaster token units (e.g., 0.1 USDT if 6 decimals)
 }

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -251,6 +251,17 @@ try {
 
 ### Ethereum Mainnet
 
+
+{% hint style="info" %}
+**Supported Paymaster Tokens**
+
+The following tokens are supported for gas payments on Ethereum Mainnet:
+
+*   **USDT**: `0xdAC17F958D2ee523a2206206994597C13D831ec7`
+*   **USA₮**: `0x07041776f5007aca2a54844f50503a18a72a8b68`
+*   **XAUT**: `0x68749665ff8d2d112fa859aa293f07a622782f38`
+{% endhint %}
+
 ```javascript
 const ethereumConfig = {
   chainId: 1,
@@ -262,6 +273,10 @@ const ethereumConfig = {
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
+    // Supported Paymaster Tokens:
+    // USDT: 0xdAC17F958D2ee523a2206206994597C13D831ec7
+    // USA₮: 0x07041776f5007aca2a54844f50503a18a72a8b68
+    // XAUT: 0x68749665ff8d2d112fa859aa293f07a622782f38
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDT
   },
   transferMaxFee: 100000 // 100,000 paymaster token units (e.g., 0.1 USDT if 6 decimals)

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -273,11 +273,7 @@ const ethereumConfig = {
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    // Supported Paymaster Tokens:
-    // USD₮: 0xdAC17F958D2ee523a2206206994597C13D831ec7
-    // USA₮: 0x07041776f5007aca2a54844f50503a18a72a8b68
-    // XAU₮: 0x68749665ff8d2d112fa859aa293f07a622782f38
-    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USD₮
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDT
   },
   transferMaxFee: 100000 // 100,000 paymaster token units (e.g., 0.1 USDT if 6 decimals)
 }


### PR DESCRIPTION
This PR updates the `wallet-evm-erc-4337` configuration documentation to explicitly list USA₮ and XAU₮ as supported tokens for gas payments on Ethereum Mainnet.

## Changes
- Modified [sdk/wallet-modules/wallet-evm-erc-4337/configuration.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md):
  - Added a "Supported Paymaster Tokens" callout box in the "Ethereum Mainnet" section.

**Ticket:** [DOC-241](https://app.asana.com/1/45238840754660/project/1210603136530746/task/1212857390512238?focus=true)

## Verification
- Verified the contract addresses against the ticket (DOC-241) and Etherscan.
- Verified markdown rendering on gitbook.
<img width="790" height="677" alt="image" src="https://github.com/user-attachments/assets/f253a890-f4c8-46e6-a5b0-349df00755ec" />

