### PR TITLE
docs(solana): fix types and account instantiation pattern

### DIFF
--- a/sdk/wallet-modules/wallet-solana/api-reference.md
+++ b/sdk/wallet-modules/wallet-solana/api-reference.md
@@ -61,7 +61,7 @@ const wallet = new WalletManagerSolana(seedPhrase, {
 |--------|-------------|---------|
 | `getAccount(index)` | Returns a wallet account at the specified index | `Promise<WalletAccountSolana>` |
 | `getAccountByPath(path)` | Returns a wallet account at the specified BIP-44 derivation path | `Promise<WalletAccountSolana>` |
-| `getFeeRates()` | Returns current fee rates for transactions | `Promise<{normal: number, fast: number}>` |
+| `getFeeRates()` | Returns current fee rates for transactions | `Promise<{normal: bigint, fast: bigint}>` |
 | `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` |
 
 ##### `getAccount(index)`
@@ -93,7 +93,7 @@ const account = await wallet.getAccountByPath("0'/0/1")
 ##### `getFeeRates()`
 Returns current fee rates for transactions based on recent prioritization fees.
 
-**Returns:** `Promise<{normal: number, fast: number}>` - Object containing fee rates in lamports
+**Returns:** `Promise<{normal: bigint, fast: bigint}>` - Object containing fee rates in lamports
 
 **Throws:** Error if wallet is not connected to a provider
 
@@ -134,12 +134,12 @@ new WalletAccountSolana(seed, path, config)
 | `getAddress()` | Returns the account's Solana address | `Promise<string>` |
 | `sign(message)` | Signs a message using the account's private key | `Promise<string>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` |
-| `sendTransaction(tx)` | Sends a Solana transaction | `Promise<{hash: string, fee: number}>` |
-| `quoteSendTransaction(tx)` | Estimates the fee for a transaction | `Promise<{fee: number}>` |
-| `transfer(options)` | Transfers SPL tokens to another address | `Promise<{hash: string, fee: number}>` |
-| `quoteTransfer(options)` | Estimates the fee for an SPL token transfer | `Promise<{fee: number}>` |
-| `getBalance()` | Returns the native SOL balance (in lamports) | `Promise<number>` |
-| `getTokenBalance(tokenMint)` | Returns the balance of a specific SPL token | `Promise<number>` |
+| `sendTransaction(tx)` | Sends a Solana transaction | `Promise<{hash: string, fee: bigint}>` |
+| `quoteSendTransaction(tx)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
+| `transfer(options)` | Transfers SPL tokens to another address | `Promise<{hash: string, fee: bigint}>` |
+| `quoteTransfer(options)` | Estimates the fee for an SPL token transfer | `Promise<{fee: bigint}>` |
+| `getBalance()` | Returns the native SOL balance (in lamports) | `Promise<bigint>` |
+| `getTokenBalance(tokenMint)` | Returns the balance of a specific SPL token | `Promise<bigint>` |
 | `toReadOnlyAccount()` | Returns a read-only copy of the account | `Promise<WalletAccountReadOnlySolana>` |
 | `dispose()` | Disposes the wallet account, clearing private keys from memory | `void` |
 
@@ -191,7 +191,7 @@ Sends a Solana transaction.
   - `to` (string): Recipient's Solana address (base58-encoded)
   - `value` (number): Amount in lamports
 
-**Returns:** `Promise<{hash: string, fee: number}>` - Object containing transaction hash and fee (in lamports)
+**Returns:** `Promise<{hash: string, fee: bigint}>` - Object containing transaction hash and fee (in lamports)
 
 **Throws:** Error if wallet is not connected to a provider
 
@@ -210,7 +210,7 @@ Estimates the fee for a Solana transaction.
 **Parameters:**
 - `tx` (SolanaTransaction): The transaction object (same as sendTransaction)
 
-**Returns:** `Promise<{fee: number}>` - Object containing fee estimate (in lamports)
+**Returns:** `Promise<{fee: bigint}>` - Object containing fee estimate (in lamports)
 
 **Example:**
 ```javascript
@@ -230,7 +230,7 @@ Transfers SPL tokens to another address.
   - `recipient` (string): Recipient's Solana address (base58-encoded)
   - `amount` (number): Amount in token's base units
 
-**Returns:** `Promise<{hash: string, fee: number}>` - Object containing transaction hash and fee (in lamports)
+**Returns:** `Promise<{hash: string, fee: bigint}>` - Object containing transaction hash and fee (in lamports)
 
 **Throws:** Error if wallet is not connected to a provider or if fee exceeds maximum
 
@@ -251,7 +251,7 @@ Estimates the fee for an SPL token transfer.
 **Parameters:**
 - `options` (TransferOptions): Transfer options (same as transfer)
 
-**Returns:** `Promise<{fee: number}>` - Object containing fee estimate (in lamports)
+**Returns:** `Promise<{fee: bigint}>` - Object containing fee estimate (in lamports)
 
 **Example:**
 ```javascript
@@ -265,7 +265,7 @@ console.log('Transfer fee estimate:', quote.fee, 'lamports')
 ##### `getBalance()`
 Returns the native SOL balance (in lamports).
 
-**Returns:** `Promise<number>` - Balance in lamports
+**Returns:** `Promise<bigint>` - Balance in lamports
 
 **Example:**
 ```javascript
@@ -279,7 +279,7 @@ Returns the balance of a specific SPL token.
 **Parameters:**
 - `tokenMint` (string): Token mint address (base58-encoded)
 
-**Returns:** `Promise<number>` - Token balance in base units
+**Returns:** `Promise<bigint>` - Token balance in base units
 
 **Example:**
 ```javascript
@@ -336,10 +336,10 @@ new WalletAccountReadOnlySolana(publicKey, config)
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getAddress()` | Returns the account's Solana address | `Promise<string>` |
-| `getBalance()` | Returns the native SOL balance (in lamports) | `Promise<number>` |
-| `getTokenBalance(tokenMint)` | Returns the balance of a specific SPL token | `Promise<number>` |
-| `quoteSendTransaction(tx)` | Estimates the fee for a transaction | `Promise<{fee: number}>` |
-| `quoteTransfer(options)` | Estimates the fee for an SPL token transfer | `Promise<{fee: number}>` |
+| `getBalance()` | Returns the native SOL balance (in lamports) | `Promise<bigint>` |
+| `getTokenBalance(tokenMint)` | Returns the balance of a specific SPL token | `Promise<bigint>` |
+| `quoteSendTransaction(tx)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
+| `quoteTransfer(options)` | Estimates the fee for an SPL token transfer | `Promise<{fee: bigint}>` |
 
 ##### `getAddress()`
 Returns the account's Solana address.
@@ -355,7 +355,7 @@ console.log('Account address:', address)
 ##### `getBalance()`
 Returns the native SOL balance (in lamports).
 
-**Returns:** `Promise<number>` - Balance in lamports
+**Returns:** `Promise<bigint>` - Balance in lamports
 
 **Example:**
 ```javascript
@@ -369,7 +369,7 @@ Returns the balance of a specific SPL token.
 **Parameters:**
 - `tokenMint` (string): Token mint address (base58-encoded)
 
-**Returns:** `Promise<number>` - Token balance in base units
+**Returns:** `Promise<bigint>` - Token balance in base units
 
 **Example:**
 ```javascript
@@ -385,7 +385,7 @@ Estimates the fee for a transaction.
   - `to` (string): Recipient's Solana address (base58-encoded)
   - `value` (number): Amount in lamports
 
-**Returns:** `Promise<{fee: number}>` - Object containing fee estimate (in lamports)
+**Returns:** `Promise<{fee: bigint}>` - Object containing fee estimate (in lamports)
 
 **Example:**
 ```javascript
@@ -404,7 +404,7 @@ Estimates the fee for an SPL token transfer.
   - `recipient` (string): Recipient's Solana address (base58-encoded)
   - `amount` (number): Amount in token's base units
 
-**Returns:** `Promise<{fee: number}>` - Object containing fee estimate (in lamports)
+**Returns:** `Promise<{fee: bigint}>` - Object containing fee estimate (in lamports)
 
 **Example:**
 ```javascript

--- a/sdk/wallet-modules/wallet-solana/configuration.md
+++ b/sdk/wallet-modules/wallet-solana/configuration.md
@@ -37,15 +37,23 @@ const wallet = new WalletManagerSolana(seedPhrase, config)
 
 ## Account Configuration
 
+Accounts are obtained through the `WalletManagerSolana` instance using `getAccount()` or `getAccountByPath()`:
+
 ```javascript
-import { WalletAccountSolana } from '@tetherto/wdk-wallet-solana'
+import WalletManagerSolana from '@tetherto/wdk-wallet-solana'
 
 const accountConfig = {
   rpcUrl: 'https://api.mainnet-beta.solana.com',
   transferMaxFee: 10000000 // Optional: Maximum fee in lamports
 }
 
-const account = new WalletAccountSolana(seedPhrase, "0'/0/0", accountConfig)
+const wallet = new WalletManagerSolana(seedPhrase, accountConfig)
+
+// Get account by index
+const account = await wallet.getAccount(0)
+
+// Or get account by custom derivation path
+const customAccount = await wallet.getAccountByPath("0'/0/5")
 ```
 
 ## Configuration Options

--- a/sdk/wallet-modules/wallet-solana/usage.md
+++ b/sdk/wallet-modules/wallet-solana/usage.md
@@ -45,7 +45,7 @@ import WalletManagerSolana, {
 } from '@tetherto/wdk-wallet-solana'
 
 // Use a BIP-39 seed phrase (replace with your own secure phrase)
-const seedPhrase = 'your twelve word seed phrase here' // Replace with actual seed generation
+const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
 
 
 // Create wallet manager with Solana RPC provider
@@ -144,7 +144,7 @@ const result = await account.sendTransaction({
   value: 1000000000n, // 1 SOL in lamports
   commitment: 'confirmed' // Optional: commitment level
 })
-console.log('Transaction signature:', result.signature)
+console.log('Transaction hash:', result.hash)
 console.log('Transaction fee:', result.fee, 'lamports')
 
 // Get transaction fee estimate
@@ -170,7 +170,7 @@ const transferResult = await account.transfer({
 }, {
   commitment: 'confirmed' // Optional: commitment level
 });
-console.log('Transaction signature:', transferResult.signature);
+console.log('Transfer hash:', transferResult.hash);
 console.log('Transfer fee:', transferResult.fee, 'lamports');
 
 


### PR DESCRIPTION
## Summary
Fixes documentation inaccuracies found during verification against actual SDK TypeScript types.

---

## Files Changed

### 1. [sdk/wallet-modules/wallet-solana/configuration.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-solana/configuration.md)

**Issue**: Direct `WalletAccountSolana` constructor example fails at runtime.

**Fix**: Replace with `WalletManagerSolana.getAccount()` pattern.

```diff
-import { WalletAccountSolana } from '@tetherto/wdk-wallet-solana'
-const account = new WalletAccountSolana(seedPhrase, "0'/0/0", accountConfig)
+import WalletManagerSolana from '@tetherto/wdk-wallet-solana'
+const wallet = new WalletManagerSolana(seedPhrase, accountConfig)
+const account = await wallet.getAccount(0)
```

---

### 2. [sdk/wallet-modules/wallet-solana/api-reference.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-solana/api-reference.md)

**Issue**: Return types documented as `number` but SDK returns `bigint`.

**Fix**: Update all method signatures to use correct types.

| Method | Before | After |
|--------|--------|-------|
| `getFeeRates()` | `{normal: number, fast: number}` | `{normal: bigint, fast: bigint}` |
| `getBalance()` | `Promise<number>` | `Promise<bigint>` |
| `getTokenBalance()` | `Promise<number>` | `Promise<bigint>` |
| `sendTransaction()` | `{hash: string, fee: number}` | `{hash: string, fee: bigint}` |
| `transfer()` | `{hash: string, fee: number}` | `{hash: string, fee: bigint}` |
| `quoteSendTransaction()` | `{fee: number}` | `{fee: bigint}` |
| `quoteTransfer()` | `{fee: number}` | `{fee: bigint}` |

---

### 3. [sdk/wallet-modules/wallet-solana/usage.md](file:///Users/maharshimishra/Documents/wdk-docs-fork/sdk/wallet-modules/wallet-solana/usage.md)

**Issue 1**: Code examples used `result.signature` but SDK returns `result.hash`.

```diff
-console.log('Transaction signature:', result.signature)
+console.log('Transaction hash:', result.hash)
```

**Issue 2**: Quick Start used invalid placeholder seed phrase, fails when snippet copied and pasted.

```diff
-const seedPhrase = 'your twelve word seed phrase here'
+const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
```

---

## Verification

| Test | Result |
|------|--------|
| API type verification | ✅ Passed |
| Blind copy-paste tests (4 snippets) | ✅ Passed |
| TypeScript compilation | ✅ Passed |

## Related Task
[[WDK] Solana: Audit sdk/wallet-modules/wallet-solana/*](https://app.asana.com/1/45238840754660/project/1210603136530746/task/1212799451446505)
