### PR TITLE
docs: update wallet-evm (beta.7) and wallet-evm-erc-4337 (beta.4) documentation

### DIFF
--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -30,6 +30,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 - **[Agent Skills](../ai/agent-skills.md)**: New page covering WDK's agent skill capabilities, self-custodial vs hosted comparison, and platform compatibility with OpenClaw, Claude, Cursor, and other agent platforms.
 - **[OpenClaw Integration](../ai/openclaw.md)**: New page for installing and configuring the WDK skill in OpenClaw via ClawHub, including security precautions for running agents locally.
 
+**Changes**
+- **wallet-evm** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.7)): Added [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data support:
+  - Added `signTypedData(typedData)` method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountevm) for signing structured data
+  - Added `verifyTypedData(typedData, signature)` method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountevm) and [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountreadonlyevm) for verifying typed data signatures
+  - Added `address` property to [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountreadonlyevm)
+  - Added `TypedData`, `TypedDataDomain`, `TypedDataField` type exports
+
 ---
 
 ### February 10, 2026

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -36,6 +36,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
   - Added `verifyTypedData(typedData, signature)` method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountevm) and [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountreadonlyevm) for verifying typed data signatures
   - Added `address` property to [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountreadonlyevm)
   - Added `TypedData`, `TypedDataDomain`, `TypedDataField` type exports
+- **wallet-evm-erc-4337** ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.4)): Redesigned gas payment configuration and added new methods:
+  - Constructor config now supports 3 gas payment modes: Paymaster Token, Sponsorship Policy, and Native Coins
+  - Added per-call config override parameter to `sendTransaction`, `transfer`, `quoteSendTransaction`, and `quoteTransfer`
+  - Added `approve(options)` and `getAllowance(token, spender)` for ERC-20 token allowance management
+  - Added `getUserOperationReceipt(hash)` method to [`WalletAccountReadOnlyEvmErc4337`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md#walletaccountreadonlyevmerc4337)
+  - Added `verify(message, signature)` method to [`WalletAccountReadOnlyEvmErc4337`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md#walletaccountreadonlyevmerc4337)
+  - Added `UserOperationReceipt`, `ApproveOptions`, `ConfigurationError` type exports
 
 ---
 

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -27,7 +27,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 14, 2026
 
 **Changes**
-- **wallet-spark**: Upgrade spark-sdk from `0.6.1` to `0.6.4` and bare runtime to `0.0.43` ([v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.9))
+- **wallet-spark**: Upgrade spark-sdk from `0.6.1` to `0.6.4` and spark bare SDK to `0.0.43` ([v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.9))
 
 ### February 12, 2026
 

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -32,17 +32,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 **Changes**
 - **wallet-evm** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.7)): Added [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data support:
-  - Added `signTypedData(typedData)` method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountevm) for signing structured data
-  - Added `verifyTypedData(typedData, signature)` method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountevm) and [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountreadonlyevm) for verifying typed data signatures
-  - Added `address` property to [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountreadonlyevm)
-  - Added `TypedData`, `TypedDataDomain`, `TypedDataField` type exports
-- **wallet-evm-erc-4337** ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.4)): Redesigned gas payment configuration and added new methods:
-  - Constructor config now supports 3 gas payment modes: Paymaster Token, Sponsorship Policy, and Native Coins
-  - Added per-call config override parameter to `sendTransaction`, `transfer`, `quoteSendTransaction`, and `quoteTransfer`
-  - Added `approve(options)` and `getAllowance(token, spender)` for ERC-20 token allowance management
-  - Added `getUserOperationReceipt(hash)` method to [`WalletAccountReadOnlyEvmErc4337`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md#walletaccountreadonlyevmerc4337)
-  - Added `verify(message, signature)` method to [`WalletAccountReadOnlyEvmErc4337`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md#walletaccountreadonlyevmerc4337)
-  - Added `UserOperationReceipt`, `ApproveOptions`, `ConfigurationError` type exports
+  - Added [`signTypedData(typedData)`](../sdk/wallet-modules/wallet-evm/api-reference.md#signtypeddatatypeddata) method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountevm) for signing structured data
+  - Added [`verifyTypedData(typedData, signature)`](../sdk/wallet-modules/wallet-evm/api-reference.md#verifytypeddatatypeddata-signature) method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountevm) and [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference.md#walletaccountreadonlyevm) for verifying typed data signatures
+- **wallet-evm-erc-4337** ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.4)):
+  - Added 2 new gas payment modes: [Sponsorship Policy](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md#gas-payment-mode-flags) and [Native Coins](../sdk/wallet-modules/wallet-evm-erc-4337/configuration.md#gas-payment-mode-flags), alongside the existing Paymaster Token mode
+  - Added per-call [config override](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md#config-override) parameter to `sendTransaction`, `transfer`, `quoteSendTransaction`, and `quoteTransfer`
+  - Added [`getUserOperationReceipt(hash)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md#getuseroperationreceipthash) method for retrieving ERC-4337 UserOperation receipts
+  - Added [`ConfigurationError`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md#configurationerror) error type for invalid configuration validation
 
 ---
 

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,11 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### February 14, 2026
+
+**Changes**
+- **wallet-spark**: Upgrade spark-sdk from `0.6.1` to `0.6.4` and bare runtime to `0.0.43` ([v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.9))
+
 ### February 12, 2026
 
 **What's New**

--- a/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md
@@ -34,12 +34,14 @@ layout:
 
 The main class for managing ERC-4337 EVM wallets. Extends `WalletManager` from `@tetherto/wdk-wallet`.
 
-### Fee Rate Constants
+### Fee Rate Behavior
 
-```javascript
-const FEE_RATE_NORMAL_MULTIPLIER = 1.1
-const FEE_RATE_FAST_MULTIPLIER = 2.0
-```
+Internally, `getFeeRates()` applies these multipliers to the base fee:
+
+- **Normal**: base fee × 110%
+- **Fast**: base fee × 200%
+
+These multipliers are internal (`protected static`) and cannot be imported or overridden.
 
 ### Constructor
 
@@ -238,9 +240,14 @@ Represents an individual ERC-4337 wallet account. Extends `WalletAccountReadOnly
 
 ### Constants
 
+The following constant is used internally for Safe account address derivation:
+
 ```javascript
+// Internal: used by predictSafeAddress() for deterministic address generation
 const SALT_NONCE = '0x69b348339eea4ed93f9d11931c3b894c8f9d8c7663a053024b11cb7eb4e5a1f6'
 ```
+
+> **Note:** This constant is not re-exported from the package entry point. Use `predictSafeAddress()` instead of referencing it directly.
 
 
 
@@ -601,9 +608,14 @@ Represents a read-only ERC-4337 wallet account that can query balances and estim
 
 ### Constants
 
+The following constant is used internally for Safe account address derivation:
+
 ```javascript
+// Internal: used by predictSafeAddress() for deterministic address generation
 const SALT_NONCE = '0x69b348339eea4ed93f9d11931c3b894c8f9d8c7663a053024b11cb7eb4e5a1f6'
 ```
+
+> **Note:** This constant is not re-exported from the package entry point. Use `predictSafeAddress()` instead of referencing it directly.
 
 ### Constructor
 
@@ -1000,15 +1012,19 @@ interface KeyPair {
 }
 ```
 
-### Constants
+### Internal Constants
+
+The following constants are used internally by the SDK and are **not importable** from the package entry point.
 
 ```typescript
-// ERC-4337 specific constant (exported from WalletAccountReadOnlyEvmErc4337)
+// Used by predictSafeAddress() for deterministic address generation
+// Not re-exported from '@tetherto/wdk-wallet-evm-erc-4337'
 const SALT_NONCE: string = '0x69b348339eea4ed93f9d11931c3b894c8f9d8c7663a053024b11cb7eb4e5a1f6';
 
-// Fee rate multipliers (used by WalletManagerEvmErc4337)
-const FEE_RATE_NORMAL_MULTIPLIER: number = 1.1;
-const FEE_RATE_FAST_MULTIPLIER: number = 2.0;
+// Fee rate multipliers (protected static on WalletManagerEvm)
+// Applied internally by getFeeRates()
+const _FEE_RATE_NORMAL_MULTIPLIER: bigint;  // ~110%
+const _FEE_RATE_FAST_MULTIPLIER: bigint;    // ~200%
 ```
 
 

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -30,9 +30,8 @@ import WalletManagerEvmErc4337 from '@tetherto/wdk-wallet-evm-erc-4337'
 const config = {
   // Required parameters
   chainId: 1,
-  blockchain: 'ethereum',
   provider: 'https://rpc.mevblocker.io/fast',
-  safeModulesVersion: '0.3.0', // optional as it defaults to '0.3.0', only '0.2.0' and '0.3.0' are valid
+  safeModulesVersion: '0.3.0', // '0.2.0' and '0.3.0' are valid
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   bundlerUrl: `https://api.pimlico.io/v1/ethereum/rpc?apikey=${PIMLICO_API_KEY}`,
   paymasterUrl: `https://api.pimlico.io/v2/ethereum/rpc?apikey=${PIMLICO_API_KEY}`,
@@ -146,10 +145,10 @@ const config = {
 
 ### Paymaster URL
 
-The `paymasterUrl` option specifies the URL of the paymaster service that sponsors transaction fees using ERC-20 tokens. **Required** for gasless transactions.
+The `paymasterUrl` option specifies the URL of the paymaster service that sponsors transaction fees using ERC-20 tokens or sponsorship policies.
 
 **Type:** `string`  
-**Required:** Yes
+**Required:** Yes, for Paymaster Token mode and Sponsorship Policy mode. Not used in Native Coins mode.
 
 **Example:**
 ```javascript
@@ -160,10 +159,10 @@ const config = {
 
 ### Paymaster Address
 
-The `paymasterAddress` option specifies the address of the paymaster smart contract. **Required** for paymaster integration.
+The `paymasterAddress` option specifies the address of the paymaster smart contract.
 
 **Type:** `string`  
-**Required:** Yes
+**Required:** Yes, for Paymaster Token mode only. Not used in Sponsorship Policy or Native Coins modes.
 
 **Example:**
 ```javascript
@@ -202,10 +201,10 @@ const config = {
 
 ### Paymaster Token
 
-The `paymasterToken` option specifies the ERC-20 token used for paying transaction fees through the paymaster. **Required** for fee calculations and payments.
+The `paymasterToken` option specifies the ERC-20 token used for paying transaction fees through the paymaster.
 
 **Type:** `object`  
-**Required:** Yes
+**Required:** Yes, for Paymaster Token mode only. Not used in Sponsorship Policy or Native Coins modes.
 
 **Properties:**
 - `address` (string): The ERC-20 token contract address
@@ -219,11 +218,58 @@ const config = {
 }
 ```
 
+### Sponsorship Policy ID
+
+The `sponsorshipPolicyId` option specifies the sponsorship policy identifier for sponsored transactions.
+
+**Type:** `string`  
+**Required:** No (optional), only used in Sponsorship Policy mode.
+
+**Example:**
+```javascript
+const config = {
+  isSponsored: true,
+  sponsorshipPolicyId: 'sp_my_policy_id'
+}
+```
+
+### Gas Payment Mode Flags
+
+These boolean flags control which gas payment mode is used. Only one mode should be active at a time.
+
+#### `isSponsored`
+
+Enables Sponsorship Policy mode, where a sponsor covers transaction fees.
+
+**Type:** `boolean`  
+**Default:** `false`
+
+```javascript
+const config = {
+  isSponsored: true,
+  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum'
+}
+```
+
+#### `useNativeCoins`
+
+Enables Native Coins mode, where the user pays fees in the chain's native currency (ETH, MATIC, etc.).
+
+**Type:** `boolean`  
+**Default:** `false`
+
+```javascript
+const config = {
+  useNativeCoins: true,
+  transferMaxFee: 100000000000000n // Optional: max fee in wei
+}
+```
+
 ### Transfer Max Fee
 
 The `transferMaxFee` option sets the maximum fee amount **in paymaster token units** for transfer operations. This prevents transactions with unexpectedly high fees. **Optional** parameter.
 
-**Type:** `number`  
+**Type:** `number | bigint`  
 **Required:** No (optional)  
 **Unit:** Paymaster token base units
 
@@ -265,7 +311,6 @@ The following tokens are supported for gas payments on Ethereum Mainnet:
 ```javascript
 const ethereumConfig = {
   chainId: 1,
-  blockchain: 'ethereum',
   provider: 'https://rpc.mevblocker.io/fast',
   bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
   paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
@@ -284,7 +329,6 @@ const ethereumConfig = {
 ```javascript
 const polygonConfig = {
   chainId: 137,
-  blockchain: 'polygon',
   provider: 'https://polygon-rpc.com',
   bundlerUrl: 'https://api.candide.dev/public/v3/polygon',
   paymasterUrl: 'https://api.candide.dev/public/v3/polygon',
@@ -303,7 +347,6 @@ const polygonConfig = {
 ```javascript
 const arbitrumConfig = {
   chainId: 42161,
-  blockchain: 'arbitrum',
   provider: 'https://arb1.arbitrum.io/rpc',
   bundlerUrl: 'https://public.pimlico.io/v2/42161/rpc',
   paymasterUrl: 'https://public.pimlico.io/v2/42161/rpc',
@@ -322,7 +365,6 @@ const arbitrumConfig = {
 ``` javascript
 const avalancheConfig = {
   chainId: 43114,
-  blockchain: 'ethereum',
   provider: 'https://avalanche-c-chain-rpc.publicnode.com',
   bundlerUrl: "https://public.pimlico.io/v2/43114/rpc",
   paymasterUrl: "https://public.pimlico.io/v2/43114/rpc",
@@ -342,13 +384,12 @@ const avalancheConfig = {
 // Plasma (example Layer 2)
 const plasmaConfig = {
   chainId: 9745,
-  blockchain: 'plasma',
   provider: 'https://plasma.drpc.org',
   // For ERC-4337 support, optional fields:
   bundlerUrl: 'https://api.candide.dev/public/v3/9745',
   paymasterUrl: 'https://api.candide.dev/public/v3/9745',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
-  entrypointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+  entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
     address: '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb' // USDT
@@ -364,7 +405,6 @@ const plasmaConfig = {
 // Pimlico
 const sepoliaConfigPimlico = {
   chainId: 11155111,
-  blockchain: 'ethereum',
   provider: 'https://sepolia.drpc.org',
   bundlerUrl: 'https://public.pimlico.io/v2/11155111/rpc',
   paymasterUrl: 'https://public.pimlico.io/v2/11155111/rpc',
@@ -380,7 +420,6 @@ const sepoliaConfigPimlico = {
 // Candide
 const sepoliaConfigCandide = {
   chainId: 11155111,
-  blockchain: 'ethereum',
   provider: 'https://sepolia.drpc.org',
   bundlerUrl: 'https://api.candide.dev/public/v3/11155111',
   paymasterUrl: 'https://api.candide.dev/public/v3/11155111',

--- a/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/usage.md
@@ -56,13 +56,13 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
-  safeModulesVersion: '1.0.0',
+  safeModulesVersion: '0.3.0',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
   
   // Optional parameter
-  transferMaxFee: 100000000000000 // Optional: Maximum fee amount for transfer operations (in wei)
+  transferMaxFee: 100000 // Optional: Maximum fee in paymaster token units
 
 })
 
@@ -74,7 +74,7 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', { // Smart 
   paymasterUrl: 'https://api.candide.dev/public/v3/ethereum', // Required: Paymaster service
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba', // Required: Paymaster contract
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032', // Required: EntryPoint contract
-  safeModulesVersion: '1.0.0', // Required: Safe modules version
+  safeModulesVersion: '0.3.0', // Required: Safe modules version
   paymasterToken: { // Required: Paymaster token configuration
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDT token address
   }
@@ -82,7 +82,7 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', { // Smart 
 ```
 
 {% hint style="info" %}
-> To use test/mock tokens instead of real funds, see the Testnet [configuration section](./configuration.md#sepolia-testnet-usdt-erc-20).
+> To use test/mock tokens instead of real funds, see the Testnet [configuration section](./configuration.md#network-specific-configurations).
 
 {% endhint %}
 
@@ -149,7 +149,7 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', { // Smart 
   paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
-  safeModulesVersion: '1.0.0',
+  safeModulesVersion: '0.3.0',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDT
   }
@@ -175,19 +175,19 @@ console.log('Paymaster token balance:', paymasterBalance, 'units')
 ### Sending Gasless Transactions
 
 ```javascript
-// Send a gasless transaction (fees paid in paymaster token)
+// Send a transaction (fees paid in paymaster token)
 const result = await account.sendTransaction({
   to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-  value: 1000000000000000000, // 1 ETH in wei (use number, not bigint)
+  value: 1000000000000000000n, // 1 ETH in wei
   data: '0x' // Optional transaction data
 })
 console.log('Transaction hash:', result.hash)
-console.log('Transaction fee (in paymaster token units):', result.fee)
+console.log('Transaction fee:', result.fee)
 
 // Send transaction with custom paymaster token
 const customResult = await account.sendTransaction({
   to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-  value: 1000000000000000000
+  value: 1000000000000000000n
 }, {
   paymasterToken: {
     address: '0x...' // Override default paymaster token
@@ -197,9 +197,9 @@ const customResult = await account.sendTransaction({
 // Get transaction fee estimate
 const quote = await account.quoteSendTransaction({
   to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-  value: 1000000000000000000
+  value: 1000000000000000000n
 })
-console.log('Estimated fee (in paymaster token units):', quote.fee)
+console.log('Estimated fee:', quote.fee)
 ```
 
 ### Token Transfers with Gasless Transactions
@@ -279,7 +279,7 @@ async function setupErc4337Wallet() {
     paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
     paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
     entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
-    safeModulesVersion: '1.0.0',
+    safeModulesVersion: '0.3.0',
     paymasterToken: {
       address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDT
     },
@@ -310,15 +310,15 @@ async function sendGaslessTransaction(account) {
     // Get fee estimate first
     const quote = await account.quoteSendTransaction({
       to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-      value: 1000000000000000000, // 1 ETH (use number, not bigint)
+      value: 1000000000000000000n, // 1 ETH
       data: '0x'
     })
-    console.log('Estimated fee:', quote.fee, 'paymaster token units')
+    console.log('Estimated fee:', quote.fee)
     
     // Send ETH without holding any ETH for gas fees
     const result = await account.sendTransaction({
       to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-      value: 1000000000000000000, // 1 ETH
+      value: 1000000000000000000n, // 1 ETH
       data: '0x' // Optional transaction data
     })
     
@@ -346,7 +346,7 @@ async function sendTransactionWithDifferentToken(account) {
     // Send transaction paying fees with a different paymaster token
     const result = await account.sendTransaction({
       to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-      value: 1000000000000000000 // 1 ETH
+      value: 1000000000000000000n // 1 ETH
     }, {
       paymasterToken: {
         address: '0xA0b86a33E6441b8c4C8C8C8C8C8C8C8C8C8C8C8C' // Different token

--- a/sdk/wallet-modules/wallet-evm/README.md
+++ b/sdk/wallet-modules/wallet-evm/README.md
@@ -42,10 +42,10 @@ A simple and secure package to manage BIP-44 wallets for EVM (Ethereum Virtual M
 This package works with any EVM-compatible blockchain, including:
 
 - **Ethereum**: Mainnet, Sepolia
-- **Polygon**: Mainnet, Mumbai
+- **Polygon**: Mainnet, Amoy
 - **Binance Smart Chain (BSC)**: Mainnet, Testnet
 - **Arbitrum**: One, Nova
-- **Optimism**: Mainnet, Goerli
+- **Optimism**: Mainnet, Sepolia
 - **Avalanche C-Chain**: Mainnet, Fuji
 - **And many more...**
 

--- a/sdk/wallet-modules/wallet-evm/api-reference.md
+++ b/sdk/wallet-modules/wallet-evm/api-reference.md
@@ -249,23 +249,6 @@ const signature = await account.sign(message)
 console.log('Signature:', signature)
 ```
 
-#### `verify(message, signature)`
-Verifies a message signature against the account's address.
-
-**Parameters:**
-- `message` (string): The original message
-- `signature` (string): The signature to verify
-
-**Returns:** `Promise<boolean>` - True if signature is valid
-
-**Example:**
-```javascript
-const message = 'Hello, Ethereum!'
-const signature = await account.sign(message)
-const isValid = await account.verify(message, signature)
-console.log('Signature valid:', isValid) // true
-```
-
 #### `signTypedData(typedData)`
 Signs typed data according to [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
 
@@ -301,6 +284,23 @@ const typedData = {
 }
 const signature = await account.signTypedData(typedData)
 console.log('EIP-712 Signature:', signature)
+```
+
+#### `verify(message, signature)`
+Verifies a message signature against the account's address.
+
+**Parameters:**
+- `message` (string): The original message
+- `signature` (string): The signature to verify
+
+**Returns:** `Promise<boolean>` - True if signature is valid
+
+**Example:**
+```javascript
+const message = 'Hello, Ethereum!'
+const signature = await account.sign(message)
+const isValid = await account.verify(message, signature)
+console.log('Signature valid:', isValid) // true
 ```
 
 #### `verifyTypedData(typedData, signature)`
@@ -402,31 +402,6 @@ console.log('Transfer hash:', result.hash)
 console.log('Transfer fee:', result.fee, 'wei')
 ```
 
-#### `approve(options)`
-Approves a specific amount of tokens to a spender.
-
-**Parameters:**
-- `options` (ApproveOptions): Approve options
-  - `token` (string): Token contract address
-  - `spender` (string): Spender address
-  - `amount` (number | bigint): Amount to approve
-
-**Returns:** `Promise<{hash: string, fee: bigint}>` - Transaction result
-
-**Throws:** 
-- Error if no provider is configured
-- Error if trying to re-approve USDT on Ethereum without resetting to 0 first
-
-**Example:**
-```javascript
-const result = await account.approve({
-  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDT
-  spender: '0xSpenderAddress...',
-  amount: 1000000n
-})
-console.log('Approve hash:', result.hash)
-```
-
 #### `quoteTransfer(options)`
 Estimates the fee for an ERC20 token transfer.
 
@@ -477,6 +452,31 @@ Returns the balance of a specific ERC20 token using the balanceOf function.
 const usdtBalance = await account.getTokenBalance('0xdAC17F958D2ee523a2206206994597C13D831ec7')
 console.log('USDT balance:', usdtBalance) // In 6 decimal places
 console.log('USDT balance formatted:', usdtBalance / 1000000, 'USDT')
+```
+
+#### `approve(options)`
+Approves a specific amount of tokens to a spender.
+
+**Parameters:**
+- `options` (ApproveOptions): Approve options
+  - `token` (string): Token contract address
+  - `spender` (string): Spender address
+  - `amount` (number | bigint): Amount to approve
+
+**Returns:** `Promise<{hash: string, fee: bigint}>` - Transaction result
+
+**Throws:** 
+- Error if no provider is configured
+- Error if trying to re-approve USDT on Ethereum without resetting to 0 first
+
+**Example:**
+```javascript
+const result = await account.approve({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDT
+  spender: '0xSpenderAddress...',
+  amount: 1000000n
+})
+console.log('Approve hash:', result.hash)
 ```
 
 #### `getAllowance(token, spender)`
@@ -605,23 +605,15 @@ const readOnlyAccount = new WalletAccountReadOnlyEvm('0x742d35Cc6634C0532925a3b8
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<EvmTransactionReceipt \| null>` | If no provider |
 | `getAllowance(token, spender)` | Returns current allowance for a spender | `Promise<bigint>` | If no provider |
 
-#### `verify(message, signature)`
-Verifies a message signature against the account's address.
+#### `getAddress()`
+Returns the account's Ethereum address.
 
-**Parameters:**
-- `message` (string): The original message
-- `signature` (string): The signature to verify
-
-**Returns:** `Promise<boolean>` - True if signature is valid
+**Returns:** `Promise<string>` - Checksummed Ethereum address
 
 **Example:**
 ```javascript
-const message = 'Hello, Ethereum!'
-const signature = await account.sign(message)
-
-const readOnlyAccount = new WalletAccountReadOnlyEvm('0x...', { provider: '...' })
-const isValid = await readOnlyAccount.verify(message, signature)
-console.log('Signature valid:', isValid) // true
+const address = await readOnlyAccount.getAddress()
+console.log('Account address:', address) // 0x...
 ```
 
 #### `getBalance()`
@@ -651,21 +643,6 @@ Returns the balance of a specific ERC20 token.
 ```javascript
 const tokenBalance = await readOnlyAccount.getTokenBalance('0xdAC17F958D2ee523a2206206994597C13D831ec7')
 console.log('USDT balance:', tokenBalance)
-```
-
-#### `verifyTypedData(typedData, signature)`
-Verifies a typed data signature according to [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
-
-**Parameters:**
-- `typedData` (TypedData): The typed data that was signed
-- `signature` (string): The signature to verify
-
-**Returns:** `Promise<boolean>` - True if signature is valid
-
-**Example:**
-```javascript
-const isValid = await readOnlyAccount.verifyTypedData(typedData, signature)
-console.log('Typed data signature valid:', isValid) // true
 ```
 
 #### `quoteSendTransaction(tx)`
@@ -705,6 +682,40 @@ const quote = await readOnlyAccount.quoteTransfer({
   amount: 1000000
 })
 console.log('Transfer fee estimate:', quote.fee, 'wei')
+```
+
+#### `verify(message, signature)`
+Verifies a message signature against the account's address.
+
+**Parameters:**
+- `message` (string): The original message
+- `signature` (string): The signature to verify
+
+**Returns:** `Promise<boolean>` - True if signature is valid
+
+**Example:**
+```javascript
+const message = 'Hello, Ethereum!'
+const signature = await account.sign(message)
+
+const readOnlyAccount = new WalletAccountReadOnlyEvm('0x...', { provider: '...' })
+const isValid = await readOnlyAccount.verify(message, signature)
+console.log('Signature valid:', isValid) // true
+```
+
+#### `verifyTypedData(typedData, signature)`
+Verifies a typed data signature according to [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
+
+**Parameters:**
+- `typedData` (TypedData): The typed data that was signed
+- `signature` (string): The signature to verify
+
+**Returns:** `Promise<boolean>` - True if signature is valid
+
+**Example:**
+```javascript
+const isValid = await readOnlyAccount.verifyTypedData(typedData, signature)
+console.log('Typed data signature valid:', isValid) // true
 ```
 
 #### `getTransactionReceipt(hash)`

--- a/sdk/wallet-modules/wallet-evm/configuration.md
+++ b/sdk/wallet-modules/wallet-evm/configuration.md
@@ -28,7 +28,7 @@ The `WalletManagerEvm` accepts a configuration object that defines how the walle
 import WalletManagerEvm from '@tetherto/wdk-wallet-evm'
 
 const config = {
-  // Required: RPC endpoint URL or EIP-1193 provider
+  // Recommended: RPC endpoint URL or EIP-1193 provider (required for blockchain operations)
   provider: 'https://eth-mainnet.g.alchemy.com/v2/your-api-key',
   
   // Optional: Maximum fee for transfer operations (in wei)

--- a/sdk/wallet-modules/wallet-evm/configuration.md
+++ b/sdk/wallet-modules/wallet-evm/configuration.md
@@ -117,7 +117,7 @@ const config = {
 
 The `transferMaxFee` option sets a maximum limit for transaction fees to prevent unexpectedly high costs.
 
-**Type:** `number` (optional)  
+**Type:** `number | bigint` (optional)  
 **Unit:** Wei (1 ETH = 1000000000000000000 Wei)
 
 **Examples:**

--- a/sdk/wallet-modules/wallet-evm/usage.md
+++ b/sdk/wallet-modules/wallet-evm/usage.md
@@ -68,7 +68,7 @@ const readOnlyAccount = await account.toReadOnlyAccount()
 {% endhint %}
 
 {% hint style="info" %}
-> To use test/mock tokens instead of real funds, see the Testnet [configuration section](./configuration.md#sepolia-testnet-usdt-erc-20).
+> To use test/mock tokens instead of real funds, see the [configuration section](./configuration.md#network-support).
 
 {% endhint %}
 
@@ -100,7 +100,7 @@ const balance = await account.getBalance()
 console.log('Native balance:', balance, 'wei')
 
 // Get ERC-20 token balance
-const tokenAddress = '0xA0b86a33E6441b8c4C8C8C8C8C8C8C8C8C8C8C8C'
+const tokenAddress = '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USD₮
 const tokenBalance = await account.getTokenBalance(tokenAddress)
 console.log('Token balance:', tokenBalance)
 ```
@@ -159,18 +159,16 @@ console.log('Estimated fee:', quote.fee, 'wei')
 ```javascript
 // Transfer ERC-20 tokens
 const transferResult = await account.transfer({
-  token: '0xA0b86a33E6441b8c4C8C8C8C8C8C8C8C8C8C8C8C',
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USD₮
   recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
   amount: 1000000000000000000n // 1 token in base units
-}, {
-  transferMaxFee: 1000000000000n // Optional: Maximum allowed fee in wei
 })
 console.log('Transfer hash:', transferResult.hash)
 console.log('Transfer fee:', transferResult.fee, 'wei')
 
 // Quote token transfer
 const transferQuote = await account.quoteTransfer({
-  token: '0xA0b86a33E6441b8c4C8C8C8C8C8C8C8C8C8C8C8C',
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USD₮
   recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
   amount: 1000000000000000000n
 })
@@ -363,8 +361,6 @@ try {
     token: tokenAddress,
     recipient,
     amount
-  }, {
-    transferMaxFee: 1000000000000n // Optional: Maximum allowed fee in wei
   })
   
   console.log('Transfer completed:', result.hash)


### PR DESCRIPTION
## Summary

Documentation updates for `@tetherto/wdk-wallet-evm` v1.0.0-beta.7, `@tetherto/wdk-wallet-evm-erc-4337` v1.0.0-beta.4, and `@tetherto/wdk-wallet-spark` v1.0.0-beta.9.

### wallet-evm
- Added EIP-712 typed data signing and verification (`signTypedData`, `verifyTypedData`)
- Updated supported networks (deprecated testnets)
- Improved configuration clarity

### wallet-evm-erc-4337
- Added 2 new gas payment modes: Sponsorship Policy and Native Coins
- Added per-call config override documentation
- Added `getUserOperationReceipt` method docs
- Added `ConfigurationError` type docs
- Added `isSponsored`, `useNativeCoins`, `sponsorshipPolicyId` config options

### wallet-spark
- Upgrade spark-sdk from `0.6.1` to `0.6.4` and bare runtime to `0.0.43`

### Changelog
- Updated changelog for all three releases

---

## Documentation Fixes

Corrections applied across both EVM modules to align docs with `.d.ts` type definitions.

### wallet-evm
- Fixed `keyPair` type from `Buffer` to `Uint8Array | null`
- Added missing inherited methods (`getTransactionReceipt`, `getAllowance`, `getAddress`) to class tables
- Added inherited statics (`getRandomSeedPhrase`, `isValidSeedPhrase`) and `seed` getter to `WalletManagerEvm`
- Added `ApproveOptions` type definition
- Removed unexported `BIP_44_ETH_DERIVATION_PATH_PREFIX` constant
- Fixed `transfer()` examples (single parameter, no config override)
- Clarified `WalletAccountReadOnlyEvm` constructor config type as `Omit<EvmWalletConfig, 'transferMaxFee'>`
- Fixed `provider` config comment (optional per type definition)
- Replaced placeholder token addresses with real USDT address
- Updated deprecated testnets (Mumbai → Amoy, Goerli → Sepolia)
- Fixed broken anchor link in usage.md

### wallet-evm-erc-4337
- Fixed `keyPair` type from `Buffer` to `Uint8Array | null`
- Fixed paymaster field requirements to be mode-specific (not unconditionally required)
- Fixed `entrypointAddress` typo to `entryPointAddress` in Plasma config
- Removed `blockchain` field from config examples (not in type definition)
- Fixed `quoteSendTransaction` and `quoteTransfer` return types to use `Omit<>`
- Added `predictSafeAddress` static method documentation
- Added `FeeRates` type definition
- Fixed fragile anchor link in usage.md