### PR TITLE
fix(docs): add AI limitations disclaimer and expand community warning

### DIFF
--- a/ai/openclaw.md
+++ b/ai/openclaw.md
@@ -23,7 +23,7 @@ layout:
 {% hint style="warning" %}
 The WDK skill for OpenClaw is a community skill, developed and maintained independently by a third-party contributor.
 
-Tether and the WDK Team do not endorse or assume responsibility for its code, security, or maintenance. Use your own judgment and proceed at your own risk.
+Tether and the WDK Team do not endorse or assume responsibility for its code, security, or maintenance. Use your own judgment and proceed at your own risk. Artificial intelligence has inherent risks and limitations. You assume full responsibility for any reliance and use of artificial intelligence and agree that any such reliance and use is entirely at your own risk.
 {% endhint %}
 
 [OpenClaw](https://openclaw.ai) is an open-source AI agent platform. With the WDK community skill, your OpenClaw agent can create wallets, send transactions, swap tokens, bridge assets, and interact with DeFi protocols. Everything stays self-custodial.
@@ -111,6 +111,16 @@ To reduce risk, here are some practical safety measures:
 - Test new capabilities on a disposable system or VM
 
 Think of OpenClaw the same way you'd think about running scripts on your system: powerful and useful, but something you need to be careful with.
+
+## Inherent Limitations of Artificial Intelligence
+
+OpenClaw makes use of artificial intelligence and machine learning technologies. While the use of artificial intelligence and machine learning enables capabilities, it also involves inherent limitations and risks. These include:
+
+1. The potential for inaccurate, incomplete, unexpected or misleading outputs or actions (including so-called hallucinations)
+2. The risk that outputs or actions may contain biases
+3. The possibility of errors related to document quality or text recognition of inputs
+4. The possibility that the outputs may suggest specific immediate or near term actions that should not be relied upon
+5. The risk that OpenClaw may take unexpected actions (including the sending of assets)
 
 ## Next Steps
 

--- a/ai/openclaw.md
+++ b/ai/openclaw.md
@@ -29,7 +29,7 @@ Tether and the WDK Team do not endorse or assume responsibility for its code, se
 [OpenClaw](https://openclaw.ai) is an open-source AI agent platform. With the WDK community skill, your OpenClaw agent can create wallets, send transactions, swap tokens, bridge assets, and interact with DeFi protocols. Everything stays self-custodial.
 
 {% hint style="info" %}
-The WDK skill follows the [AgentSkills specification](https://agentskills.io/specification), so it works with any compatible agent platform. This page covers the OpenClaw-specific setup.
+The WDK community skill follows the [AgentSkills specification](https://agentskills.io/specification), so it works with any compatible agent platform. This page covers the OpenClaw-specific setup.
 {% endhint %}
 
 ## Install the WDK Community Skill
@@ -43,16 +43,16 @@ npx clawhub install tether-wallet-development-kit
 This installs the skill into your workspace's `skills/` directory. OpenClaw picks it up automatically on the next session.
 
 {% hint style="warning" %}
-You might see a VirusTotal warning during installation. It flags the skill as suspicious because it handles crypto keys and calls external APIs. This is normal for any wallet SDK skill. Review the skill's source code on [ClawHub](https://clawhub.ai/HumanRupert/tether-wallet-development-kit) before proceeding.
+You might see a VirusTotal warning during installation. It flags the skill as suspicious because it handles crypto keys and calls external APIs. This is normal for any wallet SDK skill, nevertheless review the skill's source code on [ClawHub](https://clawhub.ai/HumanRupert/tether-wallet-development-kit) before proceeding.
 {% endhint %}
 
 {% hint style="info" %}
-We plan to publish the WDK skill to its own GitHub repository. Once that's live, you'll also be able to install via `git clone`. For now, use ClawHub.
+We plan to publish the official WDK skill to its own GitHub repository. Once that's live, you'll also be able to install via `git clone`.
 {% endhint %}
 
 ## Configuration
 
-The WDK skill does not require environment variables. Your agent will ask for a seed phrase in conversation when it needs to create or recover a wallet. The skill passes the seed phrase as a constructor parameter in code rather than reading it from configuration.
+The WDK community skill does not require environment variables. Your agent will ask for a seed phrase in conversation when it needs to create or recover a wallet. The skill passes the seed phrase as a constructor parameter in code rather than reading it from configuration.
 
 {% hint style="warning" %}
 Your seed phrase controls real funds. Never share it, commit it to version control, or expose it in logs. The skill instructs agents to never log or expose seed phrases or private keys.
@@ -66,7 +66,7 @@ Start a new OpenClaw session and try a simple prompt:
 Create a multi-chain wallet with Ethereum and Bitcoin support, then show me the addresses.
 ```
 
-The agent should use the WDK skill to create wallet accounts and return the generated addresses. All write operations (transactions, swaps, bridges) require your explicit confirmation before executing.
+The agent should use the WDK community skill to create wallet accounts and return the generated addresses. All write operations (transactions, swaps, bridges) require your explicit confirmation before executing.
 
 <figure><img src="../.gitbook/assets/openclaw-wallet-output.png" alt="OpenClaw creating a multi-chain wallet using the WDK skill"><figcaption><p>Example output from the WDK skill creating a multi-chain wallet</p></figcaption></figure>
 
@@ -112,7 +112,7 @@ To reduce risk, here are some practical safety measures:
 
 Think of OpenClaw the same way you'd think about running scripts on your system: powerful and useful, but something you need to be careful with.
 
-## Inherent Limitations of Artificial Intelligence
+### Inherent Limitations of Artificial Intelligence
 
 OpenClaw makes use of artificial intelligence and machine learning technologies. While the use of artificial intelligence and machine learning enables capabilities, it also involves inherent limitations and risks. These include:
 


### PR DESCRIPTION
## Summary

Follow-up to PR #87. @gatteo  requested two additional changes to the OpenClaw community skill page:

## Changes

- **Expanded warning callout** - Added AI risk and responsibility language to the existing community skill disclaimer at the top of the page
- **New section: "Inherent Limitations of Artificial Intelligence"** - Lists five key risks of AI/ML technologies when using OpenClaw, including hallucinations, biases, input errors, unreliable action suggestions, and unexpected actions (e.g. sending assets)