### PR TITLE
docs: update skill install instructions to use npx skills add

### DIFF
--- a/ai/agent-skills.md
+++ b/ai/agent-skills.md
@@ -52,7 +52,7 @@ All write operations require explicit human confirmation. The skill instructs ag
 
 ## How It Works
 
-1. **Install the skill** by cloning the skill repository or installing from a skill registry like [ClawHub](https://clawhub.ai/HumanRupert/tether-wallet-development-kit)
+1. **Install the skill** by running `npx skills add tetherto/wdk-agent-skills` and selecting the agent you prefer
 2. **Agent loads the skill** and reads `SKILL.md` along with per-module reference files to learn WDK's API surface
 3. **Agent executes operations** when you ask it to create a wallet or send a transaction, generating the correct WDK code
 4. **You confirm** before any write operation (transactions, swaps, bridges) goes through
@@ -69,7 +69,7 @@ WDK's agent skills use a self-custodial model where your agent controls its own 
 | Multi-chain | Yes (EVM, Bitcoin, Solana, TON, Tron, Spark + more) | EVM + Solana | EVM + Solana + Bitcoin + more |
 | Open source | Yes (SDK + skills) | CLI/skills open, infra closed | Skills open, API closed |
 | MCP support | Yes ([MCP Toolkit](mcp-toolkit/README.md)) | Via skills | Via skills |
-| OpenClaw support | Yes ([ClawHub skill](https://clawhub.ai/HumanRupert/tether-wallet-development-kit)) | Yes (npx skills) | Yes (ClawHub skill) |
+| OpenClaw support | Yes (`npx skills add tetherto/wdk-agent-skills`) | Yes (npx skills) | Yes (ClawHub skill) |
 | x402 payments | Via [community extensions](#community-projects) | Yes (native) | No |
 | Key management | Local / self-managed | Coinbase infrastructure | Privy infrastructure |
 
@@ -77,7 +77,7 @@ WDK's agent skills use a self-custodial model where your agent controls its own 
 
 | Platform | How to Use |
 | --- | --- |
-| **OpenClaw** | Install from [ClawHub](openclaw.md) or clone to workspace. See [OpenClaw Integration](openclaw.md) |
+| **OpenClaw** | Run `npx skills add tetherto/wdk-agent-skills` and select your agent. See [OpenClaw Integration](openclaw.md) |
 | **Claude** | Upload `SKILL.md` as project knowledge, or paste into conversation |
 | **Cursor / Windsurf** | Clone to `.cursor/skills/wdk` or `.windsurf/skills/wdk` |
 | **Any MCP-compatible agent** | Use the [MCP Toolkit](mcp-toolkit/README.md) for structured tool calling |
@@ -96,7 +96,7 @@ Projects built by the community using WDK's agentic capabilities:
 ## Resources
 
 - [WDK SKILL.md on GitHub](https://github.com/tetherto/wdk-docs/blob/main/skills/wdk/SKILL.md) - The full skill file agents consume
-- [WDK Skill on ClawHub](https://clawhub.ai/HumanRupert/tether-wallet-development-kit) - Install the skill
+- [WDK Agent Skills](https://github.com/tetherto/wdk-agent-skills) - Install via `npx skills add tetherto/wdk-agent-skills`
 - [AgentSkills Specification](https://agentskills.io/specification) - The skill format standard
 - [WDK MCP Toolkit](https://github.com/tetherto/wdk-mcp-toolkit) - MCP server for structured tool calling
 - [WDK Core](https://github.com/tetherto/wdk-core) - The core SDK

--- a/ai/openclaw.md
+++ b/ai/openclaw.md
@@ -32,22 +32,16 @@ Tether and the WDK Team do not endorse or assume responsibility for its code, se
 The WDK community skill follows the [AgentSkills specification](https://agentskills.io/specification), so it works with any compatible agent platform. This page covers the OpenClaw-specific setup.
 {% endhint %}
 
-## Install the WDK Community Skill
-
-Install from [ClawHub](https://clawhub.ai/HumanRupert/tether-wallet-development-kit):
+## Install the WDK Skill
 
 ```bash
-npx clawhub install tether-wallet-development-kit
+npx skills add tetherto/wdk-agent-skills
 ```
 
-This installs the skill into your workspace's `skills/` directory. OpenClaw picks it up automatically on the next session.
-
-{% hint style="warning" %}
-You might see a VirusTotal warning during installation. It flags the skill as suspicious because it handles crypto keys and calls external APIs. This is normal for any wallet SDK skill, nevertheless review the skill's source code on [ClawHub](https://clawhub.ai/HumanRupert/tether-wallet-development-kit) before proceeding.
-{% endhint %}
+The installer will prompt you to select which agent skill you want to install. Pick the one that fits your use case. Once installed, OpenClaw picks it up automatically on the next session.
 
 {% hint style="info" %}
-We plan to publish the official WDK skill to its own GitHub repository. Once that's live, you'll also be able to install via `git clone`.
+The skill will also be published on [ClawHub](https://clawhub.ai) shortly.
 {% endhint %}
 
 ## Configuration


### PR DESCRIPTION
## Summary
- Replace ClawHub install commands with `npx skills add tetherto/wdk-agent-skills` in both `ai/openclaw.md` and `ai/agent-skills.md`
- Update comparison table, platform table, and resources links in `agent-skills.md`
- Add info hint that the skill will also be published on ClawHub shortly

## Test plan
- [x] Verify the install command `npx skills add tetherto/wdk-agent-skills` renders correctly
- [x] Verify all updated links and references are accurate
- [x] Confirm ClawHub hint displays properly in GitBook