### PR TITLE
docs: rewrite partner program with partnership tracks

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,7 +5,7 @@
 * [Welcome](README.md)
 * [About WDK](overview/about.md)
 * [Our Vision](overview/vision.md)
-* [Partner Programs](overview/partner-program.md)
+* [Partner with WDK](overview/partner-program.md)
 * [Get Support](overview/support.md)
 * [Changelog](overview/changelog.md)
 * [Showcase](overview/showcase.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,7 +5,7 @@
 * [Welcome](README.md)
 * [About WDK](overview/about.md)
 * [Our Vision](overview/vision.md)
-* [Partner Program](overview/partner-program.md)
+* [Partner Programs](overview/partner-program.md)
 * [Get Support](overview/support.md)
 * [Changelog](overview/changelog.md)
 * [Showcase](overview/showcase.md)

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -75,7 +75,7 @@ Technology Partners are protocol teams, service providers, and developer organiz
 
 As a Technology Partner, you'll work closely with our SDK team to build, test, and publish modules that reach every WDK-powered wallet. You'll get early access to unreleased APIs, architecture guidance, co-marketing exposure through our documentation and community channels, and the opportunity to shape how your protocol integrates across the ecosystem.
 
-<a class="button primary" href="https://wkf.ms/4hd40JK">Become a Technology Partner</a>
+<a class="button primary" href="https://forms.monday.com/forms/f6c509ea32fabfa63f719ac8eed9f934?r=euc1">Become a Technology Partner</a>
 
 ***
 
@@ -104,4 +104,4 @@ As a Consulting & Implementation Partner, you'll gain access to Tether's referra
 **Alpha Program** - This partnership track is currently in alpha. We're onboarding a limited number of partners as we shape the program and cannot guarantee acceptance, specific benefits, or program terms at this stage. Apply to express your interest and help shape the program as it evolves.
 {% endhint %}
 
-<a class="button primary" href="https://wkf.ms/4hd40JK">Become a Consulting & Implementation Partner</a>
+<a class="button primary" href="https://forms.monday.com/forms/d4603bc6e37b0c0a9c591764bcfb9380?r=euc1">Become a Consulting & Implementation Partner</a>

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -1,5 +1,5 @@
 ---
-title: Partner Programs
+title: Partner with WDK
 description: Build with WDK alongside Tether through our partnership tracks
 icon: star
 layout:

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -24,6 +24,10 @@ Build with WDK alongside Tether. Whether you're integrating WDK into your produc
 
 WDK is built to be open and extensible, but we know that building great products often takes more than just great documentation. Our Partner Program connects you directly with Tether's engineering and product teams so you can ship faster, with confidence. We offer 3 partnership tracks depending on how you plan to work with WDK.
 
+- [Project Partners](partner-program.md#project-partners)
+- [Technology Partners](partner-program.md#technology-partners)
+- [Consulting & Implementation Partners (Alpha)](partner-program.md#consulting-and-implementation-partners-alpha)
+
 ***
 
 ## Project Partners

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -22,22 +22,24 @@ layout:
 
 Build with WDK alongside Tether. Whether you're integrating WDK into your product or extending the ecosystem with new capabilities, we have a partnership track designed for you.
 
-WDK is built to be open and extensible, but we know that building great products often takes more than just great documentation. Our Partner Program connects you directly with Tether's engineering and product teams so you can ship faster, with confidence. We offer 3 partnership tracks depending on how you plan to work with WDK.
+WDK is built to be open and extensible, but we know that building great products often takes more than just great documentation. We offer a selected group of partners a direct connection with Tether's engineering and product teams so you can ship faster, with confidence. We offer 3 partnership tracks depending on how you plan to work with WDK.
 
 - [Project Partners](partner-program.md#project-partners)
-- [Technology Partners](partner-program.md#technology-partners)
+- [WDK Tech Contributors](partner-program.md#wdk-tech-contributors)
 - [Consulting & Implementation Partners (Alpha)](partner-program.md#consulting-and-implementation-partners-alpha)
 
 ***
 
 ## Project Partners
 
-Integrate WDK with priority support and dedicated engineering.
+Integrate WDK more confidently, with direct access to Tether's engineering team and WDK solutions architects. Project Partners approved for Tether-supported implementations will benefit from:
 
-- Dedicated engineering support
+- Access to a WDK Solutions Architect to discuss product-specific implementation strategies
 - Custom integration assistance
-- Priority issue resolution
-- Direct access to the core team
+- Privileged support channel
+- WDK roadmap visibility
+- Early access to APIs and SDKs
+- Direct access to WDK product and engineering core team
 
 ### Is it for you?
 
@@ -56,28 +58,29 @@ As a Project Partner, you get hands-on integration support from the team that bu
 
 ***
 
-## Technology Partners
+## WDK Tech Contributors
 
-Develop modules and extensions for the WDK ecosystem.
+Tap into the network of WDK adopters by developing modules and extensions for the WDK ecosystem. Technology partners approved as WDK Tech Contributors will benefit from:
 
 - Build and publish WDK modules
+- Visibility across WDK community and in WDK documentation
 - Co-marketing opportunities
 - Early access to APIs and SDKs
 - Technical documentation collaboration
 
 ### Is it for you?
 
-Technology Partners are protocol teams, service providers, and developer organizations building modules, plugins, or integrations that extend what WDK can do. You're a good fit for this track if you are:
+Tech Contributors are protocol teams, service providers, and developer organizations building modules, plugins, or integrations that extend what WDK can do. You're a good fit for this track if you are:
 
-- A **swap or DEX protocol** (like StonFi, Velora) looking to provide liquidity and trading capabilities to WDK-powered wallets.
+- A **swap or DEX protocol** looking to provide liquidity and trading capabilities to WDK-powered wallets.
 - A **bridge protocol** enabling cross-chain asset transfers that WDK wallets can access natively.
-- An **on/off-ramp provider** (like MoonPay) connecting fiat currencies to the WDK ecosystem.
-- A **lending or DeFi protocol** (like Aave) looking to make your services available directly within WDK wallets.
-- A **hardware wallet or signing solution provider** (like Ledger) building signer integrations for WDK.
+- An **on/off-ramp provider** connecting fiat currencies to the WDK ecosystem.
+- A **lending or DeFi protocol** looking to make your services available directly within WDK wallets.
+- A **hardware wallet or signing solution provider** building signer integrations for WDK.
 - A **blockchain or L2 network** that wants first-class WDK wallet support for your chain.
 - An **open-source developer or team** contributing new wallet modules, protocol integrations, or developer tooling to the WDK ecosystem.
 
-As a Technology Partner, you'll work closely with our SDK team to build, test, and publish modules that reach every WDK-powered wallet. You'll get early access to unreleased APIs, architecture guidance, co-marketing exposure through our documentation and community channels, and the opportunity to shape how your protocol integrates across the ecosystem.
+As a Tech Contributor, you'll work closely with our SDK team to build, test, and publish modules that reach every WDK-powered wallet. You'll get early access to unreleased APIs, architecture guidance, co-marketing exposure through our documentation and community channels, and the opportunity to shape how your protocol integrates across the ecosystem.
 
 <a class="button primary" href="https://forms.monday.com/forms/f6c509ea32fabfa63f719ac8eed9f934?r=euc1">Become a Technology Partner</a>
 
@@ -85,24 +88,28 @@ As a Technology Partner, you'll work closely with our SDK team to build, test, a
 
 ## Consulting & Implementation Partners (Alpha)
 
-Agencies and teams building wallet solutions with WDK for their clients.
+Consulting companies, agencies, and systems integrators building wallet solutions with WDK for their clients. Approved Consulting & Implementation Partners will benefit from:
 
-- Client referrals from Tether's partner network
-- Dedicated support channel
-- Revenue sharing opportunities
-- Co-branded case studies and references
+- **Being part of Tether's partner ecosystem**
+- Access to a WDK Solutions Architect to discuss product-specific implementation strategies for your clients
+- Custom integration assistance
+- Direct access to WDK product and engineering core team
+- Privileged support channel
+- WDK roadmap visibility
+- Early access to APIs and SDKs
+- Co-marketing support
 
 ### Is it for you?
 
-Consulting & Implementation Partners are agencies, system integrators, and development studios that deliver WDK-powered solutions on behalf of their clients. You're a good fit for this track if you are:
+Consulting & Implementation Partners are agencies, system integrators, and software houses that would like to deliver WDK-powered solutions on behalf of their clients. You're a good fit for this track if you are:
 
 - A **system integrator** helping enterprise clients adopt blockchain and digital asset infrastructure.
-- A **software development agency** building custom wallet or payment applications for fintech clients.
+- A **software development agency** building custom wallet or payment applications.
 - A **blockchain consultancy** advising companies on self-custodial wallet strategy and architecture.
 - A **digital transformation firm** integrating stablecoin payments into existing client platforms.
 - A **managed services provider** offering ongoing support and maintenance for WDK-based deployments.
 
-As a Consulting & Implementation Partner, you'll gain access to Tether's referral network, dedicated technical support for your client engagements, and revenue sharing opportunities. We'll equip your team with the training, documentation, and direct engineering access needed to deliver successful WDK implementations at scale.
+As a Consulting & Implementation Partner, you'll gain access to Tether's referral network, dedicated technical support for your client engagements. We'll equip your team with the training, documentation, and direct engineering access needed to deliver successful WDK implementations at scale.
 
 {% hint style="info" %}
 **Alpha Program** - This partnership track is currently in alpha. We're onboarding a limited number of partners as we shape the program and cannot guarantee acceptance, specific benefits, or program terms at this stage. Apply to express your interest and help shape the program as it evolves.

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -65,13 +65,13 @@ Develop modules and extensions for the WDK ecosystem.
 
 Technology Partners are protocol teams, service providers, and developer organizations building modules, plugins, or integrations that extend what WDK can do. You're a good fit for this track if you are:
 
-- A swap or DEX protocol (like StonFi, Velora) looking to provide liquidity and trading capabilities to WDK-powered wallets.
-- A bridge protocol enabling cross-chain asset transfers that WDK wallets can access natively.
-- An on/off-ramp provider (like MoonPay) connecting fiat currencies to the WDK ecosystem.
-- A lending or DeFi protocol (like Aave) looking to make your services available directly within WDK wallets.
-- A hardware wallet or signing solution provider (like Ledger) building signer integrations for WDK.
-- A blockchain or L2 network that wants first-class WDK wallet support for your chain.
-- An open-source developer or team contributing new wallet modules, protocol integrations, or developer tooling to the WDK ecosystem.
+- A **swap or DEX protocol** (like StonFi, Velora) looking to provide liquidity and trading capabilities to WDK-powered wallets.
+- A **bridge protocol** enabling cross-chain asset transfers that WDK wallets can access natively.
+- An **on/off-ramp provider** (like MoonPay) connecting fiat currencies to the WDK ecosystem.
+- A **lending or DeFi protocol** (like Aave) looking to make your services available directly within WDK wallets.
+- A **hardware wallet or signing solution provider** (like Ledger) building signer integrations for WDK.
+- A **blockchain or L2 network** that wants first-class WDK wallet support for your chain.
+- An **open-source developer or team** contributing new wallet modules, protocol integrations, or developer tooling to the WDK ecosystem.
 
 As a Technology Partner, you'll work closely with our SDK team to build, test, and publish modules that reach every WDK-powered wallet. You'll get early access to unreleased APIs, architecture guidance, co-marketing exposure through our documentation and community channels, and the opportunity to shape how your protocol integrates across the ecosystem.
 

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -1,5 +1,5 @@
 ---
-title: Partner Program
+title: Partner Programs
 description: Build with WDK alongside Tether through our partnership tracks
 icon: star
 layout:

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -1,6 +1,6 @@
 ---
 title: Partner Program
-description: Join our partner program, get early access to new features and support
+description: Build with WDK alongside Tether through our partnership tracks
 icon: star
 layout:
   width: default
@@ -18,48 +18,90 @@ layout:
     visible: false
 ---
 
-# Partner Program
+# Partnering with WDK
 
-<a class="button primary" href="https://wkf.ms/4hd40JK">Get in touch</a>
+Build with WDK alongside Tether. Whether you're integrating WDK into your product or extending the ecosystem with new capabilities, we have a partnership track designed for you.
 
-
-## What is the Partner Program?
-
-The WDK Partner Program gives you **exclusive early access** to our comprehensive wallet development toolkit, allowing you to:
-
-- **Build and test** production-ready wallets across multiple blockchains
-- **Influence the roadmap** by providing direct feedback to our development team
-- **Access premium support** from our engineering team
-- **Shape the future** of cross-chain wallet infrastructure
-- **Get ahead** of the competition with early adoption
+WDK is built to be open and extensible, but we know that building great products often takes more than just great documentation. Our Partner Program connects you directly with Tether's engineering and product teams so you can ship faster, with confidence. We offer 3 partnership tracks depending on how you plan to work with WDK.
 
 ***
 
-## Your Responsibilities as a Partner
+## Project Partners
 
-As a valued partner, we ask for your collaboration in making WDK the best possible solution for the developer community:
+Integrate WDK with priority support and dedicated engineering.
 
-- **Provide regular feedback** on WDK features, functionality, and real-world usage
-- **Report issues promptly** with detailed steps to reproduce and share error messages
-- **Participate actively** in feedback sessions, surveys, and community discussions
-- **Maintain confidentiality** by keeping access private within your organization
-- **Test new features** thoroughly and confirm bug fixes and improvements
+- Dedicated engineering support
+- Custom integration assistance
+- Priority issue resolution
+- Direct access to the core team
+
+### Is it for you?
+
+Project Partners are companies and teams building end-user products powered by WDK. You're a good fit for this track if you are:
+
+- A fintech or neobank building a wallet, payments app, or asset management platform and looking to leverage WDK as your underlying wallet infrastructure.
+- An exchange or trading platform adding self-custodial wallet features for your users.
+- A messaging or social platform integrating peer-to-peer payments or tipping functionality.
+- A remittance or cross-border payments provider looking to use stablecoins and multi-chain support to serve your customers.
+- An enterprise or institutional player that needs WDK integrated into internal treasury, compliance, or operations tooling.
+- Any team that plans to ship a product to end users where WDK handles key management, transaction signing, or blockchain interactions under the hood.
+
+As a Project Partner, you get hands-on integration support from the team that builds WDK. We'll help you navigate architecture decisions, troubleshoot implementation challenges, and make sure your product launches on solid foundations.
+
+<a class="button primary" href="https://wkf.ms/4hd40JK">Become a Project Partner</a>
 
 ***
 
-## What We're Looking For
+## Technology Partners
 
-- **Innovative Use Cases**: Unique applications of WDK technology
-- **Integration Challenges**: How you solved complex technical problems
-- **Performance Improvements**: Optimizations and best practices you've discovered
-- **User Experience**: Creative approaches to wallet UX/UI
-- **Modules Expansion**: Adding support for new WDK modules or blockchain integrations
+Develop modules and extensions for the WDK ecosystem.
 
-We're excited to showcase how our partners are using WDK to build innovative wallet solutions. If you'd like to share your story or be featured in our materials, please let us know!
+- Build and publish WDK modules
+- Co-marketing opportunities
+- Early access to APIs and SDKs
+- Technical documentation collaboration
+
+### Is it for you?
+
+Technology Partners are protocol teams, service providers, and developer organizations building modules, plugins, or integrations that extend what WDK can do. You're a good fit for this track if you are:
+
+- A swap or DEX protocol (like StonFi, Velora) looking to provide liquidity and trading capabilities to WDK-powered wallets.
+- A bridge protocol enabling cross-chain asset transfers that WDK wallets can access natively.
+- An on/off-ramp provider (like MoonPay) connecting fiat currencies to the WDK ecosystem.
+- A lending or DeFi protocol (like Aave) looking to make your services available directly within WDK wallets.
+- A hardware wallet or signing solution provider (like Ledger) building signer integrations for WDK.
+- A blockchain or L2 network that wants first-class WDK wallet support for your chain.
+- An open-source developer or team contributing new wallet modules, protocol integrations, or developer tooling to the WDK ecosystem.
+
+As a Technology Partner, you'll work closely with our SDK team to build, test, and publish modules that reach every WDK-powered wallet. You'll get early access to unreleased APIs, architecture guidance, co-marketing exposure through our documentation and community channels, and the opportunity to shape how your protocol integrates across the ecosystem.
+
+<a class="button primary" href="https://wkf.ms/4hd40JK">Become a Technology Partner</a>
 
 ***
 
-## Ready to Join?
+## Consulting & Implementation Partners (Alpha)
 
-<a class="button primary" href="https://wkf.ms/4hd40JK">Get in touch</a>
+Agencies and teams building wallet solutions with WDK for their clients.
 
+- Client referrals from Tether's partner network
+- Dedicated support channel
+- Revenue sharing opportunities
+- Co-branded case studies and references
+
+### Is it for you?
+
+Consulting & Implementation Partners are agencies, system integrators, and development studios that deliver WDK-powered solutions on behalf of their clients. You're a good fit for this track if you are:
+
+- A system integrator helping enterprise clients adopt blockchain and digital asset infrastructure.
+- A software development agency building custom wallet or payment applications for fintech clients.
+- A blockchain consultancy advising companies on self-custodial wallet strategy and architecture.
+- A digital transformation firm integrating stablecoin payments into existing client platforms.
+- A managed services provider offering ongoing support and maintenance for WDK-based deployments.
+
+As a Consulting & Implementation Partner, you'll gain access to Tether's referral network, dedicated technical support for your client engagements, and revenue sharing opportunities. We'll equip your team with the training, documentation, and direct engineering access needed to deliver successful WDK implementations at scale.
+
+{% hint style="info" %}
+**Alpha Program** - This partnership track is currently in alpha. We're onboarding a limited number of partners as we shape the program and cannot guarantee acceptance, specific benefits, or program terms at this stage. Apply to express your interest and help shape the program as it evolves.
+{% endhint %}
+
+<a class="button primary" href="https://wkf.ms/4hd40JK">Become a Consulting & Implementation Partner</a>

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -48,7 +48,7 @@ Project Partners are companies and teams building end-user products powered by W
 
 As a Project Partner, you get hands-on integration support from the team that builds WDK. We'll help you navigate architecture decisions, troubleshoot implementation challenges, and make sure your product launches on solid foundations.
 
-[***Become a Project Partner***](https://forms.monday.com/forms/6d484c4b34949e3a238988c47bf0a1b6?r=euc1)
+<a class="button primary" href="https://forms.monday.com/forms/6d484c4b34949e3a238988c47bf0a1b6?r=euc1">Become a Project Partner</a>
 
 ***
 
@@ -75,7 +75,7 @@ Technology Partners are protocol teams, service providers, and developer organiz
 
 As a Technology Partner, you'll work closely with our SDK team to build, test, and publish modules that reach every WDK-powered wallet. You'll get early access to unreleased APIs, architecture guidance, co-marketing exposure through our documentation and community channels, and the opportunity to shape how your protocol integrates across the ecosystem.
 
-[***Become a Technology Partner***](https://forms.monday.com/forms/f6c509ea32fabfa63f719ac8eed9f934?r=euc1)
+<a class="button primary" href="https://forms.monday.com/forms/f6c509ea32fabfa63f719ac8eed9f934?r=euc1">Become a Technology Partner</a>
 
 ***
 
@@ -100,6 +100,8 @@ Consulting & Implementation Partners are agencies, system integrators, and devel
 
 As a Consulting & Implementation Partner, you'll gain access to Tether's referral network, dedicated technical support for your client engagements, and revenue sharing opportunities. We'll equip your team with the training, documentation, and direct engineering access needed to deliver successful WDK implementations at scale.
 
-***Alpha Program** - This partnership track is currently in alpha. We're onboarding a limited number of partners as we shape the program and cannot guarantee acceptance, specific benefits, or program terms at this stage. Apply to express your interest and help shape the program as it evolves.*
+{% hint style="info" %}
+**Alpha Program** - This partnership track is currently in alpha. We're onboarding a limited number of partners as we shape the program and cannot guarantee acceptance, specific benefits, or program terms at this stage. Apply to express your interest and help shape the program as it evolves.
+{% endhint %}
 
-[***Become a Consulting & Implementation Partner***](https://forms.monday.com/forms/d4603bc6e37b0c0a9c591764bcfb9380?r=euc1)
+<a class="button primary" href="https://forms.monday.com/forms/d4603bc6e37b0c0a9c591764bcfb9380?r=euc1">Become a Consulting & Implementation Partner</a>

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -39,16 +39,16 @@ Integrate WDK with priority support and dedicated engineering.
 
 Project Partners are companies and teams building end-user products powered by WDK. You're a good fit for this track if you are:
 
-- A fintech or neobank building a wallet, payments app, or asset management platform and looking to leverage WDK as your underlying wallet infrastructure.
-- An exchange or trading platform adding self-custodial wallet features for your users.
-- A messaging or social platform integrating peer-to-peer payments or tipping functionality.
-- A remittance or cross-border payments provider looking to use stablecoins and multi-chain support to serve your customers.
-- An enterprise or institutional player that needs WDK integrated into internal treasury, compliance, or operations tooling.
-- Any team that plans to ship a product to end users where WDK handles key management, transaction signing, or blockchain interactions under the hood.
+- A **fintech or neobank** building a wallet, payments app, or asset management platform and looking to leverage WDK as your underlying wallet infrastructure.
+- An **exchange or trading platform** adding self-custodial wallet features for your users.
+- A **messaging or social platform** integrating peer-to-peer payments or tipping functionality.
+- A **remittance or cross-border payments provider** looking to use stablecoins and multi-chain support to serve your customers.
+- An **enterprise or institutional player** that needs WDK integrated into internal treasury, compliance, or operations tooling.
+- Any team that plans to **ship a product to end users** where WDK handles key management, transaction signing, or blockchain interactions under the hood.
 
 As a Project Partner, you get hands-on integration support from the team that builds WDK. We'll help you navigate architecture decisions, troubleshoot implementation challenges, and make sure your product launches on solid foundations.
 
-<a class="button primary" href="https://forms.monday.com/forms/6d484c4b34949e3a238988c47bf0a1b6?r=euc1">Become a Project Partner</a>
+[***Become a Project Partner***](https://forms.monday.com/forms/6d484c4b34949e3a238988c47bf0a1b6?r=euc1)
 
 ***
 
@@ -75,7 +75,7 @@ Technology Partners are protocol teams, service providers, and developer organiz
 
 As a Technology Partner, you'll work closely with our SDK team to build, test, and publish modules that reach every WDK-powered wallet. You'll get early access to unreleased APIs, architecture guidance, co-marketing exposure through our documentation and community channels, and the opportunity to shape how your protocol integrates across the ecosystem.
 
-<a class="button primary" href="https://forms.monday.com/forms/f6c509ea32fabfa63f719ac8eed9f934?r=euc1">Become a Technology Partner</a>
+[***Become a Technology Partner***](https://forms.monday.com/forms/f6c509ea32fabfa63f719ac8eed9f934?r=euc1)
 
 ***
 
@@ -92,16 +92,14 @@ Agencies and teams building wallet solutions with WDK for their clients.
 
 Consulting & Implementation Partners are agencies, system integrators, and development studios that deliver WDK-powered solutions on behalf of their clients. You're a good fit for this track if you are:
 
-- A system integrator helping enterprise clients adopt blockchain and digital asset infrastructure.
-- A software development agency building custom wallet or payment applications for fintech clients.
-- A blockchain consultancy advising companies on self-custodial wallet strategy and architecture.
-- A digital transformation firm integrating stablecoin payments into existing client platforms.
-- A managed services provider offering ongoing support and maintenance for WDK-based deployments.
+- A **system integrator** helping enterprise clients adopt blockchain and digital asset infrastructure.
+- A **software development agency** building custom wallet or payment applications for fintech clients.
+- A **blockchain consultancy** advising companies on self-custodial wallet strategy and architecture.
+- A **digital transformation firm** integrating stablecoin payments into existing client platforms.
+- A **managed services provider** offering ongoing support and maintenance for WDK-based deployments.
 
 As a Consulting & Implementation Partner, you'll gain access to Tether's referral network, dedicated technical support for your client engagements, and revenue sharing opportunities. We'll equip your team with the training, documentation, and direct engineering access needed to deliver successful WDK implementations at scale.
 
-{% hint style="info" %}
-**Alpha Program** - This partnership track is currently in alpha. We're onboarding a limited number of partners as we shape the program and cannot guarantee acceptance, specific benefits, or program terms at this stage. Apply to express your interest and help shape the program as it evolves.
-{% endhint %}
+***Alpha Program** - This partnership track is currently in alpha. We're onboarding a limited number of partners as we shape the program and cannot guarantee acceptance, specific benefits, or program terms at this stage. Apply to express your interest and help shape the program as it evolves.*
 
-<a class="button primary" href="https://forms.monday.com/forms/d4603bc6e37b0c0a9c591764bcfb9380?r=euc1">Become a Consulting & Implementation Partner</a>
+[***Become a Consulting & Implementation Partner***](https://forms.monday.com/forms/d4603bc6e37b0c0a9c591764bcfb9380?r=euc1)

--- a/overview/partner-program.md
+++ b/overview/partner-program.md
@@ -48,7 +48,7 @@ Project Partners are companies and teams building end-user products powered by W
 
 As a Project Partner, you get hands-on integration support from the team that builds WDK. We'll help you navigate architecture decisions, troubleshoot implementation challenges, and make sure your product launches on solid foundations.
 
-<a class="button primary" href="https://wkf.ms/4hd40JK">Become a Project Partner</a>
+<a class="button primary" href="https://forms.monday.com/forms/6d484c4b34949e3a238988c47bf0a1b6?r=euc1">Become a Project Partner</a>
 
 ***
 


### PR DESCRIPTION
## Summary
- Rewrites the Partner Program page with three distinct partnership tracks: **Project Partners**, **Technology Partners**, and **Consulting & Implementation Partners** (Alpha)
- Each track includes a description, benefits list, "Is it for you?" criteria, and a CTA button
- Replaces the previous generic partner program content

## Test plan
- [ ] Verify the page renders correctly on GitBook
- [ ] Confirm all CTA buttons link to the correct form
- [ ] Check that the alpha disclaimer hint box renders properly