### PR TITLE
docs: add create-wdk-module docs + release + fixes (WDKDOCS-222)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -122,6 +122,7 @@
 * [Price Rates](tools/price-rates/README.md)
   * [Configuration](tools/price-rates/configuration.md)
   * [API Reference](tools/price-rates/api-reference.md)
+* [Create WDK Module](tools/create-wdk-module.md)
 
 ## Resources and Guides
 

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,15 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### March 6, 2026
+
+**Changes**
+- **wallet-tron**: Fixed case-sensitive address check in `verify`, upgraded TonWeb to v6.2.0 ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.5))
+- **lending-aave-evm**: Security dependency updates ([v1.0.0-beta.4](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.4))
+- **wdk**: Security dependency updates ([v1.0.0-beta.6](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.6))
+
+---
+
 ### March 5, 2026
 
 **What's New**

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### March 5, 2026
+
+**What's New**
+- **create-wdk-module**: Added documentation for the [`create-wdk-module`](../tools/create-wdk-module.md) CLI scaffolding tool. Updated [Community Modules](../sdk/community-modules/) and [SDK Get Started](../sdk/get-started.md) pages with references to the new tool.
+
+---
+
 ### February 20, 2026
 
 **What's New**

--- a/sdk/community-modules/README.md
+++ b/sdk/community-modules/README.md
@@ -36,15 +36,17 @@ Tether and the WDK Team do not endorse or assume responsibility for their code, 
 
 ## Create Your Own Module
 
-Want to extend WDK with your own custom module? We encourage community contributions!
+Want to extend WDK with your own custom module? Use the `create-wdk-module` CLI to scaffold a fully configured project in seconds:
 
-{% hint style="info" %}
-**Coming Soon: Custom Module Guide**
+{% code title="Scaffold a new module" %}
+```bash
+npx create-wdk-module@latest
+```
+{% endcode %}
 
-We're preparing a comprehensive guide on how to create custom WDK modules. Join our [Discord](https://discord.gg/arYXDhHB2w) for updates!
-{% endhint %}
+The CLI generates source files, tests, TypeScript type definitions, and CI workflows for all five module types (wallet, swap, bridge, lending, fiat). See the [Create WDK Module documentation](../../tools/create-wdk-module.md) for the full guide, CLI options, and generated project structure.
 
-In the meantime, you can:
+You can also:
 
 1. **Study existing modules** - Review the source code of official WDK modules on [GitHub](https://github.com/orgs/tetherto/repositories?q=wdk) to understand the patterns and interfaces
 2. **Join the community** - Connect with other developers on our [Discord](https://discord.gg/arYXDhHB2w) to discuss your ideas

--- a/sdk/get-started.md
+++ b/sdk/get-started.md
@@ -196,6 +196,16 @@ const swapResult = await wdkWithProtocols.executeProtocol('swap-velora-evm', {
 
 ### Creating Custom Modules
 
+{% hint style="success" %}
+**Recommended**: Use the `create-wdk-module` CLI to scaffold a new module with all the boilerplate in place:
+
+```bash
+npx create-wdk-module@latest
+```
+
+See the [Create WDK Module](../tools/create-wdk-module.md) page for the full guide, CLI options, and generated project structure.
+{% endhint %}
+
 WDK's modular architecture makes it straightforward to add support for new blockchains or protocols. Each module type has a specific interface that must be implemented.
 
 #### Wallet Module Interface
@@ -308,9 +318,9 @@ const balance = await customAccount.getBalance()
 {% endcode %}
 
 
-<!-- {% hint style="info" %} -->
-<!-- **Learn More**: For detailed information on creating custom modules, check out our [Extender Guide](../extender-guide.md).
-{% endhint %} -->
+{% hint style="info" %}
+**Learn More**: For detailed information on creating custom modules, check out the [Create WDK Module](../tools/create-wdk-module.md) tool and the [Community Modules](../community-modules/) page.
+{% endhint %}
 
 ***
 

--- a/sdk/wallet-modules/wallet-evm-erc-4337/README.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/README.md
@@ -38,11 +38,15 @@ A simple and secure package to manage ERC-4337 compliant wallets for EVM-compati
 
 ## Supported Networks
 
-This package works with any EVM-compatible blockchain, including:
+ERC-4337 support depends on the Safe4337Module contract being deployed on the target chain, along with a compatible bundler and paymaster service. The following networks are verified:
 
-- **Ethereum Mainnet**
-- **Ethereum Testnets** (Sepolia)
-- **Other EVM Chains** (Polygon, Arbitrum, Avalanche C-chain, Plasma etc.)
+- **Ethereum Mainnet** (Chain ID: 1)
+- **Polygon** (Chain ID: 137)
+- **Arbitrum One** (Chain ID: 42161)
+- **Plasma** (Chain ID: 9745)
+- **Ethereum Sepolia Testnet** (Chain ID: 11155111)
+
+See [Configuration](./configuration.md#verified-supported-networks) for the full compatibility matrix and ready-to-use config examples.
 
 ## Next Steps
 

--- a/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
+++ b/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md
@@ -98,9 +98,8 @@ const config = { chainId: 137 }
 // Arbitrum One
 const config = { chainId: 42161 }
 
-// Avalanche C-Chain
-const config = { chainId: 43114 }
-
+// Plasma
+const config = { chainId: 9745 }
 ```
 
 ### Provider
@@ -295,6 +294,28 @@ try {
 
 ## Network-Specific Configurations
 
+ERC-4337 account abstraction requires three independent layers on any given chain:
+
+1. **Safe4337Module contract** deployed and registered in `@safe-global/safe-modules-deployments`
+2. **Bundler service** (Pimlico or Candide) that supports the chain
+3. **Paymaster service** (Pimlico or Candide) that supports the chain
+
+If any layer is missing for a chain, the SDK will fail. The following networks have been verified to support all three layers.
+
+### Verified Supported Networks
+
+| Network | Chain ID | Bundler | Paymaster | Status |
+| ------- | -------- | ------- | --------- | ------ |
+| Ethereum | 1 | Candide | Candide | Supported |
+| Polygon | 137 | Candide | Candide | Supported |
+| Arbitrum One | 42161 | Pimlico (public) | Pimlico (public) | Supported |
+| Plasma | 9745 | Candide | Candide | Supported |
+| Sepolia (testnet) | 11155111 | Pimlico / Candide | Pimlico / Candide | Supported |
+
+{% hint style="danger" %}
+**Avalanche C-Chain (43114) is not supported.** The Safe4337Module v0.3.0 contract is not deployed on Avalanche. Attempting to use ERC-4337 on Avalanche will fail with `Safe4337Module not available for chain 43114`.
+{% endhint %}
+
 ### Ethereum Mainnet
 
 
@@ -329,7 +350,7 @@ const ethereumConfig = {
 ```javascript
 const polygonConfig = {
   chainId: 137,
-  provider: 'https://polygon-rpc.com',
+  provider: 'https://polygon-bor-rpc.publicnode.com',
   bundlerUrl: 'https://api.candide.dev/public/v3/polygon',
   paymasterUrl: 'https://api.candide.dev/public/v3/polygon',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
@@ -360,32 +381,12 @@ const arbitrumConfig = {
 }
 ```
 
-### Avalanche C-Chain
-
-``` javascript
-const avalancheConfig = {
-  chainId: 43114,
-  provider: 'https://avalanche-c-chain-rpc.publicnode.com',
-  bundlerUrl: "https://public.pimlico.io/v2/43114/rpc",
-  paymasterUrl: "https://public.pimlico.io/v2/43114/rpc",
-  paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
-  entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
-  safeModulesVersion: '0.3.0',
-  paymasterToken: {
-    address: '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7' // USDT
-  },
-  transferMaxFee: 100000 // 100,000 paymaster token units (e.g., 0.1 USDT if 6 decimals)
-}
-```
-
 ### Plasma
 
 ```javascript
-// Plasma (example Layer 2)
 const plasmaConfig = {
   chainId: 9745,
   provider: 'https://plasma.drpc.org',
-  // For ERC-4337 support, optional fields:
   bundlerUrl: 'https://api.candide.dev/public/v3/9745',
   paymasterUrl: 'https://api.candide.dev/public/v3/9745',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',

--- a/skills/wdk/references/chains.md
+++ b/skills/wdk/references/chains.md
@@ -137,4 +137,4 @@ Minimum meaningful amounts below which transactions will fail or be rejected by 
 Source chains (EVM only): ethereum, arbitrum, polygon, berachain, ink
 Destination chains: ethereum, arbitrum, polygon, berachain, ink, ton, tron
 
-ERC-4337 (Account Abstraction) currently supported on: Arbitrum
+ERC-4337 (Account Abstraction) verified on: Ethereum (1), Polygon (137), Arbitrum (42161), Plasma (9745), Sepolia (11155111). Avalanche (43114) is NOT supported (Safe4337Module not deployed).

--- a/tools/create-wdk-module.md
+++ b/tools/create-wdk-module.md
@@ -1,0 +1,290 @@
+---
+title: Create WDK Module
+description: CLI scaffolding tool to generate new WDK wallet and protocol modules with a single command.
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: false
+  metadata:
+    visible: false
+---
+
+# Create WDK Module
+
+Scaffold new WDK modules with a single command. The CLI generates a fully configured project with source files, tests, TypeScript type definitions, and CI workflows — ready for you to add your blockchain or protocol integration logic.
+
+Powered by [`create-wdk-module`](https://github.com/tetherto/create-wdk-module).
+
+---
+
+## Quick Start
+
+{% stepper %}
+{% step %}
+### Run the scaffolding command
+
+{% code title="Scaffold a new module" %}
+```bash
+npx create-wdk-module@latest
+```
+{% endcode %}
+
+You can also pass arguments directly to skip the interactive prompts:
+
+{% code title="Scaffold with arguments" %}
+```bash
+npx create-wdk-module@latest wallet stellar
+```
+{% endcode %}
+{% endstep %}
+
+{% step %}
+### Install and run tests
+
+{% code title="Set up the generated project" %}
+```bash
+cd wdk-wallet-stellar
+npm install
+npm test
+```
+{% endcode %}
+{% endstep %}
+{% endstepper %}
+
+---
+
+## Module Types
+
+The CLI supports all five WDK module categories. The generated package name follows WDK naming conventions automatically.
+
+| Type | Description | Generated Package Example |
+|------|-------------|---------------------------|
+| `wallet` | Blockchain wallet integration | `wdk-wallet-stellar` |
+| `swap` | DEX/token swap protocol | `wdk-protocol-swap-jupiter-solana` |
+| `bridge` | Cross-chain bridge protocol | `wdk-protocol-bridge-wormhole-evm` |
+| `lending` | DeFi lending protocol | `wdk-protocol-lending-compound-evm` |
+| `fiat` | Fiat on/off-ramp provider | `wdk-protocol-fiat-moonpay` |
+
+---
+
+## CLI Options
+
+| Option | Alias | Description | Default |
+|--------|-------|-------------|---------|
+| `[type]` | | Module type (wallet, swap, bridge, lending, fiat) | (interactive prompt) |
+| `[name]` | | Module or protocol name | (interactive prompt) |
+| `[blockchain]` | | Target blockchain | (interactive prompt) |
+| `--scope <scope>` | `-s` | npm scope (e.g., `@myorg`) | none |
+| `--git` | | Initialize a git repository | `true` |
+| `--no-git` | | Skip git initialization | |
+| `--yes` | `-y` | Skip prompts, use defaults | `false` |
+| `--version` | `-v` | Show version | |
+| `--help` | `-h` | Show help | |
+
+### Examples
+
+{% code title="Common CLI usage patterns" %}
+```bash
+# Create a wallet module with an npm scope
+npx create-wdk-module@latest wallet stellar --scope @myorg
+
+# Create a swap protocol module
+npx create-wdk-module@latest swap jupiter solana
+
+# Create with all defaults, no prompts
+npx create-wdk-module@latest wallet stellar --yes
+```
+{% endcode %}
+
+---
+
+## Interactive Mode
+
+When run without arguments, the CLI guides you through module setup step by step:
+
+{% code title="Interactive session" %}
+```bash
+$ npx create-wdk-module@latest
+
+  Create WDK Module
+
+? What type of module do you want to create?
+  > Wallet Module (blockchain wallet integration)
+    Swap Module (DEX/token swap integration)
+    Bridge Module (cross-chain bridging)
+    Lending Module (DeFi lending protocol)
+    Fiat Module (fiat on/off-ramp)
+
+? What is the blockchain name? (e.g., "stellar", "solana")
+  > stellar
+
+? npm scope (leave empty for none, e.g., @myorg):
+  >
+
+? Initialize git repository?
+  > Yes
+
+Creating wdk-wallet-stellar...
+
+✓ Template files copied
+✓ Initialized git repository
+
+Success! Created wdk-wallet-stellar at ./wdk-wallet-stellar
+
+Next steps:
+  cd wdk-wallet-stellar
+  npm install
+  npm test
+```
+{% endcode %}
+
+---
+
+## Generated Project Structure
+
+The scaffolded project includes source files, tests, TypeScript definitions, and GitHub CI workflows out of the box.
+
+<details>
+<summary>Wallet Module structure</summary>
+
+{% code title="Wallet module project tree" %}
+```
+wdk-wallet-stellar/
+├── .github/
+│   ├── workflows/
+│   │   ├── build.yml
+│   │   └── publish.yml
+│   ├── ISSUE_TEMPLATE/
+│   │   └── general.md
+│   └── PULL_REQUEST_TEMPLATE.md
+├── src/
+│   ├── wallet-manager-stellar.js
+│   ├── wallet-account-stellar.js
+│   └── wallet-account-read-only-stellar.js
+├── tests/
+│   ├── wallet-manager-stellar.test.js
+│   ├── wallet-account-stellar.test.js
+│   └── wallet-account-read-only-stellar.test.js
+├── types/
+│   ├── index.d.ts
+│   └── src/
+│       ├── wallet-manager-stellar.d.ts
+│       ├── wallet-account-stellar.d.ts
+│       └── wallet-account-read-only-stellar.d.ts
+├── .editorconfig
+├── .gitignore
+├── .npmignore
+├── bare.js
+├── index.js
+├── LICENSE
+├── package.json
+├── README.md
+└── tsconfig.json
+```
+{% endcode %}
+
+Wallet modules generate three core files that correspond to the WDK wallet architecture:
+
+| File | Purpose |
+|------|---------|
+| `wallet-manager-*.js` | Module entry point, handles wallet registration and account derivation |
+| `wallet-account-*.js` | Full account with signing capabilities (transactions, messages) |
+| `wallet-account-read-only-*.js` | Read-only account for balance checks and transaction history |
+
+</details>
+
+<details>
+<summary>Protocol Module structure (swap, bridge, lending, fiat)</summary>
+
+{% code title="Protocol module project tree" %}
+```
+wdk-protocol-swap-jupiter-solana/
+├── .github/
+│   ├── workflows/
+│   │   ├── build.yml
+│   │   └── publish.yml
+│   ├── ISSUE_TEMPLATE/
+│   │   └── general.md
+│   └── PULL_REQUEST_TEMPLATE.md
+├── src/
+│   └── jupiter-protocol-solana.js
+├── tests/
+│   └── jupiter-protocol-solana.test.js
+├── types/
+│   ├── index.d.ts
+│   └── src/
+│       └── jupiter-protocol-solana.d.ts
+├── .editorconfig
+├── .gitignore
+├── .npmignore
+├── bare.js
+├── index.js
+├── LICENSE
+├── package.json
+├── README.md
+└── tsconfig.json
+```
+{% endcode %}
+
+Protocol modules generate a single provider file rather than the three-file wallet pattern, since protocols interact with external services through a unified interface.
+
+</details>
+
+---
+
+## Next Steps
+
+<table data-card-size="large" data-view="cards">
+	<thead>
+		<tr>
+			<th></th>
+			<th></th>
+			<th></th>
+			<th data-hidden data-card-target data-type="content-ref"></th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>
+				<i class="fa-code">:code:</i>
+			</td>
+			<td>
+				<strong>Wallet Modules</strong>
+			</td>
+			<td>See how official wallet modules are structured and documented</td>
+			<td>
+				<a href="../sdk/wallet-modules/">wallet-modules</a>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<i class="fa-puzzle-piece">:puzzle-piece:</i>
+			</td>
+			<td>
+				<strong>Community Modules</strong>
+			</td>
+			<td>Explore community-built modules and submit your own</td>
+			<td>
+				<a href="../sdk/community-modules/">community-modules</a>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+{% hint style="info" %}
+**Reference implementation**: The [`wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) module is a good reference for understanding how a production wallet module implements the WDK interfaces. The [`wdk-wallet`](https://github.com/tetherto/wdk-wallet) package defines the base classes your module must extend.
+{% endhint %}
+
+***
+
+## Need Help?
+
+{% include "../.gitbook/includes/support-cards.md" %}


### PR DESCRIPTION
## Summary

- Added new docs page (`tools/create-wdk-module.md`) for the [`create-wdk-module`](https://github.com/tetherto/create-wdk-module) CLI scaffolding tool, covering Quick Start (stepper), Module Types, CLI Options, Interactive Mode, and Generated Project Structure.
- Replaced the "Coming Soon: Custom Module Guide" placeholder in `sdk/community-modules/README.md` with a working quick-start and link to the new page.
- Updated `sdk/get-started.md` "Creating Custom Modules" section with a recommendation hint for `create-wdk-module` and replaced the commented-out "Extender Guide" link with a live link to the new page.
- Added `Create WDK Module` entry to `SUMMARY.md` under the Tools section.
- Added March 5, 2026 changelog entry in `overview/changelog.md`.

## ERC-4337 Supported Networks Audit

Ran end-to-end tests against every chain listed in the ERC-4337 configuration docs. Checked the Safe4337Module v0.3.0 deployment registry, bundler/paymaster availability, account creation, and actual UserOperation submission on Sepolia with both Pimlico and Candide.

**Findings:**
- Avalanche C-Chain (43114) fails because Safe4337Module v0.3.0 is not in `@safe-global/safe-modules-deployments` for that chain. Bundler and paymaster services exist, but the SDK throws before reaching them.
- All other documented chains (Ethereum, Polygon, Arbitrum, Plasma, Sepolia) pass all layers.
- Polygon RPC URL `polygon-rpc.com` was returning 401 errors.

**Changes:**
- `configuration.md`: Removed Avalanche config section, added a verified supported networks table with the three-layer requirement explained, added a danger hint about Avalanche, fixed Polygon RPC to `polygon-bor-rpc.publicnode.com`, cleaned up Plasma config comments.
- `README.md` (ERC-4337 overview): Replaced "any EVM-compatible blockchain" with the actual verified list of 5 networks.
- `skills/wdk/references/chains.md`: Updated the ERC-4337 support line with all verified chains and the Avalanche exclusion.

## Release Notes (March 6, 2026)

Changelog entries for 3 releases. No public API changes detected; all entries are changelog-only.

- **wdk-wallet-tron** v1.0.0-beta.5 ([PR #30](https://github.com/tetherto/wdk-wallet-tron/pull/30)): Fixed case-sensitive address check in `verify`, upgraded TonWeb to v6.2.0, security dependency updates. Audited `.d.ts` from beta.4; `verify(message, signature)` signature unchanged, `verifyMessageV2` change is internal only.
- **wdk-protocol-lending-aave-evm** v1.0.0-beta.4 ([PR #11](https://github.com/tetherto/wdk-protocol-lending-aave-evm/pull/11)): Added AGENTS.md, security dependency updates. No public API changes.
- **wdk** v1.0.0-beta.6 ([PR #39](https://github.com/tetherto/wdk/pull/39)): Added AGENTS.md, security dependency updates. No public API changes.

## Verification

- [x] GitBook render safety: all tags balanced (hint, stepper, step, code, details/summary)
- [x] Token naming: no branded symbols in code blocks
- [x] Link validation: all relative links resolve to existing pages
- [x] Content accuracy: CLI options, module types, and project structures match the GitHub repo README
- [x] Ripple effect: no stale "Coming Soon" or "Extender Guide" references remain
- [x] ERC-4337 chain audit: tested registry, bundler, paymaster, and account creation for all 6 documented chains
- [x] Sepolia E2E: real UserOp transfers verified with both Pimlico and Candide

## Test plan

- [ ] Verify the new `tools/create-wdk-module.md` page renders correctly in GitBook preview
- [ ] Confirm stepper, collapsible sections, tables, and cards display properly
- [ ] Check all relative links navigate to the correct pages
- [ ] Verify `sdk/community-modules/README.md` and `sdk/get-started.md` updates render correctly
- [ ] Verify ERC-4337 configuration page renders the supported networks table and Avalanche warning correctly

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213581575431186
  - https://app.asana.com/0/0/1213581575431193