### PR TITLE
fix: correct scoped package name in create-wdk-module docs

### DIFF
--- a/sdk/community-modules/README.md
+++ b/sdk/community-modules/README.md
@@ -40,7 +40,7 @@ Want to extend WDK with your own custom module? Use the `create-wdk-module` CLI 
 
 {% code title="Scaffold a new module" %}
 ```bash
-npx create-wdk-module@latest
+npx @tetherto/create-wdk-module@latest
 ```
 {% endcode %}
 

--- a/sdk/get-started.md
+++ b/sdk/get-started.md
@@ -200,7 +200,7 @@ const swapResult = await wdkWithProtocols.executeProtocol('swap-velora-evm', {
 **Recommended**: Use the `create-wdk-module` CLI to scaffold a new module with all the boilerplate in place:
 
 ```bash
-npx create-wdk-module@latest
+npx @tetherto/create-wdk-module@latest
 ```
 
 See the [Create WDK Module](../tools/create-wdk-module.md) page for the full guide, CLI options, and generated project structure.

--- a/tools/create-wdk-module.md
+++ b/tools/create-wdk-module.md
@@ -33,7 +33,7 @@ Powered by [`create-wdk-module`](https://github.com/tetherto/create-wdk-module).
 
 {% code title="Scaffold a new module" %}
 ```bash
-npx create-wdk-module@latest
+npx @tetherto/create-wdk-module@latest
 ```
 {% endcode %}
 
@@ -41,7 +41,7 @@ You can also pass arguments directly to skip the interactive prompts:
 
 {% code title="Scaffold with arguments" %}
 ```bash
-npx create-wdk-module@latest wallet stellar
+npx @tetherto/create-wdk-module@latest wallet stellar
 ```
 {% endcode %}
 {% endstep %}
@@ -94,13 +94,13 @@ The CLI supports all five WDK module categories. The generated package name foll
 {% code title="Common CLI usage patterns" %}
 ```bash
 # Create a wallet module with an npm scope
-npx create-wdk-module@latest wallet stellar --scope @myorg
+npx @tetherto/create-wdk-module@latest wallet stellar --scope @myorg
 
 # Create a swap protocol module
-npx create-wdk-module@latest swap jupiter solana
+npx @tetherto/create-wdk-module@latest swap jupiter solana
 
 # Create with all defaults, no prompts
-npx create-wdk-module@latest wallet stellar --yes
+npx @tetherto/create-wdk-module@latest wallet stellar --yes
 ```
 {% endcode %}
 
@@ -112,7 +112,7 @@ When run without arguments, the CLI guides you through module setup step by step
 
 {% code title="Interactive session" %}
 ```bash
-$ npx create-wdk-module@latest
+$ npx @tetherto/create-wdk-module@latest
 
   Create WDK Module
 


### PR DESCRIPTION
## Summary
- Replace `npx create-wdk-module@latest` with `npx @tetherto/create-wdk-module@latest` in all documentation pages
- The package is published under the `@tetherto` npm scope, so the unscoped name returns a 404

### Files changed
- `tools/create-wdk-module.md` (8 occurrences)
- `sdk/community-modules/README.md` (1 occurrence)
- `sdk/get-started.md` (1 occurrence)

## Test plan
- [ ] Verify all code blocks in the docs show the correct `npx @tetherto/create-wdk-module@latest` command