### PR TITLE
docs: wallet-btc v1.0.0-beta.6: add dispose() to WalletAccountReadOnlyBtc

### DIFF
--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### March 12, 2026
+
+**Changes**
+- **wallet-btc** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.6)): Added `dispose()` method to [`WalletAccountReadOnlyBtc`](../sdk/wallet-modules/wallet-btc/api-reference.md#walletaccountreadonlybtc) for closing internal Electrum connections. Security dependency updates.
+
+---
+
 ### March 6, 2026
 
 **Changes**

--- a/sdk/wallet-modules/wallet-btc/api-reference.md
+++ b/sdk/wallet-modules/wallet-btc/api-reference.md
@@ -468,7 +468,7 @@ console.log('Signature valid:', isValid)
 ```
 
 ##### `dispose()`
-Closes any internal Electrum connection owned by this account. If a `client` was provided via config, the connection is left open (the caller manages its lifecycle).
+Closes any internal Electrum connection owned by this account. If a [`client`](/sdk/wallet-modules/wallet-btc/configuration#client) was provided via config, the connection is left open (the caller manages its lifecycle).
 
 **Returns:** `void`
 

--- a/sdk/wallet-modules/wallet-btc/api-reference.md
+++ b/sdk/wallet-modules/wallet-btc/api-reference.md
@@ -60,7 +60,7 @@ new WalletManagerBtc(seed, config)
 | `getAccount(index)` | Returns a wallet account at the specified index | `Promise<WalletAccountBtc>` |
 | `getAccountByPath(path)` | Returns a wallet account at the specified derivation path | `Promise<WalletAccountBtc>` |
 | `getFeeRates()` | Returns current fee rates for transactions | `Promise<{normal: bigint, fast: bigint}>` |
-| `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` |
+| `dispose()` | Disposes all wallet accounts, clearing private keys from memory and closing internal Electrum connections | `void` |
 
 
 ##### `getAccount(index)`
@@ -109,7 +109,7 @@ console.log('Fast fee rate:', feeRates.fast, 'sat/vB')
 ```
 
 ##### `dispose()`
-Disposes all wallet accounts and clears sensitive data from memory.
+Disposes all wallet accounts, clears sensitive data from memory, and closes internal Electrum connections.
 
 **Returns:** `void`
 
@@ -376,6 +376,7 @@ new WalletAccountReadOnlyBtc(address, config)
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransactionReceipt \| null>` |
 | `getMaxSpendable()` | Returns the maximum spendable amount | `Promise<BtcMaxSpendableResult>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` |
+| `dispose()` | Closes any internal Electrum connection | `void` |
 
 
 ##### `getAddress()`
@@ -464,6 +465,16 @@ Verifies a message signature using the account's public key.
 ```javascript
 const isValid = await readOnlyAccount.verify('Hello Bitcoin!', signature)
 console.log('Signature valid:', isValid)
+```
+
+##### `dispose()`
+Closes any internal Electrum connection owned by this account. If a `client` was provided via config, the connection is left open (the caller manages its lifecycle).
+
+**Returns:** `void`
+
+**Example:**
+```javascript
+readOnlyAccount.dispose()
 ```
 
 


### PR DESCRIPTION
## Summary
- **wallet-btc** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.6)): Added `dispose()` method to [`WalletAccountReadOnlyBtc`](sdk/wallet-modules/wallet-btc/api-reference.md#walletaccountreadonlybtc) methods table and expanded explanation for closing internal Electrum connections.
- Updated `WalletManagerBtc.dispose()` description to mention closing Electrum connections (table row + expanded section).
- Added March 12, 2026 changelog entry.
## Triage (Phase 0)
| Change | Classification |
|--------|---------------|
| New public `dispose()` on `WalletAccountReadOnlyBtc` | **Document** — new public method in `.d.ts` |
| Updated `WalletManagerBtc.dispose()` behavior | **Document** (minor) — description update |
| Shared Electrum client refactor | Skip — internal, no public API 
| `_createClient` → `protected static` | Skip — protected member |
| CI: add bitcoind & electrs | Skip — CI only |
| `npm audit fix` | Changelog only — security dep bumps |
## Verification
- `dispose(): void` added to `types/src/wallet-account-read-only-btc.d.ts` ([PR #73 diff](https://github.com/tetherto/wdk-wallet-btc/pull/73))
- Ripple check on README.md, usage.md, configuration.md — no changes needed

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213698734681738