### PR TITLE
docs: add LangChain integration page to MCP Toolkit section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -22,6 +22,7 @@
   * [Get Started](ai/mcp-toolkit/get-started.md)
   * [Configuration](ai/mcp-toolkit/configuration.md)
   * [API Reference](ai/mcp-toolkit/api-reference.md)
+  * [LangChain Integration](ai/mcp-toolkit/langchain.md)
 * [Agent Skills](ai/agent-skills.md)
 * [OpenClaw](ai/openclaw.md)
 * [x402](ai/x402.md)

--- a/ai/mcp-toolkit/README.md
+++ b/ai/mcp-toolkit/README.md
@@ -107,6 +107,18 @@ You can register **any** blockchain name - the `CHAINS` constants are for conven
 				<a href="./api-reference.md">api-reference.md</a>
 			</td>
 		</tr>
+		<tr>
+			<td>
+				<i class="fa-link">:link:</i>
+			</td>
+			<td>
+				<strong>LangChain Integration</strong>
+			</td>
+			<td>Use WDK tools in LangChain agents via the serve CLI</td>
+			<td>
+				<a href="./langchain.md">langchain.md</a>
+			</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/ai/mcp-toolkit/get-started.md
+++ b/ai/mcp-toolkit/get-started.md
@@ -21,7 +21,7 @@ layout:
 # Get Started
 
 {% hint style="info" %}
-**Building a LangChain agent?** The `serve` command provides zero-config MCP server startup therefore no server script needed. See [LangChain Integration](langchain.md).
+**Building a LangChain agent?** The `serve` command provides zero-config MCP server startup -- no server script needed. See [LangChain Integration](langchain.md).
 {% endhint %}
 
 ## Setup Wizard
@@ -29,18 +29,15 @@ layout:
 The fastest way to get running. Clone the repository and let the wizard configure everything:
 
 {% code title="Terminal" %}
-
 ```bash
 git clone https://github.com/tetherto/wdk-mcp-toolkit.git
 cd wdk-mcp-toolkit
 npm install
 npm run setup
 ```
-
 {% endcode %}
 
 The wizard will:
-
 1. Prompt for your seed phrase (required)
 2. Ask for optional API keys (WDK Indexer, MoonPay)
 3. Generate `.vscode/mcp.json` with your credentials
@@ -52,7 +49,7 @@ Once complete, open the project in VS Code, start the MCP server from `.vscode/m
 **Security** - Your seed phrase is stored locally in `.vscode/mcp.json`, which is gitignored. Always use a **dedicated development wallet** with limited funds.
 {% endhint %}
 
----
+***
 
 ## Manual Setup
 
@@ -66,7 +63,6 @@ If you prefer to set things up yourself or want to integrate the toolkit into an
 Install the MCP Toolkit and the wallet modules you need:
 
 {% code title="Terminal" %}
-
 ```bash
 npm install @tetherto/wdk-mcp-toolkit @modelcontextprotocol/sdk
 
@@ -74,7 +70,6 @@ npm install @tetherto/wdk-mcp-toolkit @modelcontextprotocol/sdk
 npm install @tetherto/wdk-wallet-evm    # Ethereum, Polygon, Arbitrum, etc.
 npm install @tetherto/wdk-wallet-btc    # Bitcoin
 ```
-
 {% endcode %}
 
 {% endstep %}
@@ -86,40 +81,33 @@ npm install @tetherto/wdk-wallet-btc    # Bitcoin
 Create `index.js` with a basic multi-chain server:
 
 {% code title="index.js" lineNumbers="true" %}
-
 ```javascript
-import {
-  WdkMcpServer,
-  CHAINS,
-  WALLET_TOOLS,
-  PRICING_TOOLS,
-} from "@tetherto/wdk-mcp-toolkit";
-import WalletManagerEvm from "@tetherto/wdk-wallet-evm";
-import WalletManagerBtc from "@tetherto/wdk-wallet-btc";
+import { WdkMcpServer, CHAINS, WALLET_TOOLS, PRICING_TOOLS } from '@tetherto/wdk-mcp-toolkit'
+import WalletManagerEvm from '@tetherto/wdk-wallet-evm'
+import WalletManagerBtc from '@tetherto/wdk-wallet-btc'
 
-const server = new WdkMcpServer("my-wallet-server", "1.0.0");
+const server = new WdkMcpServer('my-wallet-server', '1.0.0')
 
 // 1. Enable WDK with your seed phrase
-server.useWdk({ seed: process.env.WDK_SEED });
+server.useWdk({ seed: process.env.WDK_SEED })
 
 // 2. Register wallet modules
-server.registerWallet("ethereum", WalletManagerEvm, {
-  provider: "https://eth.drpc.org",
-});
+server.registerWallet('ethereum', WalletManagerEvm, {
+  provider: 'https://eth.drpc.org'
+})
 
-server.registerWallet("bitcoin", WalletManagerBtc, {
-  network: "bitcoin",
-  host: "electrum.blockstream.info",
-  port: 50001,
-});
+server.registerWallet('bitcoin', WalletManagerBtc, {
+  network: 'bitcoin',
+  host: 'electrum.blockstream.info',
+  port: 50001
+})
 
 // 3. Enable pricing
-server.usePricing();
+server.usePricing()
 
 // 4. Register tools and start
-server.registerTools([...WALLET_TOOLS, ...PRICING_TOOLS]);
+server.registerTools([...WALLET_TOOLS, ...PRICING_TOOLS])
 ```
-
 {% endcode %}
 
 {% endstep %}
@@ -136,7 +124,6 @@ Add the MCP server to your AI tool's configuration:
 **Config path:** `.vscode/mcp.json` (project-level)
 
 {% code title=".vscode/mcp.json" %}
-
 ```json
 {
   "servers": {
@@ -151,11 +138,9 @@ Add the MCP server to your AI tool's configuration:
   }
 }
 ```
-
 {% endcode %}
 
 Then in VS Code:
-
 1. Open `.vscode/mcp.json` and click **Start** above the server config
 2. Open GitHub Copilot Chat and select **Agent mode**
 3. Click **Tools** to verify the MCP tools are available
@@ -292,38 +277,31 @@ Write operations (sending, swapping, bridging) will show a **confirmation dialog
 {% endstep %}
 {% endstepper %}
 
----
+***
 
 ## Optional Capabilities
 
 Add more capabilities by installing additional packages and enabling them on the server:
 
 {% code title="Additional capabilities" lineNumbers="true" %}
-
 ```javascript
-import {
-  INDEXER_TOOLS,
-  SWAP_TOOLS,
-  BRIDGE_TOOLS,
-  LENDING_TOOLS,
-  FIAT_TOOLS,
-} from "@tetherto/wdk-mcp-toolkit";
-import VeloraProtocolEvm from "@tetherto/wdk-protocol-swap-velora-evm";
-import Usdt0ProtocolEvm from "@tetherto/wdk-protocol-bridge-usdt0-evm";
-import AaveProtocolEvm from "@tetherto/wdk-protocol-lending-aave-evm";
-import MoonPayProtocol from "@tetherto/wdk-protocol-fiat-moonpay";
+import { INDEXER_TOOLS, SWAP_TOOLS, BRIDGE_TOOLS, LENDING_TOOLS, FIAT_TOOLS } from '@tetherto/wdk-mcp-toolkit'
+import VeloraProtocolEvm from '@tetherto/wdk-protocol-swap-velora-evm'
+import Usdt0ProtocolEvm from '@tetherto/wdk-protocol-bridge-usdt0-evm'
+import AaveProtocolEvm from '@tetherto/wdk-protocol-lending-aave-evm'
+import MoonPayProtocol from '@tetherto/wdk-protocol-fiat-moonpay'
 
 // Indexer - transaction history
-server.useIndexer({ apiKey: process.env.WDK_INDEXER_API_KEY });
+server.useIndexer({ apiKey: process.env.WDK_INDEXER_API_KEY })
 
 // DeFi protocols
-server.registerProtocol("ethereum", "velora", VeloraProtocolEvm);
-server.registerProtocol("ethereum", "usdt0", Usdt0ProtocolEvm);
-server.registerProtocol("ethereum", "aave", AaveProtocolEvm);
-server.registerProtocol("ethereum", "moonpay", MoonPayProtocol, {
+server.registerProtocol('ethereum', 'velora', VeloraProtocolEvm)
+server.registerProtocol('ethereum', 'usdt0', Usdt0ProtocolEvm)
+server.registerProtocol('ethereum', 'aave', AaveProtocolEvm)
+server.registerProtocol('ethereum', 'moonpay', MoonPayProtocol, {
   secretKey: process.env.MOONPAY_SECRET_KEY,
-  apiKey: process.env.MOONPAY_API_KEY,
-});
+  apiKey: process.env.MOONPAY_API_KEY
+})
 
 // Register the corresponding tools
 server.registerTools([
@@ -331,31 +309,30 @@ server.registerTools([
   ...SWAP_TOOLS,
   ...BRIDGE_TOOLS,
   ...LENDING_TOOLS,
-  ...FIAT_TOOLS,
-]);
+  ...FIAT_TOOLS
+])
 ```
-
 {% endcode %}
 
----
+***
 
 ## Environment Variables
 
-| Variable              | Required | Description                                                                |
-| --------------------- | -------- | -------------------------------------------------------------------------- |
-| `WDK_SEED`            | Yes      | BIP-39 seed phrase for wallet derivation                                   |
-| `WDK_INDEXER_API_KEY` | No       | Enables `INDEXER_TOOLS` - [get a key](https://wdk-api.tether.io/register)  |
-| `MOONPAY_API_KEY`     | No       | Enables `FIAT_TOOLS` - [MoonPay Dashboard](https://dashboard.moonpay.com/) |
-| `MOONPAY_SECRET_KEY`  | No       | Required with `MOONPAY_API_KEY`                                            |
+| Variable | Required | Description |
+| --- | --- | --- |
+| `WDK_SEED` | Yes | BIP-39 seed phrase for wallet derivation |
+| `WDK_INDEXER_API_KEY` | No | Enables `INDEXER_TOOLS` - [get a key](https://wdk-api.tether.io/register) |
+| `MOONPAY_API_KEY` | No | Enables `FIAT_TOOLS` - [MoonPay Dashboard](https://dashboard.moonpay.com/) |
+| `MOONPAY_SECRET_KEY` | No | Required with `MOONPAY_API_KEY` |
 
----
+***
 
 ## Next Steps
 
-- [**Configuration**](configuration.md) - Wallets, tokens, protocols, custom tools, and security
-- [**API Reference**](api-reference.md) - All 35 built-in MCP tools with parameters and schemas
+* [**Configuration**](configuration.md) - Wallets, tokens, protocols, custom tools, and security
+* [**API Reference**](api-reference.md) - All 35 built-in MCP tools with parameters and schemas
 
----
+***
 
 ## Need Help?
 

--- a/ai/mcp-toolkit/get-started.md
+++ b/ai/mcp-toolkit/get-started.md
@@ -21,7 +21,7 @@ layout:
 # Get Started
 
 {% hint style="info" %}
-**Building a LangChain agent?** The `serve` command provides zero-config MCP server startup -- no server script needed. See [LangChain Integration](langchain.md).
+**Building a LangChain agent?** The `serve` command provides zero-config MCP server startup therefore no server script needed. See [LangChain Integration](langchain.md).
 {% endhint %}
 
 ## Setup Wizard
@@ -29,15 +29,18 @@ layout:
 The fastest way to get running. Clone the repository and let the wizard configure everything:
 
 {% code title="Terminal" %}
+
 ```bash
 git clone https://github.com/tetherto/wdk-mcp-toolkit.git
 cd wdk-mcp-toolkit
 npm install
 npm run setup
 ```
+
 {% endcode %}
 
 The wizard will:
+
 1. Prompt for your seed phrase (required)
 2. Ask for optional API keys (WDK Indexer, MoonPay)
 3. Generate `.vscode/mcp.json` with your credentials
@@ -49,7 +52,7 @@ Once complete, open the project in VS Code, start the MCP server from `.vscode/m
 **Security** - Your seed phrase is stored locally in `.vscode/mcp.json`, which is gitignored. Always use a **dedicated development wallet** with limited funds.
 {% endhint %}
 
-***
+---
 
 ## Manual Setup
 
@@ -63,6 +66,7 @@ If you prefer to set things up yourself or want to integrate the toolkit into an
 Install the MCP Toolkit and the wallet modules you need:
 
 {% code title="Terminal" %}
+
 ```bash
 npm install @tetherto/wdk-mcp-toolkit @modelcontextprotocol/sdk
 
@@ -70,6 +74,7 @@ npm install @tetherto/wdk-mcp-toolkit @modelcontextprotocol/sdk
 npm install @tetherto/wdk-wallet-evm    # Ethereum, Polygon, Arbitrum, etc.
 npm install @tetherto/wdk-wallet-btc    # Bitcoin
 ```
+
 {% endcode %}
 
 {% endstep %}
@@ -81,33 +86,40 @@ npm install @tetherto/wdk-wallet-btc    # Bitcoin
 Create `index.js` with a basic multi-chain server:
 
 {% code title="index.js" lineNumbers="true" %}
-```javascript
-import { WdkMcpServer, CHAINS, WALLET_TOOLS, PRICING_TOOLS } from '@tetherto/wdk-mcp-toolkit'
-import WalletManagerEvm from '@tetherto/wdk-wallet-evm'
-import WalletManagerBtc from '@tetherto/wdk-wallet-btc'
 
-const server = new WdkMcpServer('my-wallet-server', '1.0.0')
+```javascript
+import {
+  WdkMcpServer,
+  CHAINS,
+  WALLET_TOOLS,
+  PRICING_TOOLS,
+} from "@tetherto/wdk-mcp-toolkit";
+import WalletManagerEvm from "@tetherto/wdk-wallet-evm";
+import WalletManagerBtc from "@tetherto/wdk-wallet-btc";
+
+const server = new WdkMcpServer("my-wallet-server", "1.0.0");
 
 // 1. Enable WDK with your seed phrase
-server.useWdk({ seed: process.env.WDK_SEED })
+server.useWdk({ seed: process.env.WDK_SEED });
 
 // 2. Register wallet modules
-server.registerWallet('ethereum', WalletManagerEvm, {
-  provider: 'https://eth.drpc.org'
-})
+server.registerWallet("ethereum", WalletManagerEvm, {
+  provider: "https://eth.drpc.org",
+});
 
-server.registerWallet('bitcoin', WalletManagerBtc, {
-  network: 'bitcoin',
-  host: 'electrum.blockstream.info',
-  port: 50001
-})
+server.registerWallet("bitcoin", WalletManagerBtc, {
+  network: "bitcoin",
+  host: "electrum.blockstream.info",
+  port: 50001,
+});
 
 // 3. Enable pricing
-server.usePricing()
+server.usePricing();
 
 // 4. Register tools and start
-server.registerTools([...WALLET_TOOLS, ...PRICING_TOOLS])
+server.registerTools([...WALLET_TOOLS, ...PRICING_TOOLS]);
 ```
+
 {% endcode %}
 
 {% endstep %}
@@ -124,6 +136,7 @@ Add the MCP server to your AI tool's configuration:
 **Config path:** `.vscode/mcp.json` (project-level)
 
 {% code title=".vscode/mcp.json" %}
+
 ```json
 {
   "servers": {
@@ -138,9 +151,11 @@ Add the MCP server to your AI tool's configuration:
   }
 }
 ```
+
 {% endcode %}
 
 Then in VS Code:
+
 1. Open `.vscode/mcp.json` and click **Start** above the server config
 2. Open GitHub Copilot Chat and select **Agent mode**
 3. Click **Tools** to verify the MCP tools are available
@@ -277,31 +292,38 @@ Write operations (sending, swapping, bridging) will show a **confirmation dialog
 {% endstep %}
 {% endstepper %}
 
-***
+---
 
 ## Optional Capabilities
 
 Add more capabilities by installing additional packages and enabling them on the server:
 
 {% code title="Additional capabilities" lineNumbers="true" %}
+
 ```javascript
-import { INDEXER_TOOLS, SWAP_TOOLS, BRIDGE_TOOLS, LENDING_TOOLS, FIAT_TOOLS } from '@tetherto/wdk-mcp-toolkit'
-import VeloraProtocolEvm from '@tetherto/wdk-protocol-swap-velora-evm'
-import Usdt0ProtocolEvm from '@tetherto/wdk-protocol-bridge-usdt0-evm'
-import AaveProtocolEvm from '@tetherto/wdk-protocol-lending-aave-evm'
-import MoonPayProtocol from '@tetherto/wdk-protocol-fiat-moonpay'
+import {
+  INDEXER_TOOLS,
+  SWAP_TOOLS,
+  BRIDGE_TOOLS,
+  LENDING_TOOLS,
+  FIAT_TOOLS,
+} from "@tetherto/wdk-mcp-toolkit";
+import VeloraProtocolEvm from "@tetherto/wdk-protocol-swap-velora-evm";
+import Usdt0ProtocolEvm from "@tetherto/wdk-protocol-bridge-usdt0-evm";
+import AaveProtocolEvm from "@tetherto/wdk-protocol-lending-aave-evm";
+import MoonPayProtocol from "@tetherto/wdk-protocol-fiat-moonpay";
 
 // Indexer - transaction history
-server.useIndexer({ apiKey: process.env.WDK_INDEXER_API_KEY })
+server.useIndexer({ apiKey: process.env.WDK_INDEXER_API_KEY });
 
 // DeFi protocols
-server.registerProtocol('ethereum', 'velora', VeloraProtocolEvm)
-server.registerProtocol('ethereum', 'usdt0', Usdt0ProtocolEvm)
-server.registerProtocol('ethereum', 'aave', AaveProtocolEvm)
-server.registerProtocol('ethereum', 'moonpay', MoonPayProtocol, {
+server.registerProtocol("ethereum", "velora", VeloraProtocolEvm);
+server.registerProtocol("ethereum", "usdt0", Usdt0ProtocolEvm);
+server.registerProtocol("ethereum", "aave", AaveProtocolEvm);
+server.registerProtocol("ethereum", "moonpay", MoonPayProtocol, {
   secretKey: process.env.MOONPAY_SECRET_KEY,
-  apiKey: process.env.MOONPAY_API_KEY
-})
+  apiKey: process.env.MOONPAY_API_KEY,
+});
 
 // Register the corresponding tools
 server.registerTools([
@@ -309,30 +331,31 @@ server.registerTools([
   ...SWAP_TOOLS,
   ...BRIDGE_TOOLS,
   ...LENDING_TOOLS,
-  ...FIAT_TOOLS
-])
+  ...FIAT_TOOLS,
+]);
 ```
+
 {% endcode %}
 
-***
+---
 
 ## Environment Variables
 
-| Variable | Required | Description |
-| --- | --- | --- |
-| `WDK_SEED` | Yes | BIP-39 seed phrase for wallet derivation |
-| `WDK_INDEXER_API_KEY` | No | Enables `INDEXER_TOOLS` - [get a key](https://wdk-api.tether.io/register) |
-| `MOONPAY_API_KEY` | No | Enables `FIAT_TOOLS` - [MoonPay Dashboard](https://dashboard.moonpay.com/) |
-| `MOONPAY_SECRET_KEY` | No | Required with `MOONPAY_API_KEY` |
+| Variable              | Required | Description                                                                |
+| --------------------- | -------- | -------------------------------------------------------------------------- |
+| `WDK_SEED`            | Yes      | BIP-39 seed phrase for wallet derivation                                   |
+| `WDK_INDEXER_API_KEY` | No       | Enables `INDEXER_TOOLS` - [get a key](https://wdk-api.tether.io/register)  |
+| `MOONPAY_API_KEY`     | No       | Enables `FIAT_TOOLS` - [MoonPay Dashboard](https://dashboard.moonpay.com/) |
+| `MOONPAY_SECRET_KEY`  | No       | Required with `MOONPAY_API_KEY`                                            |
 
-***
+---
 
 ## Next Steps
 
-* [**Configuration**](configuration.md) - Wallets, tokens, protocols, custom tools, and security
-* [**API Reference**](api-reference.md) - All 35 built-in MCP tools with parameters and schemas
+- [**Configuration**](configuration.md) - Wallets, tokens, protocols, custom tools, and security
+- [**API Reference**](api-reference.md) - All 35 built-in MCP tools with parameters and schemas
 
-***
+---
 
 ## Need Help?
 

--- a/ai/mcp-toolkit/get-started.md
+++ b/ai/mcp-toolkit/get-started.md
@@ -20,6 +20,10 @@ layout:
 
 # Get Started
 
+{% hint style="info" %}
+**Building a LangChain agent?** The `serve` command provides zero-config MCP server startup -- no server script needed. See [LangChain Integration](langchain.md).
+{% endhint %}
+
 ## Setup Wizard
 
 The fastest way to get running. Clone the repository and let the wizard configure everything:

--- a/ai/mcp-toolkit/langchain.md
+++ b/ai/mcp-toolkit/langchain.md
@@ -66,15 +66,15 @@ The command has built-in definitions for 13 chains and 4 protocol modules. When 
 
 | Module | Registers | Default |
 | --- | --- | --- |
-| `@tetherto/wdk-wallet-evm` | Ethereum, Arbitrum, Polygon, Optimism, Base, Avalanche, BNB, Plasma, Spark | Ethereum + Arbitrum enabled |
-| `@tetherto/wdk-wallet-btc` | Bitcoin | Enabled |
-| `@tetherto/wdk-wallet-sol` | Solana | Not enabled by default |
-| `@tetherto/wdk-wallet-ton` | TON | Not enabled by default |
-| `@tetherto/wdk-wallet-tron` | Tron | Not enabled by default |
-| `@tetherto/wdk-protocol-swap-velora-evm` | Swap tools (Ethereum, Arbitrum) | -- |
-| `@tetherto/wdk-protocol-bridge-usdt0-evm` | Bridge tools (Ethereum, Arbitrum) | -- |
-| `@tetherto/wdk-protocol-lending-aave-evm` | Lending tools (Ethereum) | -- |
-| `@tetherto/wdk-protocol-fiat-moonpay` | Fiat tools (Ethereum) | Requires `MOONPAY_*` env vars |
+| [`@tetherto/wdk-wallet-evm`](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm) | Ethereum, Arbitrum, Polygon, Optimism, Base, Avalanche, BNB, Plasma, Spark | Ethereum + Arbitrum enabled |
+| [`@tetherto/wdk-wallet-btc`](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc) | Bitcoin | Enabled |
+| [`@tetherto/wdk-wallet-solana`](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana) | Solana | Not enabled by default |
+| [`@tetherto/wdk-wallet-ton`](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton) | TON | Not enabled by default |
+| [`@tetherto/wdk-wallet-tron`](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron) | Tron | Not enabled by default |
+| [`@tetherto/wdk-protocol-swap-velora-evm`](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm) | Swap tools (Ethereum, Arbitrum) | -- |
+| [`@tetherto/wdk-protocol-bridge-usdt0-evm`](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm) | Bridge tools (Ethereum, Arbitrum) | -- |
+| [`@tetherto/wdk-protocol-lending-aave-evm`](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm) | Lending tools (Ethereum) | -- |
+| [`@tetherto/wdk-protocol-fiat-moonpay`](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay) | Fiat tools (Ethereum) | Requires `MOONPAY_*` env vars |
 
 {% hint style="info" %}
 Missing packages are silently skipped. Install only the modules you need and `serve` will pick them up. For chains or protocols **not** in the built-in registry, use a [custom config file](#custom-config-file).

--- a/ai/mcp-toolkit/langchain.md
+++ b/ai/mcp-toolkit/langchain.md
@@ -1,0 +1,290 @@
+---
+title: LangChain Integration
+description: Use WDK MCP tools in LangChain agents with zero-config server startup
+icon: link
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: false
+---
+
+# LangChain Integration
+
+You can use the WDK MCP Toolkit as a tool provider for [LangChain](https://www.langchain.com/) agents in both Python and TypeScript. LangChain's `MultiServerMCPClient` spawns the MCP server as a subprocess and converts WDK tools into LangChain-compatible tools, giving your agent access to wallet operations, pricing, swaps, bridges, lending, and more.
+
+This integration uses the `serve` CLI command, which starts a fully configured MCP server on stdio with no server script required.
+
+{% hint style="info" %}
+This approach uses LangChain's MCP adapters to connect to the WDK MCP server. WDK does not ship a native LangChain integration, it leverages the standard MCP protocol that LangChain already supports.
+{% endhint %}
+
+{% hint style="info" %}
+**Want more control?** The `serve` command is the fastest way to get running, but you can also [write your own MCP server](get-started.md#manual-setup) with the programmatic API for full control over wallets, tools, and protocols. Then point LangChain's `MultiServerMCPClient` at it using `node your-server.js` instead of the `serve` command.
+{% endhint %}
+
+***
+
+## The `serve` Command
+
+The `serve` command provides zero-config MCP server startup so you don't need to write a server script:
+
+{% code title="Terminal" %}
+```bash
+npx @tetherto/wdk-mcp-toolkit serve
+```
+{% endcode %}
+
+Pass `WDK_SEED` to enable wallet operations, or omit it to run with pricing tools only:
+
+{% code title="Terminal" %}
+```bash
+# With wallet operations
+WDK_SEED="your twelve word seed phrase here" npx @tetherto/wdk-mcp-toolkit serve
+
+# Pricing-only mode (no seed required)
+npx @tetherto/wdk-mcp-toolkit serve
+```
+{% endcode %}
+
+### Default Chains
+
+By default, `serve` enables **three chains**: Ethereum, Arbitrum, and Bitcoin. For each enabled chain it dynamically imports the required wallet package and skips any that aren't installed. You can change the enabled set with the `WDK_CHAINS` environment variable.
+
+### Built-in Registry
+
+The command has built-in definitions for 13 chains and 4 protocol modules. When a chain is enabled and its package is installed, the wallet is registered automatically. Protocol modules are also auto-registered when their packages are installed and at least one of their target chains is enabled.
+
+| Module | Registers | Default |
+| --- | --- | --- |
+| `@tetherto/wdk-wallet-evm` | Ethereum, Arbitrum, Polygon, Optimism, Base, Avalanche, BNB, Plasma, Spark | Ethereum + Arbitrum enabled |
+| `@tetherto/wdk-wallet-btc` | Bitcoin | Enabled |
+| `@tetherto/wdk-wallet-sol` | Solana | Not enabled by default |
+| `@tetherto/wdk-wallet-ton` | TON | Not enabled by default |
+| `@tetherto/wdk-wallet-tron` | Tron | Not enabled by default |
+| `@tetherto/wdk-protocol-swap-velora-evm` | Swap tools (Ethereum, Arbitrum) | -- |
+| `@tetherto/wdk-protocol-bridge-usdt0-evm` | Bridge tools (Ethereum, Arbitrum) | -- |
+| `@tetherto/wdk-protocol-lending-aave-evm` | Lending tools (Ethereum) | -- |
+| `@tetherto/wdk-protocol-fiat-moonpay` | Fiat tools (Ethereum) | Requires `MOONPAY_*` env vars |
+
+{% hint style="info" %}
+Missing packages are silently skipped. Install only the modules you need and `serve` will pick them up. For chains or protocols **not** in the built-in registry, use a [custom config file](#custom-config-file).
+{% endhint %}
+
+***
+
+## Quick Start
+
+{% tabs %}
+{% tab title="Python" %}
+
+#### Install dependencies
+
+{% code title="Terminal" %}
+```bash
+pip install langchain-mcp-adapters langgraph langchain-openai
+```
+{% endcode %}
+
+#### Create your agent
+
+{% code title="agent.py" lineNumbers="true" %}
+```python
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+from langchain_openai import ChatOpenAI
+
+async def main():
+    client = MultiServerMCPClient({
+        "wdk": {
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", "@tetherto/wdk-mcp-toolkit", "serve"],
+            "env": {
+                "WDK_SEED": "your twelve word seed phrase here",
+                "WDK_MCP_ELICITATION": "false",
+            },
+        }
+    })
+
+    tools = await client.get_tools()
+    agent = create_react_agent(ChatOpenAI(model="gpt-4o"), tools)
+
+    result = await agent.ainvoke({
+        "messages": [{"role": "user", "content": "What is my Ethereum address?"}]
+    })
+    print(result["messages"][-1].content)
+
+    await client.close()
+
+asyncio.run(main())
+```
+{% endcode %}
+
+#### Run it
+
+{% code title="Terminal" %}
+```bash
+export OPENAI_API_KEY="sk-..."
+python agent.py
+```
+{% endcode %}
+
+{% endtab %}
+{% tab title="TypeScript" %}
+
+#### Install dependencies
+
+{% code title="Terminal" %}
+```bash
+npm install @langchain/mcp-adapters @langchain/langgraph @langchain/core @langchain/openai
+```
+{% endcode %}
+
+#### Create your agent
+
+{% code title="agent.ts" lineNumbers="true" %}
+```typescript
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { ChatOpenAI } from "@langchain/openai";
+
+const client = new MultiServerMCPClient({
+  wdk: {
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "@tetherto/wdk-mcp-toolkit", "serve"],
+    env: {
+      WDK_SEED: "your twelve word seed phrase here",
+      WDK_MCP_ELICITATION: "false",
+    },
+  },
+});
+
+const tools = await client.getTools();
+const agent = createReactAgent({
+  llm: new ChatOpenAI({ model: "gpt-4o" }),
+  tools,
+});
+
+const result = await agent.invoke({
+  messages: [
+    { role: "user", content: "What is the current price of Bitcoin?" },
+  ],
+});
+
+console.log(result.messages[result.messages.length - 1].content);
+await client.close();
+```
+{% endcode %}
+
+#### Run it
+
+{% code title="Terminal" %}
+```bash
+export OPENAI_API_KEY="sk-..."
+npx tsx agent.ts
+```
+{% endcode %}
+
+{% endtab %}
+{% endtabs %}
+
+{% hint style="warning" %}
+**Security** -- Always use a dedicated development wallet with limited funds. Set `WDK_MCP_ELICITATION` to `"false"` for programmatic agents since elicitation dialogs require a human in the loop.
+{% endhint %}
+
+***
+
+## Configuration
+
+### Environment Variables
+
+Control `serve` behavior through environment variables:
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `WDK_SEED` | No | -- | BIP-39 seed phrase. If omitted, only pricing tools are available |
+| `WDK_CHAINS` | No | `ethereum,arbitrum,bitcoin` | Comma-separated list of chains to enable |
+| `WDK_MCP_ELICITATION` | No | `true` | Set to `"false"` for programmatic agents that cannot handle confirmation dialogs |
+| `WDK_RPC_<CHAIN>` | No | Built-in defaults | Override the RPC endpoint for a chain (e.g. `WDK_RPC_ETHEREUM=https://my-rpc.com`) |
+| `WDK_CONFIG` | No | -- | Path to a `wdk.config.json` file for custom chains and protocols |
+| `WDK_INDEXER_API_KEY` | No | -- | Enables indexer tools for balance and transfer history queries |
+| `MOONPAY_API_KEY` | No | -- | Enables fiat on/off-ramp tools |
+| `MOONPAY_SECRET_KEY` | No | -- | Required with `MOONPAY_API_KEY` |
+
+### Custom Config File
+
+For chains or protocols not in the built-in defaults, create a `wdk.config.json` and pass its path via `WDK_CONFIG`:
+
+{% code title="Terminal" %}
+```bash
+WDK_CONFIG=./wdk.config.json WDK_SEED="..." npx @tetherto/wdk-mcp-toolkit serve
+```
+{% endcode %}
+
+{% code title="wdk.config.json" %}
+```json
+{
+  "chains": {
+    "zksync": {
+      "module": "@myorg/wdk-wallet-zksync",
+      "config": { "provider": "https://mainnet.era.zksync.io" }
+    },
+    "ethereum": {
+      "config": { "provider": "https://my-private-rpc.com" }
+    }
+  },
+  "protocols": [
+    {
+      "module": "@myorg/wdk-protocol-swap-custom",
+      "label": "custom-swap",
+      "type": "swap",
+      "chains": ["zksync"]
+    }
+  ],
+  "enabledChains": ["ethereum", "zksync", "bitcoin"]
+}
+```
+{% endcode %}
+
+| Field | Description |
+| --- | --- |
+| `chains` | Add new chains or override config for built-in ones. New chains require a `module` field; overrides for existing chains can omit it |
+| `protocols` | Add custom protocols. Each entry requires `module`, `label`, and `chains`. The `type` field (`swap`, `bridge`, `lending`, `fiat`) maps to the corresponding built-in tool set |
+| `enabledChains` | Overrides `WDK_CHAINS` env var. If omitted, `WDK_CHAINS` is used |
+
+***
+
+## LLM Provider Support
+
+Both the Python and TypeScript examples support OpenAI and Anthropic. Set the corresponding environment variable and install the matching package:
+
+| Provider | Environment Variable | Python Package | TypeScript Package |
+| --- | --- | --- | --- |
+| OpenAI | `OPENAI_API_KEY` | `langchain-openai` | `@langchain/openai` |
+| Anthropic | `ANTHROPIC_API_KEY` | `langchain-anthropic` | `@langchain/anthropic` |
+
+{% hint style="info" %}
+The examples auto-detect which provider to use based on which API key is set. If both are set, OpenAI takes priority.
+{% endhint %}
+
+{% hint style="success" %}
+**Full examples** -- See the complete interactive agent examples with conversation loops on GitHub: [`examples/langchain/python/`](https://github.com/tetherto/wdk-mcp-toolkit/tree/main/examples/langchain/python) and [`examples/langchain/typescript/`](https://github.com/tetherto/wdk-mcp-toolkit/tree/main/examples/langchain/typescript).
+{% endhint %}
+
+***
+
+## Need Help?
+
+{% include "../../.gitbook/includes/support-cards.md" %}


### PR DESCRIPTION
# Description

Add a dedicated documentation page for the LangChain + MCP integration introduced in [tetherto/wdk-mcp-toolkit#10](https://github.com/tetherto/wdk-mcp-toolkit/pull/10).

### What's included

**New page: `ai/mcp-toolkit/langchain.md`**
- Documents the `serve` CLI command and its built-in chain/protocol registry
- Quick start snippets for Python and TypeScript using `MultiServerMCPClient`
- Configuration reference: environment variables, `WDK_CHAINS`, custom `wdk.config.json`
- LLM provider support table (OpenAI / Anthropic)

**Navigation updates**
- Added entry in `SUMMARY.md`
- Added navigation card in MCP Toolkit landing page
- Added cross-link hint in Get Started page

## Type of change

- [x] Documentation update