### PR TITLE
docs: update faucets section with legal disclaimer and additional faucets

### DIFF
--- a/resources/concepts.md
+++ b/resources/concepts.md
@@ -157,7 +157,9 @@ Local networks for development and testing:
 
 To test transactions without spending real assets, developers use "Testnets"—networks that mimic the main blockchain but use tokens with no monetary value. You can obtain these tokens for free from different publicly available "Faucets". Links to common "Faucets" are below.
 
-> **Important** The below faucets are for testnets. The USD₮ tokens and other tokens available at the links below are not real and do not entitle the holder to anything. In particular, they cannot be redeemed with Tether International, S.A. de C.V. ("Tether International") and are not Tether Tokens as described in [Tether International's Terms of Service](https://tether.to/en/legal). The USD₮ tokens available at the links below on various testnets are intended for testing WDK on the applicable testnet. The links below are links to third-party websites and are Third-Party Information as described in Tether Operations, S.A. de [C.V.'s Website Terms](https://tether.io/terms/).
+{% hint style="warning" %}
+The below faucets are for testnets. The USD₮ tokens and other tokens available at the links below are not real and do not entitle the holder to anything. In particular, they cannot be redeemed with Tether International, S.A. de C.V. ("Tether International") and are not Tether Tokens as described in [Tether International's Terms of Service](https://tether.to/en/legal). The USD₮ tokens available at the links below on various testnets are intended for testing WDK on the applicable testnet. The links below are links to third-party websites and are Third-Party Information as described in Tether Operations, S.A. de [C.V.'s Website Terms](https://tether.io/terms/).
+{% endhint %}
 
 #### Common Faucets
 *   **USD₮ Test Tokens (Sepolia)**: [Pimlico Faucet](https://dashboard.pimlico.io/test-erc20-faucet)

--- a/resources/concepts.md
+++ b/resources/concepts.md
@@ -155,9 +155,13 @@ Local networks for development and testing:
 
 ### Testnet Funds & Faucets
 
-To test transactions without spending real assets, developers use "Testnets"—networks that mimic the main blockchain but use tokens with no monetary value. You can obtain these tokens for free from "Faucets".
+To test transactions without spending real assets, developers use "Testnets"—networks that mimic the main blockchain but use tokens with no monetary value. You can obtain these tokens for free from different publicly available "Faucets". Links to common "Faucets" are below.
+
+> **Important** The below faucets are for testnets. The USD₮ tokens and other tokens available at the links below are not real and do not entitle the holder to anything. In particular, they cannot be redeemed with Tether International, S.A. de C.V. ("Tether International") and are not Tether Tokens as described in [Tether International's Terms of Service](https://tether.to/en/legal). The USD₮ tokens available at the links below on various testnets are intended for testing WDK on the applicable testnet. The links below are links to third-party websites and are Third-Party Information as described in Tether Operations, S.A. de [C.V.'s Website Terms](https://tether.io/terms/).
 
 #### Common Faucets
+*   **USD₮ Test Tokens (Sepolia)**: [Pimlico Faucet](https://dashboard.pimlico.io/test-erc20-faucet)
+*   **USD₮ Test Tokens (Sepolia)**: [Candide Faucet](https://dashboard.candide.dev/faucet)
 *   **Ethereum (Sepolia)**: [Google Cloud Web3 Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia)
 *   **Aave Test Tokens (Sepolia)**: [Aave Faucet](https://app.aave.com/faucet/) — get test USD₮, DAI and other tokens for DeFi testing
 *   **TON Testnet**: [Testgiver Bot](https://t.me/testgiver_ton_bot)


### PR DESCRIPTION
## Summary
- Added legal disclaimer to the Testnet Funds & Faucets section in concepts page, clarifying that testnet tokens are not real and cannot be redeemed
- Added links to Tether International's Terms of Service and Tether Operations Website Terms
- Added Pimlico and Candide USD₮ test token faucets to the common faucets list

## Test plan
- [ ] Verify the faucets section renders correctly with the blockquote disclaimer
- [ ] Verify all faucet links are working
- [ ] Verify Terms of Service and Website Terms links are correct