### PR TITLE
Document April 2026 WDK release updates

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -204,6 +204,18 @@
 * [Create WDK Module](tools/create-wdk-module.md)
 * [React Native Core](tools/react-native-core/README.md)
   * [API Reference](tools/react-native-core/api-reference.md)
+* [Failover Provider](tools/failover-provider/README.md)
+  * [Configuration](tools/failover-provider/configuration.md)
+  * [API Reference](tools/failover-provider/api-reference.md)
+* [Pear Worklet WDK](tools/pear-wrk-wdk/README.md)
+  * [Configuration](tools/pear-wrk-wdk/configuration.md)
+  * [API Reference](tools/pear-wrk-wdk/api-reference.md)
+* [WDK Utils](tools/wdk-utils/README.md)
+  * [Configuration](tools/wdk-utils/configuration.md)
+  * [API Reference](tools/wdk-utils/api-reference.md)
+* [Worklet Bundler](tools/worklet-bundler/README.md)
+  * [Configuration](tools/worklet-bundler/configuration.md)
+  * [API Reference](tools/worklet-bundler/api-reference.md)
 
 ## Resources and Guides
 

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,37 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### April 14, 2026
+
+**What's New**
+- **failover-provider** ([v1.0.0-beta.1](https://github.com/tetherto/wdk-failover-provider/releases/tag/v1.0.0-beta.1)): Initial release of a generic `FailoverProvider<T>` that chains provider candidates and retries sync or async failures with configurable `retries` and `shouldRetryOn(error)` logic.
+
+**Changes**
+- **fiat-moonpay** ([v1.0.0-beta.2](https://github.com/tetherto/wdk-protocol-fiat-moonpay/releases/tag/v1.0.0-beta.2)): [Breaking] Replace `secretKey` signing with optional backend `signUrl`, add `environment` selection for production or sandbox widget URLs, and return unsigned widget URLs when no signer is configured.
+
+---
+
+### April 13, 2026
+
+**What's New**
+- **wdk-utils** ([v1.0.0-beta.2](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.2)): Add EIP-681 request parsing utilities for transfer deeplinks, including request detection and structured parse results.
+- **wdk-core** ([v1.0.0-beta.7](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.7)): Added `dispose(blockchains?)`, so you can dispose one or more registered wallets without tearing down every wallet in the WDK instance.
+- **pear-wrk-wdk** ([v1.0.0-beta.8](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.8)): Adds `resetWdkWallets({ config })` so custom Bare hosts can selectively dispose and re-register wallet modules from a new `networks` config.
+
+**Changes**
+- **wallet-spark** ([v1.0.0-beta.13](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.13)): Refresh `@buildonspark/bare` and `@buildonspark/spark-sdk` dependencies.
+- **wallet-spark** ([v1.0.0-beta.14](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.14)): Add SparkScan-backed balance polling for `getBalance()`.
+- **wallet-spark** ([v1.0.0-beta.15](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.15)): Refresh `@buildonspark/bare`, `@buildonspark/spark-sdk`, and `bare-node-runtime` dependencies.
+- **wallet-spark** ([v1.0.0-beta.16](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.16)): Add `syncAndRetry` and `syncWalletBalance()` for retrying failed `sendTransaction()` and `payLightningInvoice()` calls once after syncing wallet state.
+
+**Fixes**
+- **worklet-bundler** ([v1.0.0-beta.3](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.3)): Generated worklet entrypoints now suspend and resume both HTTP and HTTPS global agents with Bare thread lifecycle events.
+- **wallet-btc** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.8)): `getBalance()` now includes unconfirmed funds when present, and `sendTransaction()` accepts an optional `timeoutMs` to keep polling after broadcast until spent inputs disappear from unspent outputs.
+- **wallet-evm** ([v1.0.0-beta.11](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.11)): Pin string-backed RPC providers to a static network during EVM account setup.
+- **wallet-evm-erc-4337** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.6)): Reuse the internal EVM read-only helper during ERC-4337 method calls instead of recreating it on each call.
+
+---
+
 ### April 3, 2026
 
 **Changes**

--- a/sdk/core-module/api-reference.md
+++ b/sdk/core-module/api-reference.md
@@ -67,7 +67,7 @@ const wdk2 = new WDK(seedBytes)
 | `getAccount(blockchain, index?)` | Returns a wallet account for a blockchain and index | `Promise<IWalletAccountWithProtocols>` | If wallet not registered |
 | `getAccountByPath(blockchain, path)` | Returns a wallet account for a blockchain and derivation path | `Promise<IWalletAccountWithProtocols>` | If wallet not registered |
 | `getFeeRates()` | Returns current fee rates | `Promise<FeeRates>` | - |
-| `dispose()` | Disposes all wallets and accounts, clearing sensitive data | `void` | - |
+| `dispose(blockchains?)` | Disposes all registered wallets, or only the named blockchains, and clears their sensitive data | `void` | - |
 
 ##### `registerWallet(blockchain, wallet, config)`
 Registers a new wallet manager for a specific blockchain.
@@ -247,14 +247,20 @@ console.log('Fee rates:', feeRates)
 ```
 {% endcode %}
 
-##### `dispose()`
-Disposes all wallets and accounts, erasing any sensitive data from memory.
+##### `dispose(blockchains?)`
+Disposes all registered wallets when called without arguments, or only the wallets for the named blockchains when you pass a string array.
+
+**Parameters:**
+- `blockchains` (string[], optional): The blockchain identifiers to dispose. Omit this parameter to dispose every registered wallet.
 
 **Example:**
 {% code title="Dispose WDK" lineNumbers="true" %}
 ```javascript
 // Clean up all sensitive data
 wdk.dispose()
+
+// Dispose only one registered wallet
+wdk.dispose(['ethereum'])
 ```
 {% endcode %}
 

--- a/sdk/core-module/guides/error-handling.md
+++ b/sdk/core-module/guides/error-handling.md
@@ -46,11 +46,11 @@ Always use `try/catch` blocks when initializing sessions or accessing dynamic fe
 
 ## Memory Management
 
-For security, you should clear sensitive data from memory when a session is complete. The WDK provides a `.dispose()` method for this purpose.
+For security, clear sensitive data from memory when a session is complete. The WDK provides [`dispose()`](../api-reference.md#disposeblockchains) for this purpose.
 
 ### Disposing the Instance
 
-Calling `dispose()` clears the seed phrase and private keys derived in memory.
+You can clear every registered wallet using [`dispose()`](../api-reference.md#disposeblockchains):
 
 {% code title="Dispose WDK" lineNumbers="true" %}
 ```typescript
@@ -66,8 +66,19 @@ function endSession(wdk) {
 ```
 {% endcode %}
 
+### Disposing Specific Wallets
+
+You can dispose only the wallets you no longer need using [`dispose()`](../api-reference.md#disposeblockchains):
+
+{% code title="Dispose Specific Wallets" lineNumbers="true" %}
+```typescript
+// Keep the TON wallet registered, but dispose the Ethereum wallet
+wdk.dispose(['ethereum'])
+```
+{% endcode %}
+
 {% hint style="warning" %}
-**After Disposal:** Once disposed, any attempt to use the `wdk` instance or its derived accounts will result in an error. You must instantiate a new instance to resume operations.
+**After Disposal:** Once a wallet is disposed, any later call that depends on that wallet registration will fail until you register it again. If you call `wdk.dispose()` without arguments, you must instantiate a new WDK instance or register fresh wallets before resuming operations.
 {% endhint %}
 
 ## Security Best Practices

--- a/sdk/fiat-modules/fiat-moonpay/README.md
+++ b/sdk/fiat-modules/fiat-moonpay/README.md
@@ -19,7 +19,7 @@ layout:
 
 # @tetherto/wdk-protocol-fiat-moonpay Overview
 
-A WDK module for integrating MoonPay's fiat on-ramp and off-ramp services. This module generates signed widget URLs that allow users to buy and sell cryptocurrency using fiat currencies directly within your application.
+A WDK module for integrating MoonPay's fiat on-ramp and off-ramp services. This module generates signed or unsigned widget URLs that allow users to buy and sell cryptocurrency using fiat currencies directly within your application. Provide a `signUrl` callback if you want the protocol to return signed URLs from a trusted backend, or omit it to use the unsigned widget URLs directly.
 
 Get started by reading the [Usage](./usage.md) guide.
 
@@ -27,10 +27,12 @@ Get started by reading the [Usage](./usage.md) guide.
 This module requires a MoonPay developer account. [Create your account here](https://dashboard.moonpay.com/signup).
 {% endhint %}
 
+If you want MoonPay to sign the widget URLs before they are returned, provide a `signUrl` callback that talks to a trusted backend signer. If you omit `signUrl`, the protocol returns unsigned widget URLs directly.
+
 ## Features
 
-- **Fiat On-Ramp**: Generate widget URLs for users to buy cryptocurrency with fiat
-- **Fiat Off-Ramp**: Generate widget URLs for users to sell cryptocurrency for fiat
+- **Fiat On-Ramp**: Generate signed or unsigned widget URLs for users to buy cryptocurrency with fiat
+- **Fiat Off-Ramp**: Generate signed or unsigned widget URLs for users to sell cryptocurrency with fiat
 - **Price Quotes**: Get real-time quotes for buy and sell operations
 - **Transaction Tracking**: Retrieve transaction status and details
 - **Currency Support**: Query supported cryptocurrencies, fiat currencies, and countries
@@ -70,7 +72,7 @@ This module supports purchasing and selling cryptocurrencies on networks compati
     <tr>
       <td>:gear:</td>
       <td><strong>Configuration</strong></td>
-      <td>Set up your MoonPay API credentials and configure the module</td>
+      <td>Set up your MoonPay API key, optional signing callback, and environment</td>
       <td><a href="./configuration.md">Configuration</a></td>
     </tr>
     <tr>

--- a/sdk/fiat-modules/fiat-moonpay/api-reference.md
+++ b/sdk/fiat-modules/fiat-moonpay/api-reference.md
@@ -40,8 +40,9 @@ Creates a new MoonPayProtocol instance.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `apiKey` | string | Yes | - | Your MoonPay publishable API key |
-| `secretKey` | string | Yes | - | Your MoonPay secret key |
+| `signUrl` | function | No | - | Callback used to sign buy and sell widget URLs through a trusted backend |
 | `cacheTime` | number | No | `600000` | Cache duration for currencies (ms) |
+| `environment` | `'production' \| 'sandbox'` | No | `production` | MoonPay widget URL endpoint set |
 
 **Example:**
 
@@ -50,7 +51,8 @@ import MoonPayProtocol from '@tetherto/wdk-protocol-fiat-moonpay';
 
 const moonpay = new MoonPayProtocol(walletAccount, {
   apiKey: 'pk_live_xxxxx',
-  secretKey: 'sk_live_xxxxx',
+  signUrl: async (urlForSignature) => urlForSignature,
+  environment: 'production',
 });
 ```
 
@@ -60,7 +62,7 @@ const moonpay = new MoonPayProtocol(walletAccount, {
 
 ### `buy(options)`
 
-Generates a signed widget URL for purchasing cryptocurrency.
+Generates a MoonPay widget URL for purchasing cryptocurrency. If `signUrl` is configured, the URL is signed through that callback before being returned.
 
 **Parameters:**
 
@@ -81,7 +83,7 @@ Generates a signed widget URL for purchasing cryptocurrency.
 
 ### `sell(options)`
 
-Generates a signed widget URL for selling cryptocurrency.
+Generates a MoonPay widget URL for selling cryptocurrency. If `signUrl` is configured, the URL is signed through that callback before being returned.
 
 **Parameters:**
 
@@ -215,7 +217,7 @@ Retrieves details of a specific transaction.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `txId` | string | Yes | - | MoonPay transaction ID |
-| `direction` | `'buy'` \| `'sell'` | No | `'buy'` | Transaction type |
+| `direction` | `'buy' \| 'sell'` | No | `'buy'` | Transaction type |
 
 **Returns:** `Promise<MoonPayTransactionDetail>`
 
@@ -237,8 +239,9 @@ Retrieves details of a specific transaction.
 ```typescript
 interface MoonPayProtocolConfig {
   apiKey: string;
-  secretKey: string;
+  signUrl?: (urlForSignature: string) => Promise<string>;
   cacheTime?: number;
+  environment?: 'production' | 'sandbox';
 }
 ```
 

--- a/sdk/fiat-modules/fiat-moonpay/configuration.md
+++ b/sdk/fiat-modules/fiat-moonpay/configuration.md
@@ -20,14 +20,15 @@ layout:
 
 # Configuration
 
-This page covers all configuration options for the MoonPay fiat module.
+This page covers all configuration options for the MoonPay fiat module, including optional URL signing and environment selection.
 
 ## Prerequisites
 
 Before using this module, you need:
 
 1. A MoonPay developer account - [Create an account on MoonPay Dashboard](https://dashboard.moonpay.com/signup)
-2. API credentials (API Key and Secret Key) from your dashboard
+2. A publishable API key from your dashboard
+3. If you want signed widget URLs, a trusted backend signing endpoint for the `signUrl` callback
 
 ## Installation
 
@@ -41,8 +42,25 @@ npm install @tetherto/wdk-protocol-fiat-moonpay
 import MoonPayProtocol from '@tetherto/wdk-protocol-fiat-moonpay';
 
 const moonpay = new MoonPayProtocol(walletAccount, {
-  apiKey: 'pk_live_xxxxx',      // Your MoonPay publishable API key
-  secretKey: 'sk_live_xxxxx',   // Your MoonPay secret key
+  apiKey: 'pk_live_xxxxx', // Your MoonPay publishable API key
+  signUrl: async (urlForSignature) => {
+    const response = await fetch('/api/moonpay/sign-url', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ urlForSignature }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to sign MoonPay URL: ${response.status} ${response.statusText}`);
+    }
+
+    const { signedUrl } = await response.json();
+
+    return signedUrl;
+  },
+  environment: 'sandbox',
 });
 ```
 
@@ -51,8 +69,9 @@ const moonpay = new MoonPayProtocol(walletAccount, {
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
 | `apiKey` | string | Yes | - | Your MoonPay publishable API key |
-| `secretKey` | string | Yes | - | Your MoonPay secret key |
+| `signUrl` | function | No | - | Callback used to sign buy and sell widget URLs through a trusted backend |
 | `cacheTime` | number | No | `600000` (10 min) | Duration in milliseconds to cache supported currencies |
+| `environment` | `'production' \| 'sandbox'` | No | `production` | MoonPay widget URL endpoint set |
 
 ## Constructor Overloads
 
@@ -73,12 +92,23 @@ const moonpay = new MoonPayProtocol(walletAccount, config);
 
 ### Sandbox (Testing)
 
-Use test API keys for development and testing:
+Use sandbox endpoints for development and testing:
 
 ```typescript
 const moonpay = new MoonPayProtocol(walletAccount, {
   apiKey: 'pk_test_xxxxx',
-  secretKey: 'sk_test_xxxxx',
+  signUrl: async (urlForSignature) => {
+    const response = await fetch('/api/moonpay/sign-url', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ urlForSignature }),
+    });
+
+    return (await response.json()).signedUrl;
+  },
+  environment: 'sandbox',
 });
 ```
 
@@ -87,14 +117,27 @@ In sandbox mode:
 - Use test card numbers provided by MoonPay
 - KYC verification is simulated
 
+If you do not need signed URLs, omit `signUrl` and the protocol returns unsigned widget URLs directly.
+
 ### Production
 
-For production deployments, use live API keys:
+For production deployments, use live API keys and the production endpoint set:
 
 ```typescript
 const moonpay = new MoonPayProtocol(walletAccount, {
   apiKey: 'pk_live_xxxxx',
-  secretKey: 'sk_live_xxxxx',
+  signUrl: async (urlForSignature) => {
+    const response = await fetch('/api/moonpay/sign-url', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ urlForSignature }),
+    });
+
+    return (await response.json()).signedUrl;
+  },
+  environment: 'production',
 });
 ```
 
@@ -121,7 +164,7 @@ const result = await moonpay.buy({
 | Option | Type | Description |
 |--------|------|-------------|
 | `colorCode` | string | Hexadecimal color for widget accent |
-| `theme` | `'dark'` \| `'light'` | Widget appearance theme |
+| `theme` | `'dark' \| 'light'` | Widget appearance theme |
 | `themeId` | string | ID of a custom theme |
 | `language` | string | ISO 639-1 language code |
 | `showAllCurrencies` | boolean | Show all supported cryptocurrencies |

--- a/sdk/wallet-modules/wallet-btc/api-reference.md
+++ b/sdk/wallet-modules/wallet-btc/api-reference.md
@@ -145,8 +145,8 @@ new WalletAccountBtc(seed, path, config)
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getAddress()` | Returns the account's Bitcoin address | `Promise<string>` |
-| `getBalance()` | Returns the confirmed account balance in satoshis | `Promise<bigint>` |
-| `sendTransaction(options)` | Sends a Bitcoin transaction | `Promise<{hash: string, fee: bigint}>` |
+| `getBalance()` | Returns the total account balance in satoshis, including unconfirmed funds when present | `Promise<bigint>` |
+| `sendTransaction(options, timeoutMs?)` | Sends a Bitcoin transaction and optionally polls until spent inputs disappear from unspent outputs | `Promise<{hash: string, fee: bigint}>` |
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransfers(options?)` | Returns the account's transfer history | `Promise<BtcTransfer[]>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransactionReceipt \| null>` |
@@ -167,7 +167,7 @@ const address = await account.getAddress()
 console.log('Address:', address) // bc1q... (BIP-84) or 1... (BIP-44)
 ```
 ##### `getBalance()`
-Returns the account's confirmed balance in satoshis.
+Returns the account's total balance in satoshis, including unconfirmed funds when present.
 
 **Returns:** `Promise<bigint>` - Balance in satoshis
 
@@ -177,8 +177,8 @@ const balance = await account.getBalance()
 console.log('Balance:', balance, 'satoshis')
 ```
 
-##### `sendTransaction(options)`
-Sends a Bitcoin transaction to a single recipient.
+##### `sendTransaction(options, timeoutMs?)`
+Sends a Bitcoin transaction to a single recipient and optionally polls after broadcast until spent inputs disappear from the unspent-output set.
 
 **Parameters:**
 - `options` (BtcTransaction): Transaction options
@@ -186,6 +186,7 @@ Sends a Bitcoin transaction to a single recipient.
   - `value` (number | bigint): Amount in satoshis
   - `feeRate` (number | bigint, optional): Fee rate in sat/vB. If provided, overrides the fee rate estimated from the blockchain.
   - `confirmationTarget` (number, optional): Target blocks for confirmation (default: 1)
+- `timeoutMs` (number, optional): Maximum milliseconds to poll after broadcast before returning (default: 10000)
 
 **Returns:** `Promise<{hash: string, fee: bigint}>`
 - `hash`: Transaction hash
@@ -371,7 +372,7 @@ new WalletAccountReadOnlyBtc(address, config)
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getAddress()` | Returns the account's Bitcoin address | `Promise<string>` |
-| `getBalance()` | Returns the confirmed account balance in satoshis | `Promise<bigint>` |
+| `getBalance()` | Returns the total account balance in satoshis, including unconfirmed funds when present | `Promise<bigint>` |
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransactionReceipt \| null>` |
 | `getMaxSpendable()` | Returns the maximum spendable amount | `Promise<BtcMaxSpendableResult>` |

--- a/sdk/wallet-modules/wallet-btc/guides/check-balances.md
+++ b/sdk/wallet-modules/wallet-btc/guides/check-balances.md
@@ -28,12 +28,12 @@ You can retrieve the confirmed balance in satoshis using [`account.getBalance()`
 {% code title="Get Native BTC Balance" lineNumbers="true" %}
 ```javascript
 const balance = await account.getBalance()
-console.log('Confirmed balance:', balance, 'satoshis')
+console.log('Total balance:', balance, 'satoshis')
 ```
 {% endcode %}
 
 {% hint style="info" %}
-On Bitcoin, balances are expressed in satoshis (1 BTC = 100,000,000 satoshis). The [`getBalance()`](../api-reference.md#getbalance) method returns confirmed balance only.
+On Bitcoin, balances are expressed in satoshis (1 BTC = 100,000,000 satoshis). The [`getBalance()`](../api-reference.md#getbalance) method returns the total balance, including unconfirmed funds when present.
 {% endhint %}
 
 ## Maximum Spendable Amount
@@ -80,6 +80,10 @@ const balance = await readOnlyAccount.getBalance()
 console.log('Read-only account balance:', balance, 'satoshis')
 ```
 {% endcode %}
+
+{% hint style="info" %}
+Read-only accounts follow the same balance behavior as owned accounts: [`getBalance()`](../api-reference.md#getbalance) includes unconfirmed funds when present.
+{% endhint %}
 
 {% hint style="info" %}
 You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](../api-reference.md#toreadonlyaccount).

--- a/sdk/wallet-modules/wallet-btc/guides/send-transactions.md
+++ b/sdk/wallet-modules/wallet-btc/guides/send-transactions.md
@@ -40,6 +40,28 @@ console.log('Transaction fee:', result.fee, 'satoshis')
 Bitcoin transactions support a single recipient only. Amounts and fees are always in satoshis (1 BTC = 100,000,000 satoshis). The minimum amount must be above the dust limit (294 satoshis for SegWit, 546 for legacy).
 {% endhint %}
 
+## Extend Post-Broadcast Polling
+
+If you want [`account.sendTransaction()`](../api-reference.md#sendtransaction-options-timeoutms) to keep polling after broadcast until spent inputs disappear from the unspent-output set, pass the optional `timeoutMs` argument:
+
+{% code title="Send BTC With Extended Polling" lineNumbers="true" %}
+```javascript
+const result = await account.sendTransaction(
+  {
+    to: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+    value: 100000n,
+  },
+  30000
+)
+
+console.log('Transaction hash:', result.hash)
+```
+{% endcode %}
+
+{% hint style="info" %}
+If you omit `timeoutMs`, the wallet uses the default post-broadcast polling window before returning.
+{% endhint %}
+
 ## Estimate Fees
 
 You can estimate the fee for a transaction without broadcasting it using [`account.quoteSendTransaction()`](../api-reference.md#quotesendtransaction-options):

--- a/sdk/wallet-modules/wallet-spark/README.md
+++ b/sdk/wallet-modules/wallet-spark/README.md
@@ -26,6 +26,8 @@ A simple and secure package to manage BIP-32 wallets for the Spark blockchain. T
 - **Spark Blockchain Support**: Full integration with the Spark Bitcoin [layer 2](../../../resources/concepts.md#layer-2-solutions) network
 - **Lightning Network Integration**: Create and pay [Lightning Network](../../../resources/concepts.md#lightning-network) invoices directly
 - **Spark Invoices**: Create and pay Spark invoices for receiving sats and tokens directly on the Spark network
+- **SparkScan Balance Polling**: Use SparkScan-backed balance polling in [`getBalance()`](./api-reference.md#getbalance) when `sparkscan` is configured
+- **Sync and Retry**: Optionally sync wallet state and retry failed [`sendTransaction()`](./api-reference.md) and [`payLightningInvoice()`](./api-reference.md) calls once
 - **Token Transfers**: Transfer tokens to other Spark addresses
 - **Bitcoin Layer 1 Bridge**: Deposit and withdraw Bitcoin between layer 1 and Spark
 - **Static Deposit Addresses**: Reusable deposit addresses for Bitcoin layer 1 deposits

--- a/sdk/wallet-modules/wallet-spark/api-reference.md
+++ b/sdk/wallet-modules/wallet-spark/api-reference.md
@@ -42,6 +42,8 @@ new WalletManagerSpark(seed, config)
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (object, optional): Configuration object
   - `network` (string, optional): 'MAINNET', 'SIGNET', or 'REGTEST' (default: 'MAINNET')
+  - `sparkscan` (`SparkScanConfig`, optional): SparkScan configuration for balance polling
+  - `syncAndRetry` (boolean, optional): When true, failed sends and Lightning payments sync wallet state and retry once
 
 ### Methods
 
@@ -150,6 +152,7 @@ Represents an individual Spark wallet account. Implements `IWalletAccount` from 
 | `createSparkSatsInvoice(options)` | Creates a Spark invoice for receiving sats | `Promise<SparkAddressFormat>` |
 | `createSparkTokensInvoice(options)` | Creates a Spark invoice for receiving tokens | `Promise<SparkAddressFormat>` |
 | `paySparkInvoice(invoices)` | Pays one or more Spark invoices | `Promise<FulfillSparkInvoiceResponse>` |
+| `syncWalletBalance()` | Reconciles wallet state and waits for any triggered optimization to complete | `Promise<void>` |
 | `getSparkInvoices(params)` | Queries the status of Spark invoices | `Promise<{invoiceStatuses: InvoiceResponse[], offset: number}>` |
 | `toReadOnlyAccount()` | Creates a read-only version of this account | `Promise<WalletAccountReadOnlySpark>` |
 | `cleanupConnections()` | Cleans up network connections and resources | `Promise<void>` |
@@ -193,6 +196,8 @@ console.log('Identity key:', identityKey) // 02eda8...
 
 ##### `sendTransaction({to, value})`
 Sends a Spark transaction.
+
+When `syncAndRetry` is enabled, the wallet syncs state and retries once after a failure.
 
 **Parameters:**
 - `to` (string): Recipient's Spark address
@@ -268,7 +273,7 @@ console.log('Transfer fee:', Number(quote.fee))
 ```
 
 ##### `getBalance()`
-Returns the account's native token balance in satoshis.
+Returns the account's native token balance in satoshis. When `sparkscan` is configured, this uses SparkScan's `btcSoftBalanceSats` value.
 
 **Returns:** `Promise<bigint>` - Balance in satoshis
 
@@ -536,6 +541,8 @@ if (request) {
 ##### `payLightningInvoice(options)`
 Pays a Lightning invoice.
 
+When `syncAndRetry` is enabled, the wallet syncs state and retries once after a failure.
+
 **Parameters:**
 - `options` (PayLightningInvoiceParams): Payment options object
   - `encodedInvoice` (string): BOLT11 Lightning invoice
@@ -653,6 +660,16 @@ const result = await account.paySparkInvoice([
 console.log('Payment result:', result)
 ```
 
+##### `syncWalletBalance()`
+Reconciles the wallet's internal state with the server and waits for any triggered optimization to complete.
+
+**Returns:** `Promise<void>`
+
+**Example:**
+```javascript
+await account.syncWalletBalance()
+```
+
 ##### `getSparkInvoices(params)`
 Queries the status of Spark invoices.
 
@@ -763,7 +780,7 @@ console.log('Identity key:', identityKey) // 02eda8...
 ```
 
 ##### `getBalance()`
-Returns the account's native token balance in satoshis.
+Returns the account's native token balance in satoshis. When `sparkscan` is configured, this uses SparkScan's `btcSoftBalanceSats` value.
 
 **Returns:** `Promise<bigint>` - Balance in satoshis
 
@@ -920,11 +937,23 @@ console.log('Transfer fee:', Number(quote.fee))
 
 ## Types
 
+### SparkScanConfig
+
+```typescript
+interface SparkScanConfig {
+  baseUrl?: string  // Optional SparkScan URL (default: "https://api.sparkscan.io")
+  network?: 'MAINNET' | 'SIGNET' | 'REGTEST'  // Spark network, SparkScan only accepts MAINNET and REGTEST at runtime
+  apiKey?: string  // Optional API key for SparkScan requests
+}
+```
+
 ### SparkWalletConfig
 
 ```typescript
 interface SparkWalletConfig {
   network?: 'MAINNET' | 'SIGNET' | 'REGTEST'  // The network (default: "MAINNET")
+  sparkscan?: SparkScanConfig  // Optional SparkScan configuration for balance polling
+  syncAndRetry?: boolean       // When true, failed sends and Lightning payments sync wallet state and retry once
 }
 ```
 
@@ -1239,4 +1268,3 @@ interface RefundStaticDepositOptions {
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-

--- a/sdk/wallet-modules/wallet-spark/configuration.md
+++ b/sdk/wallet-modules/wallet-spark/configuration.md
@@ -24,7 +24,11 @@ layout:
 
 ```javascript
 const config = {
-  network: 'MAINNET' // 'MAINNET', 'SIGNET', or 'REGTEST'
+  network: 'MAINNET', // 'MAINNET', 'SIGNET', or 'REGTEST'
+  sparkscan: {
+    apiKey: 'your-api-key-here'
+  },
+  syncAndRetry: true
 }
 
 const wallet = new WalletManagerSpark(seedPhrase, config)
@@ -59,6 +63,47 @@ const config = {
   network: 'REGTEST' // Use REGTEST for development
 }
 ```
+
+### SparkScan Balance Polling
+
+The `sparkscan` option configures SparkScan-backed balance polling for [`getBalance()`](./api-reference.md#getbalance).
+
+**Type:** `SparkScanConfig` (optional)
+
+**Fields:**
+- `baseUrl` - Optional SparkScan URL, default: `https://api.sparkscan.io`
+- `network` - Optional Spark network. SparkScan supports `MAINNET` and `REGTEST`
+- `apiKey` - Optional SparkScan API key
+
+**Example:**
+```javascript
+const config = {
+  network: 'MAINNET',
+  sparkscan: {
+    apiKey: 'your-api-key-here'
+  }
+}
+```
+
+When `sparkscan` is configured, [`getBalance()`](./api-reference.md#getbalance) returns SparkScan's soft balance from `btcSoftBalanceSats`.
+
+### Automatic Retry
+
+The `syncAndRetry` option tells [`sendTransaction()`](./api-reference.md#sendtransaction-to-value) and [`payLightningInvoice()`](./api-reference.md#paylightninginvoice-options) to sync wallet state and retry once after a failure.
+
+**Type:** `boolean` (optional)
+
+**Default:** `false`
+
+**Example:**
+```javascript
+const config = {
+  network: 'MAINNET',
+  syncAndRetry: true
+}
+```
+
+You can also call [`syncWalletBalance()`](./api-reference.md#syncwalletbalance) directly when you want to reconcile wallet state before retrying an operation.
 
 ## Network Configuration
 
@@ -101,7 +146,11 @@ import WalletManagerSpark from '@tetherto/wdk-wallet-spark'
 // Create wallet manager with configuration
 const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
 const wallet = new WalletManagerSpark(seedPhrase, {
-  network: 'MAINNET'
+  network: 'MAINNET',
+  sparkscan: {
+    apiKey: 'your-api-key-here'
+  },
+  syncAndRetry: true
 })
 
 // Get accounts (no additional configuration needed)
@@ -180,6 +229,5 @@ wallet.dispose()
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
 
 

--- a/sdk/wallet-modules/wallet-spark/guides/check-balances.md
+++ b/sdk/wallet-modules/wallet-spark/guides/check-balances.md
@@ -37,6 +37,23 @@ console.log('Balance in BTC:', Number(balance) / 100000000)
 Balances are in satoshis (1 BTC = 100,000,000 satoshis).
 {% endhint %}
 
+If you configure [`sparkscan`](../configuration.md#sparkscan-balance-polling), [`account.getBalance()`](../api-reference.md#getbalance) returns SparkScan's `btcSoftBalanceSats` value instead of the Spark SDK balance:
+
+{% code title="SparkScan Balance Polling" lineNumbers="true" %}
+```javascript
+const wallet = new WalletManagerSpark(seedPhrase, {
+  network: 'MAINNET',
+  sparkscan: {
+    apiKey: 'your-api-key-here',
+  },
+})
+
+const account = await wallet.getAccount(0)
+const balance = await account.getBalance()
+console.log('SparkScan balance:', balance)
+```
+{% endcode %}
+
 ## Token Balance
 
 You can read a specific token balance using [`account.getTokenBalance()`](../api-reference.md#gettokenbalance-tokenaddress):
@@ -73,6 +90,10 @@ const balance = await readOnlyAccount.getBalance()
 console.log('Read-only balance:', balance, 'satoshis')
 ```
 {% endcode %}
+
+{% hint style="info" %}
+The same [`sparkscan`](../configuration.md#sparkscan-balance-polling) behavior applies to read-only accounts.
+{% endhint %}
 
 You can read a token balance on a read-only account using [`readOnlyAccount.getTokenBalance()`](../api-reference.md#gettokenbalance-tokenaddress):
 

--- a/sdk/wallet-modules/wallet-spark/guides/lightning-payments.md
+++ b/sdk/wallet-modules/wallet-spark/guides/lightning-payments.md
@@ -56,6 +56,23 @@ console.log('Payment result:', payment)
 ```
 {% endcode %}
 
+If you enable [`syncAndRetry`](../configuration.md#automatic-retry), the wallet syncs state and retries [`account.payLightningInvoice()`](../api-reference.md#paylightninginvoice-options) once after a failure:
+
+{% code title="Retry Lightning Payment Once" lineNumbers="true" %}
+```javascript
+const wallet = new WalletManagerSpark(seedPhrase, {
+  network: 'MAINNET',
+  syncAndRetry: true,
+})
+
+const account = await wallet.getAccount(0)
+await account.payLightningInvoice({
+  encodedInvoice: 'lnbc500u1p...',
+  maxFeeSats: 1000,
+})
+```
+{% endcode %}
+
 ## Estimate Lightning Fees
 
 You can estimate the routing fee before paying using [`account.quotePayLightningInvoice()`](../api-reference.md#quotepaylightninginvoice-options):

--- a/sdk/wallet-modules/wallet-spark/guides/send-and-transfer.md
+++ b/sdk/wallet-modules/wallet-spark/guides/send-and-transfer.md
@@ -43,6 +43,23 @@ console.log('Transaction fee:', result.fee)
 On-chain Spark transfers report `fee` as `0`. Memos are not supported on [`sendTransaction()`](../api-reference.md#sendtransaction-to-value). Use valid Spark network addresses.
 {% endhint %}
 
+If you enable [`syncAndRetry`](../configuration.md#automatic-retry), the wallet syncs its state and retries [`account.sendTransaction()`](../api-reference.md#sendtransaction-to-value) once after a failure:
+
+{% code title="Retry Failed Sends Once" lineNumbers="true" %}
+```javascript
+const wallet = new WalletManagerSpark(seedPhrase, {
+  network: 'MAINNET',
+  syncAndRetry: true,
+})
+
+const account = await wallet.getAccount(0)
+await account.sendTransaction({
+  to: 'spark1...',
+  value: 1000000,
+})
+```
+{% endcode %}
+
 ## Transfer Tokens
 
 You can move tokens to another Spark address using [`account.transfer()`](../api-reference.md#transfer-options):
@@ -107,6 +124,14 @@ console.log('Fast:', feeRates.fast)
 {% hint style="info" %}
 Spark network fees for native sends and token transfers are zero; [`wallet.getFeeRates()`](../api-reference.md#getfeerates) returns `{ normal: 0n, fast: 0n }`. Lightning flows can still incur fees; see [Lightning payments](./lightning-payments.md).
 {% endhint %}
+
+If you want to reconcile wallet state before retrying manually, call [`account.syncWalletBalance()`](../api-reference.md#syncwalletbalance):
+
+{% code title="Sync Wallet Balance" lineNumbers="true" %}
+```javascript
+await account.syncWalletBalance()
+```
+{% endcode %}
 
 ## Next Steps
 

--- a/tools/failover-provider/README.md
+++ b/tools/failover-provider/README.md
@@ -1,0 +1,81 @@
+---
+title: Failover Provider
+description: Generic provider failover wrapper for retrying sync and async calls across provider candidates
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: false
+  metadata:
+    visible: false
+---
+
+# Failover Provider
+
+Failover Provider wraps multiple provider-like objects behind one proxy so your integration can retry failed calls against the next candidate without rewriting each call site. Use this page to review the [Configuration](./configuration.md) and [API Reference](./api-reference.md) for the released `@tetherto/wdk-failover-provider` surface.
+
+Powered by [`@tetherto/wdk-failover-provider`](https://github.com/tetherto/wdk-failover-provider).
+
+## Features
+
+- **Generic provider wrapper**: `FailoverProvider<T>` accepts any provider-like object type and returns a proxied `T` from `initialize()`.
+- **Configurable retries**: Set `retries` to control how many additional attempts happen after the first failure.
+- **Retry predicate**: Use `shouldRetryOn(error)` to decide which errors should advance to the next provider.
+- **Sync and async failover**: The runtime retries both synchronous throws and rejected promises.
+- **Zero runtime dependencies**: The published package ships a single default export with no runtime dependency tree.
+
+## Why this matters
+
+- You can keep one provider-shaped integration surface while rotating between browser, JSON-RPC, or custom provider implementations.
+- You can narrow failover behavior to transient errors instead of retrying every exception.
+- You can add redundancy to read-heavy or submission-heavy flows without building your own retry proxy.
+
+<table data-card-size="large" data-view="cards">
+  <thead>
+    <tr>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th data-hidden data-card-target data-type="content-ref"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <i class="fa-code">:code:</i>
+      </td>
+      <td>
+        <strong>Failover Provider Configuration</strong>
+      </td>
+      <td>Install the package, add provider candidates, and tune retry behavior.</td>
+      <td>
+        <a href="./configuration.md">configuration.md</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <i class="fa-mobile-alt">:mobile-alt:</i>
+      </td>
+      <td>
+        <strong>Failover Provider API Reference</strong>
+      </td>
+      <td>Review `FailoverProvider<T>`, its config, and the proxied runtime behavior.</td>
+      <td>
+        <a href="./api-reference.md">api-reference.md</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+***
+
+## Need Help?
+
+{% include "../.gitbook/includes/support-cards.md" %}

--- a/tools/failover-provider/api-reference.md
+++ b/tools/failover-provider/api-reference.md
@@ -1,0 +1,124 @@
+---
+title: Failover Provider API Reference
+description: API for @tetherto/wdk-failover-provider
+icon: code
+---
+
+# API Reference
+
+## Package: `@tetherto/wdk-failover-provider`
+
+### Class: `FailoverProvider<T>`
+
+`FailoverProvider<T>` collects provider candidates of one shared shape and returns a proxied `T` that retries failed calls against the next provider.
+
+#### Constructor
+
+Use the constructor to set retry behavior before you add provider candidates:
+
+{% code title="Create A FailoverProvider Factory" lineNumbers="true" %}
+```javascript
+new FailoverProvider({
+  retries,        // optional, defaults to 3
+  shouldRetryOn   // optional, defaults to (error) => error instanceof Error
+})
+```
+{% endcode %}
+
+- `retries` (`number`, optional): Number of additional attempts after the first failure. Total attempts are `1 + retries`.
+- `shouldRetryOn` (`(error: Error) => boolean`, optional): Predicate that decides whether the proxy should switch to the next provider after a failure.
+
+#### Methods
+
+| Method | Description | Returns |
+| --- | --- | --- |
+| `addProvider(provider)` | Register one provider candidate and return the same factory so you can chain more candidates. | `FailoverProvider<T>` |
+| `initialize()` | Return a proxied provider of type `T` that reads from the active provider and retries failed calls against the next provider. | `T` |
+
+#### `addProvider(provider)`
+
+Register a provider candidate. Every candidate should satisfy the same `T` shape because `initialize()` returns one proxied `T`.
+
+{% code title="Register A Provider Candidate" lineNumbers="true" %}
+```javascript
+const factory = new FailoverProvider({ retries: 1 })
+
+factory.addProvider({
+  name: 'primary',
+  async getBlockNumber () {
+    return 21345678
+  }
+})
+```
+{% endcode %}
+
+#### `initialize()`
+
+Create the failover-enabled proxy after you have added at least one provider. The runtime throws if the factory is still empty.
+
+{% code title="Initialize The Failover Proxy" lineNumbers="true" %}
+```javascript
+const provider = new FailoverProvider({ retries: 1 })
+  .addProvider(primary)
+  .addProvider(secondary)
+  .initialize()
+
+const blockNumber = await provider.getBlockNumber()
+```
+{% endcode %}
+
+#### `FailoverProviderConfig`
+
+The package exports the `FailoverProviderConfig` type through its top-level type surface.
+
+| Field | Description |
+| --- | --- |
+| `retries?` | Additional retry attempts after the first failure. Defaults to `3`. |
+| `shouldRetryOn?` | Retry predicate for thrown errors and rejected promises. Defaults to retrying any `Error` instance. |
+
+## Runtime behavior
+
+- `initialize()` returns a JavaScript `Proxy` over the first added provider.
+- Non-function properties are forwarded from the currently active provider.
+- If a property getter throws and `shouldRetryOn(error)` returns `true`, the runtime advances to the next provider before retrying the property access.
+- If a synchronous method throws and `shouldRetryOn(error)` returns `true`, the runtime advances to the next provider and retries the method call.
+- If an asynchronous method rejects and `shouldRetryOn(error)` returns `true`, the runtime advances to the next provider and retries the method call.
+- Provider switching is round-robin. If the active provider already changed while another call was failing, the runtime keeps the newer active provider instead of advancing twice.
+
+## Example
+
+This example shows a transient failure on the first provider and a successful retry on the second provider:
+
+{% code title="Retry Across Two Providers" lineNumbers="true" %}
+```javascript
+import FailoverProvider from '@tetherto/wdk-failover-provider'
+
+const primary = {
+  async getBlockNumber () {
+    throw new Error('temporary upstream outage')
+  }
+}
+
+const secondary = {
+  async getBlockNumber () {
+    return 21345678
+  }
+}
+
+const provider = new FailoverProvider({
+  retries: 1,
+  shouldRetryOn: (error) => error.message.includes('temporary')
+})
+  .addProvider(primary)
+  .addProvider(secondary)
+  .initialize()
+
+const blockNumber = await provider.getBlockNumber()
+```
+{% endcode %}
+
+***
+
+## Need Help?
+
+{% include "../../.gitbook/includes/support-cards.md" %}

--- a/tools/failover-provider/configuration.md
+++ b/tools/failover-provider/configuration.md
@@ -1,0 +1,121 @@
+---
+title: Failover Provider Configuration
+description: Install @tetherto/wdk-failover-provider and configure retries, retry predicates, and provider candidates
+icon: gear
+---
+
+# Failover Provider Configuration
+
+This page shows how to install `@tetherto/wdk-failover-provider`, configure `retries` and `shouldRetryOn`, and build a proxied provider with `addProvider()` and `initialize()`.
+
+## Install the package
+
+You can install the package from npm:
+
+{% code title="Install @tetherto/wdk-failover-provider" lineNumbers="true" %}
+```bash
+npm install @tetherto/wdk-failover-provider
+```
+{% endcode %}
+
+## Create a failover provider
+
+You can wrap any provider-like object type. This example uses plain objects so the retry behavior is easy to see:
+
+{% code title="Create A Failover Provider" lineNumbers="true" %}
+```javascript
+import FailoverProvider from '@tetherto/wdk-failover-provider'
+
+const primary = {
+  name: 'primary',
+  async getBlockNumber () {
+    throw new Error('temporary upstream outage')
+  }
+}
+
+const secondary = {
+  name: 'secondary',
+  async getBlockNumber () {
+    return 21345678
+  }
+}
+
+const provider = new FailoverProvider({
+  retries: 1,
+  shouldRetryOn: (error) => error.message.includes('temporary')
+})
+  .addProvider(primary)
+  .addProvider(secondary)
+  .initialize()
+```
+{% endcode %}
+
+## Configuration options
+
+### `retries`
+
+`retries` controls how many additional attempts happen after the first failure. The published runtime defaults to `3`, which means a call can make up to `1 + retries` total attempts before the latest error is thrown.
+
+### `shouldRetryOn`
+
+`shouldRetryOn(error)` decides whether a thrown error or rejected promise should advance to the next provider. The published default retries on any `Error` instance.
+
+Use a narrow predicate when you only want to retry transient failures:
+
+{% code title="Retry Only On Transient Errors" lineNumbers="true" %}
+```javascript
+const provider = new FailoverProvider({
+  retries: 2,
+  shouldRetryOn: (error) => /timeout|temporary|429/.test(error.message)
+})
+```
+{% endcode %}
+
+## Register provider candidates
+
+Call `addProvider(provider)` once per candidate before you call `initialize()`. `addProvider()` returns the same `FailoverProvider` instance, so you can chain the calls.
+
+The generic type `T` applies to every added candidate, so keep the provider shape consistent across the chain.
+
+{% code title="Add Multiple Provider Candidates" lineNumbers="true" %}
+```javascript
+const provider = new FailoverProvider({ retries: 2 })
+  .addProvider(primary)
+  .addProvider(secondary)
+  .addProvider({
+    name: 'tertiary',
+    async getBlockNumber () {
+      return 21345679
+    }
+  })
+  .initialize()
+```
+{% endcode %}
+
+## Initialize the proxy
+
+Call `initialize()` after you have added at least one provider. The returned value is a proxied provider of type `T`.
+
+The runtime throws if you call `initialize()` before adding any providers:
+
+{% code title="Initialize Requires At Least One Provider" lineNumbers="true" %}
+```javascript
+const factory = new FailoverProvider()
+
+factory.initialize()
+// Error: Cannot initialize an empty provider. Call `addProvider` before this function.
+```
+{% endcode %}
+
+## Runtime notes
+
+- Non-function properties are read from the currently active provider.
+- When a synchronous method throws and `shouldRetryOn(error)` returns `true`, the proxy switches to the next provider and retries.
+- When an asynchronous method rejects and `shouldRetryOn(error)` returns `true`, the proxy switches to the next provider and retries.
+- Provider selection advances in round-robin order. If `retries` is larger than the number of providers, the runtime loops back through the list.
+
+***
+
+## Need Help?
+
+{% include "../../.gitbook/includes/support-cards.md" %}

--- a/tools/pear-wrk-wdk/README.md
+++ b/tools/pear-wrk-wdk/README.md
@@ -1,0 +1,85 @@
+---
+title: Pear Worklet WDK
+description: Low-level HRPC infrastructure for running WDK inside a Bare worklet
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: false
+  metadata:
+    visible: false
+---
+
+# Pear Worklet WDK
+
+Pear Worklet WDK is the low-level transport and handler layer for running WDK inside a Bare worklet. It provides the `HRPC` client, the `registerRpcHandlers()` server helper, and the typed request payloads needed to initialize WDK, call wallet methods, and reset selected wallet modules from the host app.
+
+Powered by [`@tetherto/pear-wrk-wdk`](https://github.com/tetherto/pear-wrk-wdk).
+
+## Features
+
+- **Bare worklet bridge**: Connect a host app to a worklet through the shipped `HRPC` client and generated HRPC schema
+- **Typed lifecycle requests**: Initialize WDK with `initializeWDK({ config, encryptionKey, encryptedSeed })` and tear it down with `dispose()`
+- **Selective wallet resets**: Re-register only the wallet modules listed in a new worklet `networks` config using `resetWdkWallets({ config })`
+- **Generic wallet method calls**: Call account methods through `callMethod({ methodName, network, accountIndex, args, options })`
+- **Dynamic registration hooks**: Register additional wallets or protocols with `registerWallet()` and `registerProtocol()`
+
+## Why this matters
+
+- You can keep WDK state and signing operations off the main thread in Bare-based apps
+- You can reconfigure selected wallet modules without fully disposing the worklet
+- You can use one transport layer across custom mobile, desktop, or embedded Bare integrations
+
+{% hint style="info" %}
+Use this package when you need direct control over the worklet host and RPC layer. If you want generated worklet entry files instead, start with [`@tetherto/wdk-worklet-bundler`](https://github.com/tetherto/wdk-worklet-bundler).
+{% endhint %}
+
+<table data-card-size="large" data-view="cards">
+	<thead>
+		<tr>
+			<th></th>
+			<th></th>
+			<th></th>
+			<th data-hidden data-card-target data-type="content-ref"></th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>
+				<i class="fa-gear">:gear:</i>
+			</td>
+			<td>
+				<strong>Pear Worklet WDK Configuration</strong>
+			</td>
+			<td>Build the worklet context and pass the JSON config payloads used by initialize and reset requests</td>
+			<td>
+				<a href="./configuration.md">configuration.md</a>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<i class="fa-code">:code:</i>
+			</td>
+			<td>
+				<strong>Pear Worklet WDK API Reference</strong>
+			</td>
+			<td>Review the exported class, server helper, and request shapes</td>
+			<td>
+				<a href="./api-reference.md">api-reference.md</a>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+***
+
+## Need Help?
+
+{% include "../.gitbook/includes/support-cards.md" %}

--- a/tools/pear-wrk-wdk/api-reference.md
+++ b/tools/pear-wrk-wdk/api-reference.md
@@ -1,0 +1,233 @@
+---
+title: Pear Worklet WDK API Reference
+description: API reference for the HRPC client, registerRpcHandlers helper, and request types in @tetherto/pear-wrk-wdk
+icon: code
+---
+
+# Pear Worklet WDK API Reference
+
+## Package: `@tetherto/pear-wrk-wdk`
+
+### Export: `HRPC`
+
+#### Command Methods
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `log()` | `log(args: LogRequest): void` | Sends a log payload over the HRPC stream. |
+| `workletStart()` | `workletStart(args: WorkletStartRequest): Promise<WorkletStartResponse>` | Deprecated worklet startup request. Prefer `initializeWDK()`. |
+| `initializeWDK()` | `initializeWDK(args: WdkInitializeParams): Promise<{ status: string }>` | Creates or reinitializes the worklet WDK instance and registers wallets and optional protocols from `config`. |
+| `resetWdkWallets()` | `resetWdkWallets(args: WdkResetWalletParams): Promise<{ status: string }>` | Selectively disposes and re-registers only the wallets listed in `config.networks`. |
+| `generateEntropyAndEncrypt()` | `generateEntropyAndEncrypt(args: WdkGenerateEntropyParams): Promise<WdkEntropyResult>` | Generates encrypted seed and entropy buffers inside the worklet. |
+| `getMnemonicFromEntropy()` | `getMnemonicFromEntropy(args: WdkGetMnemonicParams): Promise<{ mnemonic: string }>` | Decrypts an encrypted entropy payload and returns the mnemonic. |
+| `getSeedAndEntropyFromMnemonic()` | `getSeedAndEntropyFromMnemonic(args: { mnemonic: string }): Promise<WdkEntropyResult>` | Converts a mnemonic into encrypted seed and entropy buffers. |
+| `dispose()` | `dispose(args: DisposeRequest): void` | Disposes the worklet WDK instance. |
+| `callMethod()` | `callMethod(args: CallMethodRequest): Promise<CallMethodResponse>` | Looks up the target account and invokes one wallet or protocol method by name. |
+| `registerWallet()` | `registerWallet(args: { config: string }): Promise<{ status: string, blockchains: string }>` | Dynamically registers additional wallets from a JSON config string. |
+| `registerProtocol()` | `registerProtocol(args: { config: string }): Promise<{ status: string }>` | Dynamically registers additional protocols from a JSON config string. |
+
+#### Handler Registration Methods
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `onLog()` | `onLog(responseFn): void` | Registers the server-side handler for `log()`. |
+| `onWorkletStart()` | `onWorkletStart(responseFn): void` | Registers the server-side handler for `workletStart()`. |
+| `onInitializeWDK()` | `onInitializeWDK(responseFn): void` | Registers the server-side handler for `initializeWDK()`. |
+| `onResetWdkWallets()` | `onResetWdkWallets(responseFn): void` | Registers the server-side handler for `resetWdkWallets()`. |
+| `onGenerateEntropyAndEncrypt()` | `onGenerateEntropyAndEncrypt(responseFn): void` | Registers the server-side handler for encrypted entropy generation. |
+| `onGetMnemonicFromEntropy()` | `onGetMnemonicFromEntropy(responseFn): void` | Registers the server-side handler for mnemonic recovery. |
+| `onGetSeedAndEntropyFromMnemonic()` | `onGetSeedAndEntropyFromMnemonic(responseFn): void` | Registers the server-side handler for mnemonic migration. |
+| `onDispose()` | `onDispose(responseFn): void` | Registers the server-side handler for `dispose()`. |
+| `onCallMethod()` | `onCallMethod(responseFn): void` | Registers the server-side handler for `callMethod()`. |
+| `onRegisterWallet()` | `onRegisterWallet(responseFn): void` | Registers the server-side handler for `registerWallet()`. |
+| `onRegisterProtocol()` | `onRegisterProtocol(responseFn): void` | Registers the server-side handler for `registerProtocol()`. |
+
+#### `log`
+
+- `type?` (`LogType`): Optional numeric log level.
+- `data?` (`string | null`): Optional log payload.
+
+#### `workletStart`
+
+Deprecated startup request retained in the shipped type surface.
+
+- `enableDebugLogs?` (`number`)
+- `seedPhrase?` (`string | null`)
+- `seedBuffer?` (`string | null`)
+- `config` (`string`): JSON string of network configurations.
+
+Returns:
+
+- `status?` (`string | null`)
+
+#### `initializeWDK`
+
+- `encryptionKey?` (`string`): Base64-encoded decryption key for the encrypted seed buffer.
+- `encryptedSeed?` (`string`): Base64-encoded encrypted seed buffer.
+- `config` (`string`): JSON stringified `WdkWorkletConfig`.
+
+The handler requires `encryptionKey` and `encryptedSeed` to be passed together or omitted together. When a seeded WDK instance already exists, the runtime disposes it before re-registering the wallets and optional protocols in `config`.
+
+#### `resetWdkWallets`
+
+- `config` (`string`): JSON stringified object containing a `networks` map.
+
+The runtime validates `config.networks`, extracts each target `blockchain`, calls `wdk.dispose(targetChains)`, and re-registers only those wallet managers. This method does not re-register protocols.
+
+#### `generateEntropyAndEncrypt`
+
+- `wordCount` (`12 | 24`): The mnemonic word count to generate.
+
+Returns:
+
+- `encryptionKey` (`string`)
+- `encryptedSeedBuffer` (`string`)
+- `encryptedEntropyBuffer` (`string`)
+
+#### `getMnemonicFromEntropy`
+
+- `encryptedEntropy` (`string`): Base64-encoded encrypted entropy buffer.
+- `encryptionKey` (`string`): Base64-encoded decryption key.
+
+Returns:
+
+- `mnemonic` (`string`)
+
+#### `getSeedAndEntropyFromMnemonic`
+
+- `mnemonic` (`string`): Source mnemonic to migrate into encrypted buffers.
+
+Returns:
+
+- `encryptionKey` (`string`)
+- `encryptedSeedBuffer` (`string`)
+- `encryptedEntropyBuffer` (`string`)
+
+#### `dispose`
+
+- `args` (`DisposeRequest`): Empty request object.
+
+#### `callMethod`
+
+- `methodName` (`string`): Account method to invoke.
+- `network` (`string`): Target blockchain key used to resolve the account.
+- `accountIndex` (`number`): Account index passed to `wdk.getAccount(network, accountIndex)`.
+- `args?` (`string`): JSON string of the method arguments.
+- `options?` (`string`): JSON string of `CallMethodOptions`.
+
+`options.protocolType` may be `swap`, `bridge`, `lending`, or `fiat`. When present, the runtime resolves the protocol-specific account wrapper before invoking `methodName`.
+
+#### `registerWallet`
+
+- `config` (`string`): JSON string of network config entries.
+
+Returns:
+
+- `status` (`string`)
+- `blockchains` (`string`): JSON stringified array of registered blockchain names.
+
+#### `registerProtocol`
+
+- `config` (`string`): JSON string of protocol config entries.
+
+Returns:
+
+- `status` (`string`)
+
+#### `onLog`
+
+Registers the server-side handler used to service `log()` requests.
+
+#### `onWorkletStart`
+
+Registers the server-side handler used to service the deprecated `workletStart()` request.
+
+#### `onInitializeWDK`
+
+Registers the server-side handler used to service `initializeWDK()` requests on the worklet side.
+
+#### `onResetWdkWallets`
+
+Registers the server-side handler used to service `resetWdkWallets()` requests on the worklet side.
+
+#### `onGenerateEntropyAndEncrypt`
+
+Registers the server-side handler used to service encrypted entropy generation requests.
+
+#### `onGetMnemonicFromEntropy`
+
+Registers the server-side handler used to service mnemonic recovery requests.
+
+#### `onGetSeedAndEntropyFromMnemonic`
+
+Registers the server-side handler used to service mnemonic migration requests.
+
+#### `onDispose`
+
+Registers the server-side handler used to service `dispose()` requests.
+
+#### `onCallMethod`
+
+Registers the server-side handler used to service `callMethod()` requests.
+
+#### `onRegisterWallet`
+
+Registers the server-side handler used to service `registerWallet()` requests.
+
+#### `onRegisterProtocol`
+
+Registers the server-side handler used to service `registerProtocol()` requests.
+
+### Export: `registerRpcHandlers(rpc, context)`
+
+Registers the package's server-side handlers on the provided RPC instance.
+
+- `rpc` (`any`): RPC server instance that supports the generated handler registration methods.
+- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`.
+
+### Types
+
+#### `WdkWorkletConfig`
+
+```ts
+interface WdkWorkletConfig {
+  networks: {
+    [blockchain: string]: {
+      blockchain: string
+      config: unknown
+    }
+  }
+  protocols?: {
+    [protocolName: string]: {
+      blockchain: string
+      protocolName: string
+      config: unknown
+    }
+  }
+}
+```
+
+#### `WdkResetWalletParams`
+
+```ts
+interface WdkResetWalletParams {
+  config: string
+}
+```
+
+#### `CallMethodOptions`
+
+```ts
+interface CallMethodOptions {
+  transformResult: Function
+  defaultValue: any
+  protocolType: 'swap' | 'bridge' | 'lending' | 'fiat'
+  protocolName: string
+}
+```
+
+***
+
+## Need Help?
+
+{% include "../.gitbook/includes/support-cards.md" %}

--- a/tools/pear-wrk-wdk/configuration.md
+++ b/tools/pear-wrk-wdk/configuration.md
@@ -1,0 +1,159 @@
+---
+title: Pear Worklet WDK Configuration
+description: Configure the Bare worklet context and the JSON payloads passed to initializeWDK and resetWdkWallets
+icon: gear
+---
+
+# Pear Worklet WDK Configuration
+
+This page explains how to [build the worklet context](#worklet-context), [shape the worklet config payload](#worklet-config-payload), [initialize-wdk](#initialize-wdk), and [reset-selected-wallets](#reset-selected-wallets).
+
+## Worklet Context
+
+You can bind the shipped RPC handlers to your Bare worklet using `registerRpcHandlers()`:
+
+{% code title="Register RPC Handlers" lineNumbers="true" %}
+```javascript
+const { registerRpcHandlers } = require('@tetherto/pear-wrk-wdk/worklet')
+const { WDK } = require('@tetherto/wdk')
+const EvmWalletManager = require('@tetherto/wdk-wallet-evm')
+const SparkWalletManager = require('@tetherto/wdk-wallet-spark')
+
+const context = {
+  wdk: null,
+  WDK,
+  walletManagers: {
+    ethereum: EvmWalletManager,
+    spark: SparkWalletManager
+  },
+  protocolManagers: {},
+  wdkLoadError: null
+}
+
+module.exports = (rpc) => {
+  registerRpcHandlers(rpc, context)
+}
+```
+{% endcode %}
+
+### Required Context Fields
+
+- `wdk`: The current WDK instance. Set this to `null` before the first initialization.
+- `WDK`: The WDK constructor used to create the seeded instance.
+- `walletManagers`: A map from blockchain name to wallet manager implementation.
+- `protocolManagers`: A map from protocol name to protocol manager implementation.
+- `wdkLoadError`: Any startup error captured while loading WDK. Use `null` when there is no load failure.
+
+## Worklet Config Payload
+
+Both [`initializeWDK()`](./api-reference.md#initializewdk) and [`resetWdkWallets()`](./api-reference.md#resetwdkwallets) expect `config` to be a JSON string. The decoded object must contain at least one entry under `networks`.
+
+{% code title="Minimal Worklet Config JSON" lineNumbers="true" %}
+```javascript
+const workletConfig = {
+  networks: {
+    ethereum: {
+      blockchain: 'ethereum',
+      config: {
+        provider: 'https://rpc.ankr.com/eth_sepolia'
+      }
+    }
+  },
+  protocols: {
+    moonpay: {
+      blockchain: 'ethereum',
+      protocolName: 'moonpay',
+      config: {
+        environment: 'sandbox'
+      }
+    }
+  }
+}
+```
+{% endcode %}
+
+### Payload Rules
+
+- `networks` is required and must contain at least one network entry.
+- Each network entry must include `blockchain` and an object `config`.
+- `protocols` is optional during initialization.
+- `resetWdkWallets()` reads only the `networks` portion of the decoded config.
+
+## Initialize WDK
+
+You can create and register the WDK instance inside the worklet using [`initializeWDK()`](./api-reference.md#initializewdk):
+
+{% code title="Initialize WDK" lineNumbers="true" %}
+```javascript
+const { HRPC } = require('@tetherto/pear-wrk-wdk')
+
+const hrpc = new HRPC(ipcStream)
+
+await hrpc.initializeWDK({
+  encryptionKey: secrets.encryptionKey,
+  encryptedSeed: secrets.encryptedSeedBuffer,
+  config: JSON.stringify(workletConfig)
+})
+```
+{% endcode %}
+
+### Initialization Rules
+
+- Pass both `encryptionKey` and `encryptedSeed`, or omit both together.
+- On first initialization, the worklet must receive an encrypted seed pair so it can create `context.wdk`.
+- If `context.wdk` already exists, a later `initializeWDK()` call disposes the existing instance before re-registering wallets and protocols from the new config.
+
+## Reset Selected Wallets
+
+You can selectively dispose and re-register wallet modules using [`resetWdkWallets()`](./api-reference.md#resetwdkwallets):
+
+{% code title="Reset Selected Wallet Modules" lineNumbers="true" %}
+```javascript
+await hrpc.resetWdkWallets({
+  config: JSON.stringify({
+    networks: {
+      ethereum: {
+        blockchain: 'ethereum',
+        config: {
+          provider: 'https://rpc.ankr.com/eth_sepolia'
+        }
+      }
+    }
+  })
+})
+```
+{% endcode %}
+
+### Reset Rules
+
+- `resetWdkWallets()` requires an existing initialized `context.wdk`.
+- The handler calls `wdk.dispose(targetChains)` with the blockchains extracted from `config.networks`.
+- Only wallets listed in the request `networks` object are re-registered.
+- The reset flow does not re-register protocols.
+
+## Call Wallet Methods
+
+You can execute wallet account methods through [`callMethod()`](./api-reference.md#callmethod):
+
+{% code title="Call a Wallet Method" lineNumbers="true" %}
+```javascript
+const result = await hrpc.callMethod({
+  methodName: 'getAddress',
+  network: 'ethereum',
+  accountIndex: 0
+})
+```
+{% endcode %}
+
+### Call Method Notes
+
+- `args` is optional and must be a JSON string when provided.
+- `options` is optional and must be a JSON string when provided.
+- When `args` decodes to an array, the handler spreads the values as positional method arguments.
+- When `args` decodes to an object or primitive, the handler passes it as a single argument.
+
+***
+
+## Need Help?
+
+{% include "../.gitbook/includes/support-cards.md" %}

--- a/tools/wdk-utils/README.md
+++ b/tools/wdk-utils/README.md
@@ -1,0 +1,79 @@
+---
+title: WDK Utils
+description: Address validation helpers and EIP-681 request parsers for @tetherto/wdk-utils
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: false
+  metadata:
+    visible: false
+---
+
+# WDK Utils
+
+WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, and UMA identifiers, plus EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+
+## Features
+
+- **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Spark, and UMA inputs before you hand them to a wallet flow.
+- **EIP-681 request parsing**: Detect request-shaped EIP-681 strings and parse transfer payloads into `recipient`, `tokenAddress`, `chainId`, and `amountSmallest`.
+- **No runtime setup**: Import the functions you need. The package has no constructor or runtime configuration.
+- **TypeScript support**: The published package ships typed exports for every validator and parser.
+- **Bare runtime export**: The package publishes a bare entrypoint in addition to the default module entrypoint.
+
+## Why this matters
+
+- Validate user input early and return machine-readable failure reasons before you attempt a transaction or resolution flow.
+- Normalize EIP-681 payment links into structured transfer data that wallet UIs can inspect before execution.
+- Reuse the same helpers across Node.js and Bare-based environments without adding a larger wallet module dependency.
+
+<table data-card-size="large" data-view="cards">
+  <thead>
+    <tr>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th data-hidden data-card-target data-type="content-ref"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <i class="fa-code">:code:</i>
+      </td>
+      <td>
+        <strong>WDK Utils Configuration</strong>
+      </td>
+      <td>Install the package, import the helpers, and review runtime notes.</td>
+      <td>
+        <a href="./configuration.md">configuration.md</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <i class="fa-mobile-alt">:mobile-alt:</i>
+      </td>
+      <td>
+        <strong>WDK Utils API Reference</strong>
+      </td>
+      <td>Review the exported validators, parsers, and result types.</td>
+      <td>
+        <a href="./api-reference.md">api-reference.md</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+***
+
+## Need Help?
+
+{% include "../.gitbook/includes/support-cards.md" %}

--- a/tools/wdk-utils/api-reference.md
+++ b/tools/wdk-utils/api-reference.md
@@ -1,0 +1,271 @@
+---
+title: WDK Utils API Reference
+description: API for @tetherto/wdk-utils
+icon: code
+---
+
+# API Reference
+
+## Package: `@tetherto/wdk-utils`
+
+### Address Validation Helpers
+
+| Function | Description | Returns |
+| --- | --- | --- |
+| `validateBase58(address)` | Validate a Base58Check Bitcoin address payload and version byte. | See details below. |
+| `validateBech32(address)` | Validate a SegWit v0 Bitcoin address. | `BtcAddressValidationResult` |
+| `validateBech32m(address)` | Validate a SegWit v1+ Bitcoin address. | `BtcAddressValidationResult` |
+| `validateBitcoinAddress(address)` | Validate a Bitcoin address across Base58Check, Bech32, and Bech32m formats. | `BtcAddressValidationResult` |
+| `validateEVMAddress(address)` | Validate an EVM address, including EIP-55 checksum rules for mixed-case inputs. | `EvmAddressValidationResult` |
+| `stripLightningPrefix(input)` | Remove a leading `lightning:` prefix before other Lightning validation steps. | `string` |
+| `validateLightningInvoice(address)` | Validate a Lightning invoice string. | `LightningInvoiceValidationResult` |
+| `validateLnurl(address)` | Validate an LNURL string. | `LnurlValidationResult` |
+| `validateLightningAddress(address)` | Validate a Lightning Address in `user@domain.tld` form. | `LightningAddressValidationResult` |
+| `validateSparkAddress(address)` | Validate a Spark address or a Bitcoin L1 deposit address accepted by Spark flows. | `SparkAddressValidationResult` |
+| `validateUmaAddress(address)` | Validate a Universal Money Address. | `UmaAddressValidationResult` |
+| `resolveUmaUsername(uma)` | Split a valid UMA string into `localPart`, `domain`, and `lightningAddress`. | Parsed UMA details or `null`. |
+
+#### `validateBase58(address)`
+
+Validate a Base58Check Bitcoin address and identify whether it matches a supported P2PKH or P2SH network version byte.
+
+The published `beta.2` type declaration currently includes an internal `{ decoded: Uint8Array }` branch in this return type. The shipped runtime returns validation results rather than exposing that intermediate decode object.
+
+{% code title="Validate A Base58 Bitcoin Address" lineNumbers="true" %}
+```javascript
+import { validateBase58 } from '@tetherto/wdk-utils'
+
+const result = validateBase58('18hnriom5tB5KtFb982m8f9cZz4i72PUpZ')
+```
+{% endcode %}
+
+#### `validateBech32(address)`
+
+Validate a SegWit v0 Bech32 Bitcoin address for supported network prefixes.
+
+{% code title="Validate A Bech32 Bitcoin Address" lineNumbers="true" %}
+```javascript
+import { validateBech32 } from '@tetherto/wdk-utils'
+
+const result = validateBech32('bc1qu9yqnhc6wjj6s62s9x0shnl5l2r7gq5cudm94r7mvwv0uw4s7acq0hn9g6')
+```
+{% endcode %}
+
+#### `validateBech32m(address)`
+
+Validate a SegWit v1+ Bech32m Bitcoin address for mainnet, testnet, or regtest.
+
+{% code title="Validate A Bech32m Bitcoin Address" lineNumbers="true" %}
+```javascript
+import { validateBech32m } from '@tetherto/wdk-utils'
+
+const result = validateBech32m('bc1pkf2alvh0q96nyf7yhw2w3x7etlw22sasn2kxu59xzzl2px7ga4asctyc2v')
+```
+{% endcode %}
+
+#### `validateBitcoinAddress(address)`
+
+Run the combined Bitcoin validator across Base58Check, Bech32, and Bech32m inputs.
+
+{% code title="Validate A Bitcoin Address" lineNumbers="true" %}
+```javascript
+import { validateBitcoinAddress } from '@tetherto/wdk-utils'
+
+const result = validateBitcoinAddress('tb1pu9yqnhc6wjj6s62s9x0shnl5l2r7gq5cudm94r7mvwv0uw4s7acqjg9r2f')
+```
+{% endcode %}
+
+`BtcAddressValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'p2pkh' | 'p2sh' | 'bech32' | 'bech32m', network: 'mainnet' | 'testnet' | 'regtest' }`
+- `{ success: false, reason: string }`
+
+#### `validateEVMAddress(address)`
+
+Validate an EVM address. Mixed-case inputs must satisfy EIP-55 checksum casing, while all-lowercase and all-uppercase inputs remain valid.
+
+{% code title="Validate An EVM Address" lineNumbers="true" %}
+```javascript
+import { validateEVMAddress } from '@tetherto/wdk-utils'
+
+const result = validateEVMAddress('0x742d35Cc6634C0532925a3b844Bc454e4438f44e')
+```
+{% endcode %}
+
+`EvmAddressValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'evm' }`
+- `{ success: false, reason: string }`
+
+#### `stripLightningPrefix(input)`
+
+Remove a `lightning:` URI prefix before validating or parsing Lightning inputs.
+
+{% code title="Strip A Lightning Prefix" lineNumbers="true" %}
+```javascript
+import { stripLightningPrefix } from '@tetherto/wdk-utils'
+
+const invoice = stripLightningPrefix(
+  'lightning:lnbc100u1p5m3k6fpp5uk9rs7fdrvssehzthphfjvpc3t5hyacgrveskwqzwclrdsl0cjgsdqydp5scqzzsxqrrssrzjqvgptfurj3528snx6e3dtwepafxw5fpzdymw9pj20jj09sunnqmwqqqqqyqqqqqqqqqqqqqqqqqqqqqqjqnp4qtem70et4qm86lv449zcpqjn9nmamd6qrzm3wa3d7msnq2kx3yapwsp50c4l2z72hcmejj88en6eu2p8u2ypv87pw5pndzjjtclwaw0f7wds9qyyssqtqeqrvaaw92y7at9463vxhwkjdy7lpxet7h6g4vry8xyw4ar9yn8qq36dryntpf252v58c4hrf4g59z2pr25lhp06n7x4z7yltd022cqk7lc7e'
+)
+```
+{% endcode %}
+
+#### `validateLightningInvoice(address)`
+
+Validate a Lightning invoice string after trimming input and removing any `lightning:` URI prefix.
+
+{% code title="Validate A Lightning Invoice" lineNumbers="true" %}
+```javascript
+import { validateLightningInvoice } from '@tetherto/wdk-utils'
+
+const result = validateLightningInvoice(
+  'lnbc100u1p5m3k6fpp5uk9rs7fdrvssehzthphfjvpc3t5hyacgrveskwqzwclrdsl0cjgsdqydp5scqzzsxqrrssrzjqvgptfurj3528snx6e3dtwepafxw5fpzdymw9pj20jj09sunnqmwqqqqqyqqqqqqqqqqqqqqqqqqqqqqjqnp4qtem70et4qm86lv449zcpqjn9nmamd6qrzm3wa3d7msnq2kx3yapwsp50c4l2z72hcmejj88en6eu2p8u2ypv87pw5pndzjjtclwaw0f7wds9qyyssqtqeqrvaaw92y7at9463vxhwkjdy7lpxet7h6g4vry8xyw4ar9yn8qq36dryntpf252v58c4hrf4g59z2pr25lhp06n7x4z7yltd022cqk7lc7e'
+)
+```
+{% endcode %}
+
+`LightningInvoiceValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice' }`
+- `{ success: false, reason: string }`
+
+#### `validateLnurl(address)`
+
+Validate an LNURL string that begins with `lnurl1`.
+
+{% code title="Validate An LNURL" lineNumbers="true" %}
+```javascript
+import { validateLnurl } from '@tetherto/wdk-utils'
+
+const result = validateLnurl(
+  'lnurl1dp68gurn8ghj7ampd3kx2ar0veekzar0wd5xjtnrdakj7tnhv4kxctttdehhwm30d3h82unvwqhhxurj093k7mtxdae8gwfjnztwnf'
+)
+```
+{% endcode %}
+
+`LnurlValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'lnurl' }`
+- `{ success: false, reason: string }`
+
+#### `validateLightningAddress(address)`
+
+Validate a Lightning Address in `user@domain.tld` form.
+
+{% code title="Validate A Lightning Address" lineNumbers="true" %}
+```javascript
+import { validateLightningAddress } from '@tetherto/wdk-utils'
+
+const result = validateLightningAddress('sprycomfort92@waletofsatoshi.com')
+```
+{% endcode %}
+
+`LightningAddressValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'address' }`
+- `{ success: false, reason: string }`
+
+#### `validateSparkAddress(address)`
+
+Validate a Spark address or a Bitcoin Bech32m deposit address accepted by Spark flows.
+
+{% code title="Validate A Spark Address" lineNumbers="true" %}
+```javascript
+import { validateSparkAddress } from '@tetherto/wdk-utils'
+
+const spark = validateSparkAddress(
+  'spark1pgss82uvuvyjggx72gl42qk3285yz0j6lgxw9uk2mvgajsr8w22nudv8w6hqs2'
+)
+const l1Deposit = validateSparkAddress(
+  'bc1p4lpn5nrunrjdk6teyjd2z53vmv82hlgjvv4pejkhg9wz5jq86zuqsruz85'
+)
+```
+{% endcode %}
+
+`SparkAddressValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'spark' | 'btc' }`
+- `{ success: false, reason: string }`
+
+#### `validateUmaAddress(address)`
+
+Validate a Universal Money Address in `$user@domain.tld` form.
+
+{% code title="Validate A UMA Address" lineNumbers="true" %}
+```javascript
+import { validateUmaAddress } from '@tetherto/wdk-utils'
+
+const result = validateUmaAddress('$you@uma.money')
+```
+{% endcode %}
+
+`UmaAddressValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'uma' }`
+- `{ success: false, reason: string }`
+
+#### `resolveUmaUsername(uma)`
+
+Resolve a valid UMA string into the local part, domain, and underlying Lightning Address.
+
+{% code title="Resolve A UMA Username" lineNumbers="true" %}
+```javascript
+import { resolveUmaUsername } from '@tetherto/wdk-utils'
+
+const result = resolveUmaUsername('$alice@wallet.com')
+```
+{% endcode %}
+
+### EIP-681 Request Parsing Helpers
+
+| Function | Description | Returns |
+| --- | --- | --- |
+| `isEip681Request(input)` | Detect whether a string has the shape of a supported EIP-681 request. | `boolean` |
+| `parseEip681Request(input)` | Parse a supported EIP-681 transfer request into structured transfer data. | `Eip681ParseResult` |
+
+#### `isEip681Request(input)`
+
+Detect whether a string looks like a supported EIP-681 transfer request before you attempt a full parse.
+
+{% code title="Detect An EIP-681 Request" lineNumbers="true" %}
+```javascript
+import { isEip681Request } from '@tetherto/wdk-utils'
+
+const looksLikeRequest = isEip681Request(
+  'polygon:0xc2132D05D31c914a87C6611C10748AEb04B58e8F@137/transfer?address=0xA9e338082A061d657014c08e652D96B38639F22a&value=1000000'
+)
+```
+{% endcode %}
+
+#### `parseEip681Request(input)`
+
+Parse a supported EIP-681 transfer request. The published runtime supports `transfer` requests, accepts `value` as an alias for `uint256`, and normalizes scientific-notation amounts into integer `amountSmallest` strings.
+
+{% code title="Parse An EIP-681 Request" lineNumbers="true" %}
+```javascript
+import { parseEip681Request } from '@tetherto/wdk-utils'
+
+const result = parseEip681Request(
+  'pol:0xc2132D05D31c914a87C6611C10748AEb04B58e8F@137/transfer?address=0xA9e338082A061d657014c08e652D96B38639F22a&uint256=0.175309000e6'
+)
+```
+{% endcode %}
+
+`Eip681ParseResult` is one of these shapes:
+
+- `{ success: true, type: 'eip681-transfer', value: Eip681TransferRequest }`
+- `{ success: false, reason: 'INVALID_FORMAT' | 'UNSUPPORTED_METHOD' | 'MISSING_REQUIRED_PARAM' | 'INVALID_RECIPIENT' | 'INVALID_AMOUNT' }`
+
+`Eip681TransferRequest` contains:
+
+- `recipient: string`
+- `tokenAddress: string`
+- `chainId: number`
+- `amountSmallest: string`
+
+***
+
+## Need Help?
+
+{% include "../../.gitbook/includes/support-cards.md" %}

--- a/tools/wdk-utils/configuration.md
+++ b/tools/wdk-utils/configuration.md
@@ -1,0 +1,94 @@
+---
+title: WDK Utils Configuration
+description: Install and import validation helpers and EIP-681 parsers from @tetherto/wdk-utils
+icon: gear
+---
+
+# WDK Utils Configuration
+
+This package does not have constructor options or runtime configuration. This page shows how to install `@tetherto/wdk-utils`, import the helpers you need, and understand the published runtime surface.
+
+## Install the package
+
+You can install `@tetherto/wdk-utils` from npm:
+
+{% code title="Install @tetherto/wdk-utils" lineNumbers="true" %}
+```bash
+npm install @tetherto/wdk-utils
+```
+{% endcode %}
+
+## Import address validation helpers
+
+You can import only the validators your flow needs from the package entrypoint:
+
+{% code title="Import Address Validators" lineNumbers="true" %}
+```javascript
+import {
+  validateBitcoinAddress,
+  validateEVMAddress,
+  validateLightningInvoice,
+  validateLnurl,
+  validateLightningAddress,
+  validateSparkAddress,
+  validateUmaAddress,
+  resolveUmaUsername
+} from '@tetherto/wdk-utils'
+```
+{% endcode %}
+
+## Import EIP-681 helpers
+
+You can detect and parse token transfer requests using the `beta.2` EIP-681 helpers:
+
+{% code title="Import EIP-681 Helpers" lineNumbers="true" %}
+```javascript
+import {
+  isEip681Request,
+  parseEip681Request
+} from '@tetherto/wdk-utils'
+```
+{% endcode %}
+
+## Runtime notes
+
+- `@tetherto/wdk-utils` exports plain functions. There is no client object to initialize.
+- The package publishes a default module entrypoint through `index.js` and a bare runtime entrypoint through `bare.js`.
+- `parseEip681Request()` currently supports transfer requests for the schemes implemented in the published runtime: `ethereum`, `pol`, `matic`, `polygon`, `arbitrum`, and `plasma`.
+- `parseEip681Request()` accepts both `uint256` and `value` query parameters for the amount field and normalizes the parsed amount into `amountSmallest`.
+
+## Examples
+
+You can validate common wallet inputs before handing them to a module:
+
+{% code title="Validate Common Inputs" lineNumbers="true" %}
+```javascript
+import {
+  validateBitcoinAddress,
+  validateLightningAddress,
+  validateUmaAddress
+} from '@tetherto/wdk-utils'
+
+const btc = validateBitcoinAddress('bc1qu9yqnhc6wjj6s62s9x0shnl5l2r7gq5cudm94r7mvwv0uw4s7acq0hn9g6')
+const lightning = validateLightningAddress('sprycomfort92@waletofsatoshi.com')
+const uma = validateUmaAddress('$you@uma.money')
+```
+{% endcode %}
+
+You can parse a request-shaped EIP-681 transfer string into structured data:
+
+{% code title="Parse An EIP-681 Transfer Request" lineNumbers="true" %}
+```javascript
+import { parseEip681Request } from '@tetherto/wdk-utils'
+
+const request = parseEip681Request(
+  'pol:0xc2132D05D31c914a87C6611C10748AEb04B58e8F@137/transfer?address=0xA9e338082A061d657014c08e652D96B38639F22a&uint256=0.175309000e6'
+)
+```
+{% endcode %}
+
+***
+
+## Need Help?
+
+{% include "../../.gitbook/includes/support-cards.md" %}

--- a/tools/worklet-bundler/README.md
+++ b/tools/worklet-bundler/README.md
@@ -1,0 +1,79 @@
+---
+title: Worklet Bundler
+description: CLI tool for generating WDK Bare worklet bundles
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: false
+  metadata:
+    visible: false
+---
+
+# Worklet Bundler
+
+Worklet Bundler packages selected WDK wallet and protocol modules into a Bare runtime bundle that runs outside your main React Native application thread. Powered by [`@tetherto/wdk-worklet-bundler`](https://github.com/tetherto/wdk-worklet-bundler).
+
+## Features
+
+- **Config-driven bundle generation**: Map logical network names to wallet packages and optional protocol names to protocol packages in `wdk.config.js`.
+- **Generated worklet artifact**: Produce a bundle for the Bare runtime plus generated TypeScript types for the host app.
+- **Dependency validation helpers**: Validate configured modules, detect the active package manager, and generate install or uninstall commands when dependencies are missing.
+- **CLI workflow**: Use `init`, `validate`, `generate`, `list-modules`, and `clean` without building your own wrapper.
+- **Bare suspend and resume handling**: `beta.3` generated entrypoints suspend and resume both the `bare-http1` and `bare-https` global agents when the Bare thread lifecycle changes.
+
+## Why this matters
+
+- Bundle generation keeps wallet and protocol code in a separate Bare worklet instead of the UI thread.
+- The generated type output gives the host app a stable import for the bundle surface.
+- The `beta.3` runtime fix reduces the chance that HTTPS-backed worklet fetches keep running after a Bare thread suspension.
+
+<table data-card-size="large" data-view="cards">
+  <thead>
+    <tr>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th data-hidden data-card-target data-type="content-ref"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <i class="fa-code">:code:</i>
+      </td>
+      <td>
+        <strong>Worklet Bundler Configuration</strong>
+      </td>
+      <td>Set up `wdk.config.js`, review defaults, and understand the generated runtime behavior.</td>
+      <td>
+        <a href="./configuration.md">configuration.md</a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <i class="fa-mobile-alt">:mobile-alt:</i>
+      </td>
+      <td>
+        <strong>Worklet Bundler API Reference</strong>
+      </td>
+      <td>Review the exported config types, dependency helpers, and bundle-generation functions.</td>
+      <td>
+        <a href="./api-reference.md">api-reference.md</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+***
+
+## Need Help?
+
+{% include "../.gitbook/includes/support-cards.md" %}

--- a/tools/worklet-bundler/api-reference.md
+++ b/tools/worklet-bundler/api-reference.md
@@ -1,0 +1,209 @@
+---
+title: Worklet Bundler API Reference
+description: API for @tetherto/wdk-worklet-bundler
+icon: code
+---
+
+# API Reference
+
+## Package: `@tetherto/wdk-worklet-bundler`
+
+### Configuration Types
+
+#### `WdkBundleConfig`
+
+`WdkBundleConfig` is the public configuration shape for `wdk.config.js`.
+
+{% code title="WdkBundleConfig Shape" lineNumbers="true" %}
+```typescript
+interface WdkBundleConfig {
+  networks: Record<string, { package: string }>
+  protocols?: Record<string, { package: string; [key: string]: any }>
+  preloadModules?: string[]
+  output?: {
+    bundle?: string
+    types?: string
+  }
+  options?: {
+    minify?: boolean
+    sourceMaps?: boolean
+    targets?: string[]
+  }
+}
+```
+{% endcode %}
+
+#### `ResolvedConfig`
+
+`ResolvedConfig` extends `WdkBundleConfig` with absolute filesystem paths produced by `loadConfig()`.
+
+{% code title="ResolvedConfig Additions" lineNumbers="true" %}
+```typescript
+interface ResolvedConfig extends WdkBundleConfig {
+  configPath: string
+  projectRoot: string
+  resolvedOutput: {
+    bundle: string
+    types: string
+  }
+}
+```
+{% endcode %}
+
+### Dependency Helpers
+
+| Function | Description | Returns |
+| --- | --- | --- |
+| `validateDependencies(modules, projectRoot)` | Resolve configured packages and report which modules are installed or missing. | `ValidationResult` |
+| `detectPackageManager(projectRoot)` | Detect whether the project uses `npm`, `yarn`, or `pnpm`. | `'npm'`, `'yarn'`, or `'pnpm'` |
+| `generateInstallCommand(missing, packageManager?)` | Build the command string used to install missing dependencies. | `string` |
+| `installDependencies(missing, projectRoot, options?)` | Install missing dependencies with the detected or selected package manager. | `InstallResult` |
+| `generateUninstallCommand(packages, packageManager?)` | Build the command string used to remove packages. | `string` |
+| `uninstallDependencies(packages, projectRoot, options?)` | Remove packages with the detected or selected package manager. | `UninstallResult` |
+
+#### `validateDependencies(modules, projectRoot)`
+
+Use this helper to confirm that the packages listed in `wdk.config.js` are already resolvable from the host project.
+
+{% code title="Validate Missing Dependencies" lineNumbers="true" %}
+```typescript
+import { validateDependencies } from '@tetherto/wdk-worklet-bundler'
+
+const result = validateDependencies(
+  ['@tetherto/wdk-wallet-btc', '@tetherto/pear-wrk-wdk'],
+  process.cwd()
+)
+```
+{% endcode %}
+
+`ValidationResult` contains:
+
+- `valid` (`boolean`)
+- `installed` (`ModuleInfo[]`)
+- `missing` (`string[]`)
+
+#### `detectPackageManager(projectRoot)`
+
+Use this helper when you need the same package-manager detection logic that the CLI uses before install or uninstall flows.
+
+{% code title="Detect The Package Manager" lineNumbers="true" %}
+```typescript
+import { detectPackageManager } from '@tetherto/wdk-worklet-bundler'
+
+const packageManager = detectPackageManager(process.cwd())
+```
+{% endcode %}
+
+#### `generateInstallCommand(missing, packageManager?)`
+
+Build the install command string without mutating the project:
+
+{% code title="Generate An Install Command" lineNumbers="true" %}
+```typescript
+import { generateInstallCommand } from '@tetherto/wdk-worklet-bundler'
+
+const command = generateInstallCommand(
+  ['@tetherto/wdk-wallet-btc', '@tetherto/pear-wrk-wdk'],
+  'npm'
+)
+```
+{% endcode %}
+
+#### `installDependencies(missing, projectRoot, options?)`
+
+Run the install flow from code when you want the same dependency installation behavior as `generate --install`.
+
+#### `generateUninstallCommand(packages, packageManager?)`
+
+Build the uninstall command string without mutating the project.
+
+#### `uninstallDependencies(packages, projectRoot, options?)`
+
+Run the uninstall flow from code and receive a structured `UninstallResult`.
+
+### Bundle Generation
+
+| Function | Description | Returns |
+| --- | --- | --- |
+| `loadConfig(configPath?)` | Load, validate, and resolve a `wdk.config.js` file into absolute paths. | `Promise<ResolvedConfig>` |
+| `generateBundle(config, options?)` | Generate the entrypoint, imports, bundle, and optional type output. | `Promise<GenerateBundleResult>` |
+| `generateSourceFiles(config, options?)` | Generate the source entrypoint and related artifacts without bundling. | `Promise<{ entryPath: string }>` |
+| `generateEntryPoint(config, outputDir)` | Generate only the Bare worklet entrypoint file. | `Promise<string>` |
+| `generateWalletModulesCode(config)` | Generate the wallet-module section inserted into the entrypoint. | `string` |
+
+#### `loadConfig(configPath?)`
+
+`loadConfig()` searches for `wdk.config.js` when no explicit path is supplied, validates the public config shape, and resolves the output paths relative to the config file directory.
+
+{% code title="Load The Resolved Config" lineNumbers="true" %}
+```typescript
+import { loadConfig } from '@tetherto/wdk-worklet-bundler'
+
+const config = await loadConfig()
+```
+{% endcode %}
+
+#### `generateBundle(config, options?)`
+
+Use `generateBundle()` when you want the same bundle workflow that powers the CLI `generate` command.
+
+`GenerateBundleOptions` supports:
+
+- `dryRun`
+- `verbose`
+- `silent`
+- `skipTypes`
+- `skipGeneration`
+
+`GenerateBundleResult` contains:
+
+- `success`
+- `bundlePath`
+- `typesPath`
+- `bundleSize`
+- `duration`
+- `error?`
+- `missingModule?`
+
+{% code title="Generate A Bundle Programmatically" lineNumbers="true" %}
+```typescript
+import { generateBundle, loadConfig } from '@tetherto/wdk-worklet-bundler'
+
+const config = await loadConfig('./wdk.config.js')
+const result = await generateBundle(config, { verbose: true })
+```
+{% endcode %}
+
+#### `generateSourceFiles(config, options?)`
+
+Use `generateSourceFiles()` when you want the generated entrypoint without the final `bare-pack` step.
+
+#### `generateEntryPoint(config, outputDir)`
+
+Use `generateEntryPoint()` when you need the exact generated Bare entrypoint string written to a chosen output directory.
+
+In `beta.3`, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`.
+
+#### `generateWalletModulesCode(config)`
+
+Use `generateWalletModulesCode()` when you only need the generated wallet-module section for inspection or custom generator flows.
+
+### CLI Commands
+
+The published CLI exposes these commands through `wdk-worklet-bundler`:
+
+| Command | Description | Key Options |
+| --- | --- | --- |
+| `generate` | Generate a WDK bundle from configuration. | `--config`, `--install`, `--keep-artifacts`, `--dry-run`, `--no-types`, `--source-only`, `--skip-generation`, `--verbose` |
+| `init` | Create a new `wdk.config.js` file. | `--yes` |
+| `validate` | Validate configuration without building. | `--config` |
+| `list-modules` | List available WDK modules. | `--json` |
+| `clean` | Remove the generated `.wdk` folder. | `--yes` |
+
+For the end-to-end config workflow, see [Worklet Bundler Configuration](./configuration.md).
+
+***
+
+## Need Help?
+
+{% include "../../.gitbook/includes/support-cards.md" %}

--- a/tools/worklet-bundler/configuration.md
+++ b/tools/worklet-bundler/configuration.md
@@ -1,0 +1,147 @@
+---
+title: Worklet Bundler Configuration
+description: Configure wdk.config.js and generate Bare worklet bundles with @tetherto/wdk-worklet-bundler
+icon: gear
+---
+
+# Worklet Bundler Configuration
+
+This page shows how to install `@tetherto/wdk-worklet-bundler`, shape `wdk.config.js`, and generate a Bare worklet bundle for your WDK modules.
+
+## Install the package
+
+Install the bundler as a development dependency in the host project:
+
+{% code title="Install @tetherto/wdk-worklet-bundler" lineNumbers="true" %}
+```bash
+npm install --save-dev @tetherto/wdk-worklet-bundler
+```
+{% endcode %}
+
+## Create `wdk.config.js`
+
+Use `init` to create a starter config, or write the file yourself:
+
+{% code title="Initialize A Starter Config" lineNumbers="true" %}
+```bash
+npx wdk-worklet-bundler init
+```
+{% endcode %}
+
+The published config surface accepts `networks`, optional `protocols`, optional `preloadModules`, optional `output`, and optional `options`:
+
+{% code title="Example wdk.config.js" lineNumbers="true" %}
+```javascript
+module.exports = {
+  networks: {
+    ethereum: {
+      package: '@tetherto/wdk-wallet-evm-erc-4337'
+    },
+    bitcoin: {
+      package: '@tetherto/wdk-wallet-btc'
+    }
+  },
+
+  protocols: {
+    moonpay: {
+      package: '@tetherto/wdk-protocol-fiat-moonpay'
+    }
+  },
+
+  preloadModules: [
+    'spark-frost-bare-addon'
+  ],
+
+  output: {
+    bundle: './.wdk-bundle/wdk-worklet.bundle.js',
+    types: './.wdk/index.d.ts'
+  },
+
+  options: {
+    minify: false,
+    sourceMaps: false,
+    targets: ['ios-arm64', 'android-arm64']
+  }
+}
+```
+{% endcode %}
+
+## Required fields
+
+### `networks`
+
+`networks` is required. Each key is a logical network name, and each value must provide a `package` string for the wallet module to bundle.
+
+The loader also accepts local paths that resolve relative to the config file’s directory:
+
+{% code title="Use A Local Wallet Package" lineNumbers="true" %}
+```javascript
+module.exports = {
+  networks: {
+    local_dev: {
+      package: './local-packages/my-custom-wallet'
+    }
+  }
+}
+```
+{% endcode %}
+
+## Optional fields
+
+### `protocols` (optional)
+
+Use `protocols` when the worklet should preload WDK protocol packages alongside wallet modules.
+
+### `preloadModules` (optional)
+
+Use `preloadModules` for native addons or other modules that must be required before the generated worklet starts.
+
+### `output` (optional)
+
+If you omit `output.bundle`, the loader resolves the bundle path to `./.wdk-bundle/wdk-worklet.bundle.js`. If you omit `output.types`, the loader resolves the type path to `./.wdk/index.d.ts`.
+
+### `options` (optional)
+
+The published config type supports these build options:
+
+- `minify` (`boolean`): Minify the generated bundle.
+- `sourceMaps` (`boolean`): Request source map output.
+- `targets` (`string[]`): Override the default Bare build hosts. The shipped defaults cover iOS arm64 and simulator targets plus Android arm, arm64, ia32, and x64 hosts.
+
+## Validate and generate the bundle
+
+Use `validate` to check the config and dependency resolution before you generate the bundle:
+
+{% code title="Validate wdk.config.js" lineNumbers="true" %}
+```bash
+npx wdk-worklet-bundler validate
+```
+{% endcode %}
+
+Use `generate` to build the worklet artifact:
+
+{% code title="Generate The Worklet Bundle" lineNumbers="true" %}
+```bash
+npx wdk-worklet-bundler generate --install
+```
+{% endcode %}
+
+`generate --install` can auto-install missing configured modules after the package manager is detected from the project root. Use `--source-only` when you want the generated `.wdk/wdk-worklet.generated.js` entrypoint and related artifacts without running `bare-pack`.
+
+## Suspend and resume behavior
+
+Generated `beta.3` worklet entrypoints register Bare lifecycle handlers for `suspend` and `resume`, then apply those handlers to both the `bare-http1` and `bare-https` global agents. No config flag is required for this behavior.
+
+This matters when a generated worklet performs HTTPS-backed fetches. In `beta.2`, only the `bare-http1` agent was suspended and resumed. In `beta.3`, generated worklets suspend and resume both agents together.
+
+## Troubleshooting
+
+- If `loadConfig()` cannot find a config file, run `npx wdk-worklet-bundler init` or pass `--config <path>`.
+- If `validate` or `generate` reports missing modules, use `generate --install` or inspect the install command from the exported helper APIs in the [API Reference](./api-reference.md).
+- If you need to inspect generated source before bundling, use `generate --source-only` and review the files in `.wdk/`.
+
+***
+
+## Need Help?
+
+{% include "../../.gitbook/includes/support-cards.md" %}


### PR DESCRIPTION
## Summary

This PR documents the April 13-14, 2026 WDK releases across the SDK, wallet modules, fiat integrations, and tooling docs. It also updates the changelog with release-dated entries and adds navigation for the new tool documentation pages.

## Deliverables

- Documented `@tetherto/wdk` selective wallet disposal in the core module docs.
- Updated `wallet-btc` docs for unconfirmed balance visibility and the optional `timeoutMs` polling argument on `sendTransaction()`.
- Updated `wallet-spark` docs for SparkScan-backed `getBalance()`, `syncAndRetry`, and `syncWalletBalance()` across configuration, guides, and API reference.
- Documented the breaking `fiat-moonpay` move from `secretKey` signing to optional backend `signUrl`, plus `environment` support and unsigned URL fallback.
- Added new tool documentation sections for Failover Provider, Pear Worklet WDK, WDK Utils, and Worklet Bundler.
- Added changelog coverage for release-note-only items where the docs surface did not need module-page changes.

## Releases Covered

- [@tetherto/wdk v1.0.0-beta.7](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.7)
- [@tetherto/wdk-wallet-btc v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.8)
- [@tetherto/wdk-wallet-spark v1.0.0-beta.13](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.13)
- [@tetherto/wdk-wallet-spark v1.0.0-beta.14](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.14)
- [@tetherto/wdk-wallet-spark v1.0.0-beta.15](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.15)
- [@tetherto/wdk-wallet-spark v1.0.0-beta.16](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.16)
- [@tetherto/wdk-wallet-evm v1.0.0-beta.11](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.11)
- [@tetherto/wdk-wallet-evm-erc-4337 v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.6)
- [@tetherto/wdk-protocol-fiat-moonpay v1.0.0-beta.2](https://github.com/tetherto/wdk-protocol-fiat-moonpay/releases/tag/v1.0.0-beta.2)
- [@tetherto/wdk-utils v1.0.0-beta.2](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.2)
- [@tetherto/pear-wrk-wdk v1.0.0-beta.8](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.8)
- [@tetherto/wdk-worklet-bundler v1.0.0-beta.3](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.3)
- [@tetherto/wdk-failover-provider v1.0.0-beta.1](https://github.com/tetherto/wdk-failover-provider/releases/tag/v1.0.0-beta.1)

## Validation

- Reconciled the docs changes against the current `develop` branch structure before publishing.
- Ran `git diff --check` on the final diff.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214077822848453