### PR TITLE
docs: document wdk-wallet-solana beta.6-beta.7 release changes

### DIFF
--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### April 19, 2026
+
+**Fixes**
+- **wallet-solana** ([v1.0.0-beta.7](https://www.npmjs.com/package/@tetherto/wdk-wallet-solana/v/1.0.0-beta.7)): Fix `SolanaWalletConfig.rpcUrl` typings to accept ordered `string[]` failover endpoints and align the published TypeScript definitions with the beta.6 runtime behavior.
+
+---
+
 ### April 15, 2026
 
 **Changes**

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### April 15, 2026
+
+**Changes**
+- **wallet-solana** ([v1.0.0-beta.6](https://www.npmjs.com/package/@tetherto/wdk-wallet-solana/v/1.0.0-beta.6)): Add runtime RPC failover support for ordered `rpcUrl` lists plus `retries`, and tighten custom `TransactionMessage` and derivation-path validation for durable nonce lifetimes, fee payer matching, and hardened SLIP-0010 child paths.
+
+---
+
 ### April 14, 2026
 
 **What's New**

--- a/sdk/wallet-modules/wallet-solana/README.md
+++ b/sdk/wallet-modules/wallet-solana/README.md
@@ -19,7 +19,7 @@ layout:
 
 # @tetherto/wdk-wallet-solana Overview
 
-A simple and secure package to manage BIP-44 wallets for the Solana blockchain. This package provides a clean API for creating, managing, and interacting with Solana wallets using BIP-39 seed phrases and Solana-specific derivation paths.
+A simple and secure package to manage SLIP-0010 wallets for the Solana blockchain. This package provides a clean API for creating, managing, and interacting with Solana wallets using BIP-39 seed phrases and Solana-specific derivation paths.
 
 {% hint style="warning" %}
 
@@ -32,14 +32,14 @@ The default derivation path was updated in v1.0.0-beta.4 to match ecosystem conv
 
 If you're upgrading from an earlier version, existing wallets created with the old path will generate different addresses. Make sure to migrate any existing wallets or use the old path explicitly if needed for compatibility.
 
-Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets.
+Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets. On Solana, every child segment in a custom path must be hardened.
 
 {% endhint %}
 
 ## Features
 
 - **BIP-39 Seed Phrase Support**: Generate and validate BIP-39 mnemonic seed phrases
-- **Solana Derivation Paths**: Support for BIP-44 standard derivation paths for Solana (m/44'/501')
+- **Solana Derivation Paths**: Support for SLIP-0010 derivation paths for Solana (m/44'/501')
 - **Multi-Account Management**: Create and manage multiple accounts from a single seed phrase
 - **Solana Address Support**: Generate and manage Solana public keys and addresses
 - **Message Signing**: Sign and verify messages using Ed25519 cryptography
@@ -47,7 +47,8 @@ Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) to supply an e
 - **SPL Token Support**: Query native SOL and SPL token balances
 - **TypeScript Support**: Full TypeScript definitions included
 - **Memory Safety**: Secure private key management with memory-safe implementation
-- **Provider Flexibility**: Support for custom Solana RPC endpoints
+- **Provider Flexibility**: Support for a single Solana RPC endpoint, plus runtime failover support for ordered RPC URL lists
+- **Transaction Message Support**: Quote or send prebuilt `TransactionMessage` flows with recent blockhash or durable nonce lifetimes
 - **Fee Estimation**: Dynamic fee calculation with recent blockhash
 - **Program Interaction**: Support for interacting with Solana programs
 

--- a/sdk/wallet-modules/wallet-solana/api-reference.md
+++ b/sdk/wallet-modules/wallet-solana/api-reference.md
@@ -42,7 +42,7 @@ new WalletManagerSolana(seed, config)
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (object): Configuration object
-  - `rpcUrl` (string): RPC endpoint URL. At runtime, `v1.0.0-beta.6` also accepts an ordered list of endpoints for failover, but the published TypeScript definition still narrows this field to `string`.
+  - `rpcUrl` (string | string[]): RPC endpoint URL or an ordered list of endpoints for failover
   - `commitment` (string, optional): Commitment level ('processed', 'confirmed', or 'finalized')
   - `retries` (number, optional): Retry count for failover requests (default: 3)
   - `transferMaxFee` (number, optional): Maximum fee amount for transfer operations (in lamports)
@@ -457,14 +457,12 @@ console.log('Transfer fee estimate:', quote.fee, 'lamports')
 
 ```typescript
 interface SolanaWalletConfig {
-  rpcUrl?: string;
+  rpcUrl?: string | string[];
   commitment?: 'processed' | 'confirmed' | 'finalized';
   retries?: number;
   transferMaxFee?: number | bigint;
 }
 ```
-
-At runtime, `v1.0.0-beta.6` also accepts `rpcUrl: string[]` to enable failover across multiple Solana RPC providers. The published TypeScript definition above has not caught up yet.
 
 ### TransferOptions
 

--- a/sdk/wallet-modules/wallet-solana/api-reference.md
+++ b/sdk/wallet-modules/wallet-solana/api-reference.md
@@ -42,8 +42,9 @@ new WalletManagerSolana(seed, config)
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (object): Configuration object
-  - `rpcUrl` (string | Connection): RPC endpoint URL or Solana Connection instance
+  - `rpcUrl` (string): RPC endpoint URL. At runtime, `v1.0.0-beta.6` also accepts an ordered list of endpoints for failover, but the published TypeScript definition still narrows this field to `string`.
   - `commitment` (string, optional): Commitment level ('processed', 'confirmed', or 'finalized')
+  - `retries` (number, optional): Retry count for failover requests (default: 3)
   - `transferMaxFee` (number, optional): Maximum fee amount for transfer operations (in lamports)
 
 **Example:**
@@ -60,7 +61,7 @@ const wallet = new WalletManagerSolana(seedPhrase, {
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getAccount(index)` | Returns a wallet account at the specified index | `Promise<WalletAccountSolana>` |
-| `getAccountByPath(path)` | Returns a wallet account at the specified BIP-44 derivation path | `Promise<WalletAccountSolana>` |
+| `getAccountByPath(path)` | Returns a wallet account at the specified SLIP-0010 derivation path | `Promise<WalletAccountSolana>` |
 | `getFeeRates()` | Returns current fee rates for transactions | `Promise<{normal: bigint, fast: bigint}>` |
 | `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` |
 
@@ -78,16 +79,16 @@ const account = await wallet.getAccount(0)
 ```
 
 ##### `getAccountByPath(path)`
-Returns a wallet account at the specified BIP-44 derivation path.
+Returns a wallet account at the specified SLIP-0010 derivation path.
 
 **Parameters:**
-- `path` (string): The derivation path (e.g., "0'/0/0")
+- `path` (string): The derivation path (e.g., "0'/0'/0'"). On Solana, every child segment must be hardened.
 
 **Returns:** `Promise<WalletAccountSolana>` - The wallet account
 
 **Example:**
 ```javascript
-const account = await wallet.getAccountByPath("0'/0/1")
+const account = await wallet.getAccountByPath("0'/0'/1'")
 ```
 
 ##### `getFeeRates()`
@@ -124,7 +125,7 @@ new WalletAccountSolana(seed, path, config)
 
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
-- `path` (string): BIP-44 derivation path (e.g., "0'/0/0")
+- `path` (string): SLIP-0010 derivation path (e.g., "0'/0'/0'")
 - `config` (SolanaWalletConfig, optional): Configuration object
 
 #### Methods
@@ -189,9 +190,11 @@ console.log('Signature valid:', isValid)
 Sends a Solana transaction.
 
 **Parameters:**
-- `tx` (SolanaTransaction): The transaction object
+- `tx` (SolanaTransaction): A simple transfer object or a prebuilt `TransactionMessage`
   - `to` (string): Recipient's Solana address (base58-encoded)
-  - `value` (number): Amount in lamports
+  - `value` (number | bigint): Amount in lamports
+
+When `tx` is a `TransactionMessage`, WDK preserves an existing recent blockhash or durable nonce lifetime. If no lifetime is present, WDK fetches the latest blockhash before quoting or sending. If you set an explicit `feePayer`, it must match the wallet address.
 
 **Returns:** `Promise<{hash: string, fee: bigint}>` - Object containing transaction hash and fee (in lamports)
 
@@ -210,7 +213,7 @@ console.log('Transaction fee:', result.fee, 'lamports')
 Estimates the fee for a Solana transaction.
 
 **Parameters:**
-- `tx` (SolanaTransaction): The transaction object (same as sendTransaction)
+- `tx` (SolanaTransaction): The transaction object (same as `sendTransaction`)
 
 **Returns:** `Promise<{fee: bigint}>` - Object containing fee estimate (in lamports)
 
@@ -230,7 +233,7 @@ Transfers SPL tokens to another address.
 - `options` (TransferOptions): Transfer options
   - `token` (string): Token mint address (base58-encoded)
   - `recipient` (string): Recipient's Solana address (base58-encoded)
-  - `amount` (number): Amount in token's base units
+  - `amount` (number | bigint): Amount in token's base units
 
 **Returns:** `Promise<{hash: string, fee: bigint}>` - Object containing transaction hash and fee (in lamports)
 
@@ -450,13 +453,26 @@ console.log('Transfer fee estimate:', quote.fee, 'lamports')
 
 ## Types
 
+### SolanaWalletConfig
+
+```typescript
+interface SolanaWalletConfig {
+  rpcUrl?: string;
+  commitment?: 'processed' | 'confirmed' | 'finalized';
+  retries?: number;
+  transferMaxFee?: number | bigint;
+}
+```
+
+At runtime, `v1.0.0-beta.6` also accepts `rpcUrl: string[]` to enable failover across multiple Solana RPC providers. The published TypeScript definition above has not caught up yet.
+
 ### TransferOptions
 
 ```typescript
 interface TransferOptions {
   token: string;
   recipient: string;
-  amount: number;
+  amount: number | bigint;
 }
 ```
 

--- a/sdk/wallet-modules/wallet-solana/configuration.md
+++ b/sdk/wallet-modules/wallet-solana/configuration.md
@@ -53,22 +53,22 @@ const wallet = new WalletManagerSolana(seedPhrase, accountConfig)
 const account = await wallet.getAccount(0)
 
 // Or get account by custom derivation path
-const customAccount = await wallet.getAccountByPath("0'/0/5")
+const customAccount = await wallet.getAccountByPath("0'/0'/5'")
 ```
 
 ## Configuration Options
 
 ### rpcUrl
 
-The `rpcUrl` option specifies the Solana RPC endpoint for blockchain interactions.
+The `rpcUrl` option specifies one Solana RPC endpoint for blockchain interactions. At runtime, `v1.0.0-beta.6` also accepts an ordered list of endpoints to enable provider failover.
 
-**Type:** `string` (optional)
+**Type:** `string` in the published TypeScript definition (optional)
 
 **Default:** If not provided, wallet functionality that requires RPC will throw an error
 
 **Examples:**
 ```javascript
-// Mainnet
+// Single endpoint
 const config = {
   rpcUrl: 'https://api.mainnet-beta.solana.com'
 }
@@ -78,9 +78,42 @@ const config = {
   rpcUrl: 'https://api.devnet.solana.com'
 }
 
+// Failover across multiple endpoints
+const config = {
+  rpcUrl: [
+    'https://api.mainnet-beta.solana.com',
+    'https://rpc.ankr.com/solana'
+  ]
+}
+
 // Custom RPC
 const config = {
   rpcUrl: 'https://your-custom-rpc-endpoint.com'
+}
+```
+
+When `rpcUrl` is an array, WDK initializes a failover provider and tries the next RPC when the current provider fails.
+
+{% hint style="info" %}
+In `v1.0.0-beta.6`, the runtime accepts `rpcUrl: string[]` for failover, but the published TypeScript definition still narrows `rpcUrl` to `string`. If you're using TypeScript, cast the config or wrap it until the typings catch up.
+{% endhint %}
+
+### retries
+
+The `retries` option controls how many times the failover provider retries a request before moving on to the next RPC entry.
+
+**Type:** `number` (optional)
+
+**Default:** `3`
+
+**Example:**
+```javascript
+const config = {
+  rpcUrl: [
+    'https://api.mainnet-beta.solana.com',
+    'https://rpc.ankr.com/solana'
+  ],
+  retries: 5
 }
 ```
 
@@ -131,9 +164,10 @@ const wallet = new WalletManagerSolana(seedPhrase, config)
 
 ## Derivation Paths
 
-Solana wallets use BIP-44 standard derivation paths. The default derivation path follows ecosystem conventions:
+Solana wallets use SLIP-0010 derivation paths. The default derivation path follows ecosystem conventions:
 
 - Default path: `m/44'/501'/{index}'/0'` (where `{index}` is the account index)
+- Custom child paths must keep every segment hardened, for example `0'/0'/5'`
 
 {% hint style="warning" %}
 
@@ -153,6 +187,7 @@ Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) to supply an e
 ## Security Considerations
 
 - Always use HTTPS URLs for RPC endpoints
+- Use RPC endpoints that serve the same Solana network when enabling failover
 - Set appropriate `transferMaxFee` limits for your use case
 - Consider using environment variables for configuration in production
 - Use trusted RPC providers or run your own Solana validator for production applications
@@ -224,5 +259,3 @@ Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) to supply an e
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
-

--- a/sdk/wallet-modules/wallet-solana/configuration.md
+++ b/sdk/wallet-modules/wallet-solana/configuration.md
@@ -60,9 +60,9 @@ const customAccount = await wallet.getAccountByPath("0'/0'/5'")
 
 ### rpcUrl
 
-The `rpcUrl` option specifies one Solana RPC endpoint for blockchain interactions. At runtime, `v1.0.0-beta.6` also accepts an ordered list of endpoints to enable provider failover.
+The `rpcUrl` option specifies one Solana RPC endpoint or an ordered list of endpoints for blockchain interactions.
 
-**Type:** `string` in the published TypeScript definition (optional)
+**Type:** `string | string[]` (optional)
 
 **Default:** If not provided, wallet functionality that requires RPC will throw an error
 
@@ -93,10 +93,6 @@ const config = {
 ```
 
 When `rpcUrl` is an array, WDK initializes a failover provider and tries the next RPC when the current provider fails.
-
-{% hint style="info" %}
-In `v1.0.0-beta.6`, the runtime accepts `rpcUrl: string[]` for failover, but the published TypeScript definition still narrows `rpcUrl` to `string`. If you're using TypeScript, cast the config or wrap it until the typings catch up.
-{% endhint %}
 
 ### retries
 

--- a/sdk/wallet-modules/wallet-solana/guides/account-management.md
+++ b/sdk/wallet-modules/wallet-solana/guides/account-management.md
@@ -43,14 +43,14 @@ Use [`getAccountByPath()`](/sdk/wallet-modules/wallet-solana/api-reference#getac
 
 {% code title="Custom Derivation Path" lineNumbers="true" %}
 ```javascript
-const customAccount = await wallet.getAccountByPath("0'/0/5")
+const customAccount = await wallet.getAccountByPath("0'/0'/5'")
 const customAddress = await customAccount.getAddress()
 console.log('Custom account address:', customAddress)
 ```
 {% endcode %}
 
 {% hint style="info" %}
-All addresses are base58-encoded Solana public keys. All accounts inherit the provider configuration from the wallet manager.
+Solana uses SLIP-0010 derivation paths. Every child segment in a custom path must be hardened, for example `0'/0'/5'`. All accounts inherit the provider configuration from the wallet manager.
 {% endhint %}
 
 ## Iterate Over Multiple Accounts

--- a/sdk/wallet-modules/wallet-solana/guides/error-handling.md
+++ b/sdk/wallet-modules/wallet-solana/guides/error-handling.md
@@ -61,13 +61,13 @@ async function safeTransfer(account, wallet) {
     }
 
     const quote = await account.quoteSendTransaction({
-      recipient: '11111111111111111111111111111112',
+      to: '11111111111111111111111111111112',
       value: transferAmount
     })
     console.log('Estimated fee:', quote.fee, 'lamports')
 
     const result = await account.sendTransaction({
-      recipient: '11111111111111111111111111111112',
+      to: '11111111111111111111111111111112',
       value: transferAmount
     })
     console.log('Transaction successful:', result.hash)
@@ -91,6 +91,14 @@ async function safeTransfer(account, wallet) {
 }
 ```
 {% endcode %}
+
+## Handle Prebuilt TransactionMessage Errors
+
+If you pass a prebuilt `TransactionMessage`, make sure it already has a recent blockhash or durable nonce lifetime, or let WDK inject the latest blockhash for you. If you set `feePayer`, it must match the wallet address.
+
+{% hint style="info" %}
+Durable nonce flows still need a valid nonce account and signer setup in the message you provide. WDK preserves that lifetime instead of replacing it.
+{% endhint %}
 
 ## Manage Fee Limits
 

--- a/sdk/wallet-modules/wallet-solana/guides/getting-started.md
+++ b/sdk/wallet-modules/wallet-solana/guides/getting-started.md
@@ -59,7 +59,7 @@ const wallet = new WalletManagerSolana(seedPhrase, {
 {% endcode %}
 
 {% hint style="info" %}
-To enable RPC failover, pass `rpcUrl` as an ordered array of endpoints and set `retries` to control how many times WDK retries each provider before moving to the next one. In `v1.0.0-beta.6`, the runtime supports this, but the published TypeScript definition still narrows `rpcUrl` to `string`.
+To enable RPC failover, pass `rpcUrl` as an ordered array of endpoints and set `retries` to control how many times WDK retries each provider before moving to the next one.
 {% endhint %}
 
 {% hint style="danger" %}

--- a/sdk/wallet-modules/wallet-solana/guides/getting-started.md
+++ b/sdk/wallet-modules/wallet-solana/guides/getting-started.md
@@ -58,6 +58,10 @@ const wallet = new WalletManagerSolana(seedPhrase, {
 ```
 {% endcode %}
 
+{% hint style="info" %}
+To enable RPC failover, pass `rpcUrl` as an ordered array of endpoints and set `retries` to control how many times WDK retries each provider before moving to the next one. In `v1.0.0-beta.6`, the runtime supports this, but the published TypeScript definition still narrows `rpcUrl` to `string`.
+{% endhint %}
+
 {% hint style="danger" %}
 **Secure the Seed Phrase:** You must securely store this seed phrase immediately. If it is lost, the user will permanently lose access to their funds.
 {% endhint %}

--- a/sdk/wallet-modules/wallet-solana/guides/send-transactions.md
+++ b/sdk/wallet-modules/wallet-solana/guides/send-transactions.md
@@ -36,9 +36,8 @@ Use [`account.sendTransaction()`](/sdk/wallet-modules/wallet-solana/api-referenc
 {% code title="Send SOL" lineNumbers="true" %}
 ```javascript
 const result = await account.sendTransaction({
-  recipient: 'publicKey', // Recipient's base58-encoded public key
-  value: 1000000000n, // 1 SOL in lamports
-  commitment: 'confirmed' // Optional: commitment level
+  to: 'publicKey', // Recipient's base58-encoded public key
+  value: 1000000000n // 1 SOL in lamports
 })
 console.log('Transaction hash:', result.hash)
 console.log('Transaction fee:', result.fee, 'lamports')
@@ -52,10 +51,28 @@ Use [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-solana/api-ref
 {% code title="Quote Transaction Fee" lineNumbers="true" %}
 ```javascript
 const quote = await account.quoteSendTransaction({
-  recipient: 'publicKey',
+  to: 'publicKey',
   value: 1000000000n
 })
 console.log('Estimated fee:', quote.fee, 'lamports')
+```
+{% endcode %}
+
+## Quote or Send a TransactionMessage
+
+Use a prebuilt `TransactionMessage` when you need custom instructions or a durable nonce flow.
+
+{% hint style="info" %}
+If the transaction message already includes a recent blockhash or durable nonce lifetime, WDK preserves it. If it does not, WDK fetches the latest blockhash before quoting or sending. When you set `feePayer`, it must match the wallet address.
+{% endhint %}
+
+{% code title="Quote and Send a TransactionMessage" lineNumbers="true" %}
+```javascript
+const quote = await account.quoteSendTransaction(txMessage)
+console.log('Estimated fee:', quote.fee, 'lamports')
+
+const result = await account.sendTransaction(txMessage)
+console.log('Transaction hash:', result.hash)
 ```
 {% endcode %}
 
@@ -84,13 +101,13 @@ async function sendSOLTransfer(account, wallet) {
   }
 
   const quote = await account.quoteSendTransaction({
-    recipient: '11111111111111111111111111111112',
+    to: '11111111111111111111111111111112',
     value: transferAmount
   })
   console.log('Estimated fee:', quote.fee, 'lamports')
 
   const result = await account.sendTransaction({
-    recipient: '11111111111111111111111111111112',
+    to: '11111111111111111111111111111112',
     value: transferAmount
   })
 

--- a/sdk/wallet-modules/wallet-solana/guides/transfer-tokens.md
+++ b/sdk/wallet-modules/wallet-solana/guides/transfer-tokens.md
@@ -31,8 +31,6 @@ const transferResult = await account.transfer({
   token: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB', // USDT mint address
   recipient: 'publicKey', // Recipient's base58-encoded public key
   amount: 1000000n // Amount in token's base units (6 decimals for USDT)
-}, {
-  commitment: 'confirmed' // Optional: commitment level
 })
 console.log('Transfer hash:', transferResult.hash)
 console.log('Transfer fee:', transferResult.fee, 'lamports')


### PR DESCRIPTION
## Summary
- document the public docs updates for @tetherto/wdk-wallet-solana v1.0.0-beta.6
- update the same docs for @tetherto/wdk-wallet-solana v1.0.0-beta.7 after the published typings caught up with the beta.6 runtime behavior
- add changelog entries for April 15, 2026 and April 19, 2026

## Documentation Fixes
- document runtime failover support for ordered `rpcUrl` lists plus `retries`
- update Solana derivation guidance to use hardened SLIP-0010 child paths in the overview, configuration, API, and account management docs
- document `TransactionMessage` lifetime handling and explicit fee-payer validation for custom transaction flows
- fix stale SOL transfer examples to use `to` and remove an unsupported extra `transfer()` argument in the token transfer guide
- remove the temporary beta.6 typing caveat now that beta.7 publishes `SolanaWalletConfig.rpcUrl` as `string | string[]`

## Changelog Updates
- April 15, 2026: `wallet-solana v1.0.0-beta.6`
- April 19, 2026: `wallet-solana v1.0.0-beta.7`

## Release References
- Release PR: https://github.com/tetherto/wdk-wallet-solana/pull/53
- Release PR: https://github.com/tetherto/wdk-wallet-solana/pull/55
- npm package: https://www.npmjs.com/package/@tetherto/wdk-wallet-solana/v/1.0.0-beta.6
- npm package: https://www.npmjs.com/package/@tetherto/wdk-wallet-solana/v/1.0.0-beta.7

## Validation
- `git diff --check`
- TypeScript probe for the documented typed API paths in beta.6
- TypeScript probe for the published `rpcUrl: string | string[]` typing in beta.7
- Verified changelog dates from npm publish timestamps because there are no GitHub release objects for these Solana versions