### PR TITLE
docs: update failover-provider beta.2 and lending-aave-evm beta.4 docs

### DIFF
--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -26,7 +26,11 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ### April 19, 2026
 
+**Changes**
+- **lending-aave-evm** ([v1.0.0-beta.4](https://www.npmjs.com/package/@tetherto/wdk-protocol-lending-aave-evm/v/1.0.0-beta.4)): Expand per-operation ERC‑4337 config overrides from `paymasterToken`-only to the wallet module's paymaster-token, sponsorship-policy, and native-coin gas modes.
+
 **Fixes**
+- **failover-provider** ([v1.0.0-beta.2](https://www.npmjs.com/package/@tetherto/wdk-failover-provider/v/1.0.0-beta.2)): Remove unnecessary published type definitions without changing the runtime failover behavior.
 - **wallet-solana** ([v1.0.0-beta.7](https://www.npmjs.com/package/@tetherto/wdk-wallet-solana/v/1.0.0-beta.7)): Fix `SolanaWalletConfig.rpcUrl` typings to accept ordered `string[]` failover endpoints and align the published TypeScript definitions with the beta.6 runtime behavior.
 
 ---

--- a/sdk/lending-modules/lending-aave-evm/api-reference.md
+++ b/sdk/lending-modules/lending-aave-evm/api-reference.md
@@ -57,6 +57,8 @@ const aave = new AaveProtocolEvm(account)
 
 ---
 
+When `AaveProtocolEvm` is initialized with an ERC‑4337 smart account, the optional `config` argument on mutating and quote methods accepts the same gas-payment override families documented in [`@tetherto/wdk-wallet-evm-erc-4337`](../../../wallet-modules/wallet-evm-erc-4337/api-reference.md#config-override): paymaster token, sponsorship policy, and native coins.
+
 ### `supply(options, config?)`
 Add tokens to the pool.
 
@@ -197,9 +199,26 @@ Returns the following structure:
 
 ---
 
-## ERC‑4337 Config (optional)
+## ERC‑4337 Config Override (optional)
 
-- `paymasterToken` (`string`): token used to pay gas when sponsored.
+When the protocol uses `WalletAccountEvmErc4337` or `WalletAccountReadOnlyEvmErc4337`, the optional `config` argument on `supply`, `quoteSupply`, `withdraw`, `quoteWithdraw`, `borrow`, `quoteBorrow`, `repay`, `quoteRepay`, `setUseReserveAsCollateral`, and `setUserEMode` accepts the wallet module's per-call gas-payment overrides.
+
+- **Paymaster token mode**: `paymasterUrl`, `paymasterAddress`, `paymasterToken`, `transferMaxFee`
+- **Sponsorship policy mode**: `isSponsored`, `paymasterUrl`, `sponsorshipPolicyId`
+- **Native coin mode**: `useNativeCoins`, `transferMaxFee`
+
+Example:
+
+```javascript
+const res = await aave.supply(
+  { token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', amount: 1000000n },
+  {
+    paymasterToken: {
+      address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+    }
+  }
+)
+```
 
 ## Rules & Notes
 
@@ -264,5 +283,4 @@ Returns the following structure:
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
 

--- a/sdk/lending-modules/lending-aave-evm/configuration.md
+++ b/sdk/lending-modules/lending-aave-evm/configuration.md
@@ -57,7 +57,9 @@ const aave = new AaveProtocolEvm(account)
 
 ## ERC‑4337 (Account Abstraction)
 
-When using ERC‑4337 smart accounts, you can optionally specify a `paymasterToken` per operation to sponsor gas.
+When using ERC‑4337 smart accounts, every mutating method and quote helper accepts an optional `config` override. In `v1.0.0-beta.4`, that override matches the three gas-payment families exposed by [`@tetherto/wdk-wallet-evm-erc-4337`](../../../wallet-modules/wallet-evm-erc-4337/configuration.md): paymaster token, sponsorship policy, or native coins.
+
+Use the fields that match the gas-payment mode you want for that call. For the full field-level definitions, see the [`@tetherto/wdk-wallet-evm-erc-4337` configuration docs](../../../wallet-modules/wallet-evm-erc-4337/configuration.md) and [`Config Override`](../../../wallet-modules/wallet-evm-erc-4337/api-reference.md#config-override) reference.
 
 ```javascript
 import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -72,9 +74,17 @@ const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 const aaveAA = new AaveProtocolEvm(aa)
 
 const result = await aaveAA.supply({ token: '0xdAC17F...ec7', amount: 1000000n }, {
-  paymasterToken: 'USDT'
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  }
 })
 ```
+
+### Supported Override Families
+
+- **Paymaster token mode**: `paymasterUrl`, `paymasterAddress`, `paymasterToken`, `transferMaxFee`
+- **Sponsorship policy mode**: `isSponsored`, `paymasterUrl`, `sponsorshipPolicyId`
+- **Native coin mode**: `useNativeCoins`, `transferMaxFee`
 
 ## Network Support
 
@@ -174,6 +184,5 @@ await aave.repay({ token: 'TOKEN_ADDRESS', amount: 1000000n })
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
 
 

--- a/sdk/lending-modules/lending-aave-evm/guides/lending-operations.md
+++ b/sdk/lending-modules/lending-aave-evm/guides/lending-operations.md
@@ -125,7 +125,7 @@ Health factor and collateralization limits still apply. A quote does not guarant
 
 ## ERC-4337 smart accounts
 
-You can run the same methods through [`WalletAccountEvmErc4337`](../../../wallet-modules/wallet-evm-erc-4337/api-reference.md#walletaccountevmerc4337) and pass `paymasterToken` to [`supply()`](../api-reference.md#supply-options-config) (or other mutating calls) per the [ERC-4337 config](../api-reference.md#erc-4337-config-optional) section:
+You can run the same methods through [`WalletAccountEvmErc4337`](../../../wallet-modules/wallet-evm-erc-4337/api-reference.md#walletaccountevmerc4337) and pass a second `config` argument to override per-call gas payment settings. In `v1.0.0-beta.4`, the lending methods accept the same override families as the wallet module: paymaster token, sponsorship policy, and native coins. See the [ERC-4337 config override](../api-reference.md#erc-4337-config-override-optional) section for the full field list.
 
 {% code title="Supply with paymaster" lineNumbers="true" %}
 ```javascript
@@ -143,11 +143,21 @@ const aaveAA = new AaveProtocolEvm(aa)
 
 const result = await aaveAA.supply(
   { token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', amount: 1000000n },
-  { paymasterToken: 'USDT' }
+  {
+    paymasterToken: {
+      address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+    }
+  }
 )
 console.log('Supply hash:', result.hash)
 ```
 {% endcode %}
+
+You can use the same second argument to:
+
+- override paymaster-token mode with `paymasterUrl`, `paymasterAddress`, `paymasterToken`, or `transferMaxFee`
+- switch one call to sponsorship mode with `isSponsored`, `paymasterUrl`, and `sponsorshipPolicyId`
+- switch one call to native-coin gas mode with `useNativeCoins` and `transferMaxFee`
 
 Use token addresses that exist on the same chain as the smart account RPC.
 


### PR DESCRIPTION
## Summary
- update `lending-aave-evm` docs for `v1.0.0-beta.4`
- add April 19, 2026 changelog coverage for `failover-provider v1.0.0-beta.2` and `lending-aave-evm v1.0.0-beta.4`

## Documentation Fixes
- document the widened per-operation ERC-4337 override surface for `@tetherto/wdk-protocol-lending-aave-evm`, covering paymaster-token, sponsorship-policy, and native-coin gas modes
- update the Aave examples to use the current `paymasterToken: { address }` shape from `@tetherto/wdk-wallet-evm-erc-4337`

## Changelog Updates
- `failover-provider` [`v1.0.0-beta.2`](https://www.npmjs.com/package/@tetherto/wdk-failover-provider/v/1.0.0-beta.2): remove unnecessary published type definitions without changing runtime failover behavior
- `lending-aave-evm` [`v1.0.0-beta.4`](https://www.npmjs.com/package/@tetherto/wdk-protocol-lending-aave-evm/v/1.0.0-beta.4): expand per-operation ERC-4337 config overrides from `paymasterToken`-only to the wallet module's paymaster-token, sponsorship-policy, and native-coin gas modes

## Release References
- `wdk-failover-provider` release PR: [#10](https://github.com/tetherto/wdk-failover-provider/pull/10)
- `wdk-protocol-lending-aave-evm` release PR: [#11](https://github.com/tetherto/wdk-protocol-lending-aave-evm/pull/11)

## Excluded From Docs
- `failover-provider v1.0.0-beta.2` did not require page-level docs edits after comparing the published beta.1 and beta.2 surfaces, so it is changelog-only in this PR
