### PR TITLE
docs: add wdk beta.8 changelog entry

### DIFF
--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### April 22, 2026
+
+**Fixes**
+- **wdk-core** ([v1.0.0-beta.8](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.8)): Fix `WDK.getRandomSeedPhrase(wordCount?)` so client code can generate 24-word BIP-39 seed phrases instead of always receiving the default 12-word mnemonic.
+
+---
+
 ### April 19, 2026
 
 **Changes**


### PR DESCRIPTION
## Summary
- add changelog coverage for `wdk v1.0.0-beta.8`

## Changelog Updates
- `wdk-core` [`v1.0.0-beta.8`](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.8): fix `WDK.getRandomSeedPhrase(wordCount?)` so client code can generate 24-word BIP-39 seed phrases instead of always receiving the default 12-word mnemonic

## Release References
- `wdk` fix PR: [#50](https://github.com/tetherto/wdk/pull/50)
- GitHub release: [v1.0.0-beta.8](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.8)

## Excluded From Docs
- no `sdk/core-module/` page edits were needed because the current docs already describe `getRandomSeedPhrase(wordCount?)` and show both 12-word and 24-word usage correctly
