### PR TITLE
docs: update Solana wallet beta 8 docs

### DIFF
--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### May 01, 2026
+
+**What's New**
+- **wallet-solana** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.8)): Add `signTransaction(tx)` for offline Solana transaction signing and `getTokenBalances(tokenAddresses)` for batch SPL balance reads; prefer `provider` over the deprecated `rpcUrl` config alias, optimize `getTokenBalance()` to use one RPC call, reuse the cached read-only account helper, and bump `@tetherto/wdk-failover-provider` to `1.0.0-beta.2`.
+
+---
+
 ### April 30, 2026
 
 **What's New**

--- a/sdk/wallet-modules/wallet-solana/README.md
+++ b/sdk/wallet-modules/wallet-solana/README.md
@@ -43,11 +43,11 @@ Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) to supply an e
 - **Multi-Account Management**: Create and manage multiple accounts from a single seed phrase
 - **Solana Address Support**: Generate and manage Solana public keys and addresses
 - **Message Signing**: Sign and verify messages using Ed25519 cryptography
-- **Transaction Management**: Send transactions and get fee estimates
-- **SPL Token Support**: Query native SOL and SPL token balances
+- **Transaction Management**: Sign, send, and quote Solana transactions
+- **SPL Token Support**: Query native SOL plus single or batch SPL token balances
 - **TypeScript Support**: Full TypeScript definitions included
 - **Memory Safety**: Secure private key management with memory-safe implementation
-- **Provider Flexibility**: Support for a single Solana RPC endpoint, plus runtime failover support for ordered RPC URL lists
+- **Provider Flexibility**: Support for a single Solana RPC endpoint, plus runtime failover support for ordered `provider` lists
 - **Transaction Message Support**: Quote or send prebuilt `TransactionMessage` flows with recent blockhash or durable nonce lifetimes
 - **Fee Estimation**: Dynamic fee calculation with recent blockhash
 - **Program Interaction**: Support for interacting with Solana programs

--- a/sdk/wallet-modules/wallet-solana/api-reference.md
+++ b/sdk/wallet-modules/wallet-solana/api-reference.md
@@ -42,15 +42,16 @@ new WalletManagerSolana(seed, config)
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (object): Configuration object
-  - `rpcUrl` (string | string[]): RPC endpoint URL or an ordered list of endpoints for failover
+  - `provider` (string | string[], optional): Solana RPC endpoint URL or an ordered list of endpoints for failover
+  - `rpcUrl` (string | string[], optional): Deprecated alias for `provider`. If both are set, `provider` takes precedence
   - `commitment` (string, optional): Commitment level ('processed', 'confirmed', or 'finalized')
-  - `retries` (number, optional): Retry count for failover requests (default: 3)
+  - `retries` (number, optional): Additional retry attempts for ordered provider failover (default: 3)
   - `transferMaxFee` (number, optional): Maximum fee amount for transfer operations (in lamports)
 
 **Example:**
 ```javascript
 const wallet = new WalletManagerSolana(seedPhrase, {
-  rpcUrl: 'https://api.mainnet-beta.solana.com',
+  provider: 'https://api.mainnet-beta.solana.com',
   commitment: 'confirmed',
   transferMaxFee: 5000 // Maximum fee in lamports
 })
@@ -134,6 +135,7 @@ new WalletAccountSolana(seed, path, config)
 |--------|-------------|---------|
 | `getAddress()` | Returns the account's Solana address | `Promise<string>` |
 | `sign(message)` | Signs a message using the account's private key | `Promise<string>` |
+| `signTransaction(tx)` | Signs a Solana transaction without broadcasting it | `Promise<FullySignedTransaction>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` |
 | `sendTransaction(tx)` | Sends a Solana transaction | `Promise<{hash: string, fee: bigint}>` |
 | `quoteSendTransaction(tx)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
@@ -141,6 +143,7 @@ new WalletAccountSolana(seed, path, config)
 | `quoteTransfer(options)` | Estimates the fee for an SPL token transfer | `Promise<{fee: bigint}>` |
 | `getBalance()` | Returns the native SOL balance (in lamports) | `Promise<bigint>` |
 | `getTokenBalance(tokenMint)` | Returns the balance of a specific SPL token | `Promise<bigint>` |
+| `getTokenBalances(tokenAddresses)` | Returns balances for multiple SPL tokens | `Promise<Record<string, bigint>>` |
 | `getTransactionReceipt(hash)` | Gets the transaction receipt for a given transaction hash | `Promise<SolanaTransactionReceipt \| null>` |
 | `toReadOnlyAccount()` | Returns a read-only copy of the account | `Promise<WalletAccountReadOnlySolana>` |
 | `dispose()` | Disposes the wallet account, clearing private keys from memory | `void` |
@@ -168,6 +171,27 @@ Signs a message using the account's private key.
 ```javascript
 const signature = await account.sign('Hello, Solana!')
 console.log('Signature:', signature)
+```
+
+##### `signTransaction(tx)`
+Signs a Solana transaction without broadcasting it. Use this method when a relay, review flow, or separate submission path needs a fully signed transaction.
+
+**Parameters:**
+- `tx` (SolanaTransaction): A simple transfer object or a prebuilt `TransactionMessage`
+
+When `tx` is a `TransactionMessage`, WDK preserves an existing recent blockhash or durable nonce lifetime. If no lifetime is present, WDK fetches the latest blockhash before signing. If you set an explicit `feePayer`, it must match the wallet address.
+
+**Returns:** `Promise<FullySignedTransaction>` - The signed transaction
+
+**Throws:** Error if wallet is not connected to a provider
+
+**Example:**
+```javascript
+const signedTransaction = await account.signTransaction({
+  to: '11111111111111111111111111111112',
+  value: 1000000000 // 1 SOL in lamports
+})
+console.log('Signed transaction:', signedTransaction)
 ```
 
 ##### `verify(message, signature)`
@@ -292,13 +316,30 @@ const tokenBalance = await account.getTokenBalance('Es9vMFrzaCERmJfrF4H2FYD4KCoN
 console.log('USDT balance:', tokenBalance)
 ```
 
+##### `getTokenBalances(tokenAddresses)`
+Returns balances for multiple SPL tokens. The wallet batches associated token account lookups with `getMultipleAccounts`, returns balances in base units, and reports `0n` for token accounts that do not exist.
+
+**Parameters:**
+- `tokenAddresses` (string[]): Token mint addresses (base58-encoded)
+
+**Returns:** `Promise<Record<string, bigint>>` - Mapping of token mint address to token balance in base units
+
+**Example:**
+```javascript
+const tokenBalances = await account.getTokenBalances([
+  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+  'So11111111111111111111111111111111111111112'
+])
+console.log('Token balances:', tokenBalances)
+```
+
 ##### `getTransactionReceipt(hash)`
 Gets the transaction receipt for a given transaction hash.
 
 **Parameters:**
 - `hash` (string): Transaction hash
 
-**Returns:** `Promise<SolanaTransactionReceipt | null>` - Transaction receipt details, or null if not found
+**Returns:** `Promise<SolanaTransactionReceipt \| null>` - Transaction receipt details, or null if not found
 
 **Example:**
 ```javascript
@@ -307,7 +348,7 @@ console.log('Transaction receipt:', receipt)
 ```
 
 ##### `toReadOnlyAccount()`
-Returns a read-only copy of the account.
+Returns a read-only copy of the account. After the first call, subsequent calls reuse the same read-only account instance.
 
 **Returns:** `Promise<WalletAccountReadOnlySolana>` - The read-only account
 
@@ -357,6 +398,7 @@ new WalletAccountReadOnlySolana(publicKey, config)
 | `getAddress()` | Returns the account's Solana address | `Promise<string>` |
 | `getBalance()` | Returns the native SOL balance (in lamports) | `Promise<bigint>` |
 | `getTokenBalance(tokenMint)` | Returns the balance of a specific SPL token | `Promise<bigint>` |
+| `getTokenBalances(tokenAddresses)` | Returns balances for multiple SPL tokens | `Promise<Record<string, bigint>>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` |
 | `quoteSendTransaction(tx)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `quoteTransfer(options)` | Estimates the fee for an SPL token transfer | `Promise<{fee: bigint}>` |
@@ -395,6 +437,23 @@ Returns the balance of a specific SPL token.
 ```javascript
 const tokenBalance = await readOnlyAccount.getTokenBalance('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB')
 console.log('USDT balance:', tokenBalance)
+```
+
+##### `getTokenBalances(tokenAddresses)`
+Returns balances for multiple SPL tokens from the read-only account address.
+
+**Parameters:**
+- `tokenAddresses` (string[]): Token mint addresses (base58-encoded)
+
+**Returns:** `Promise<Record<string, bigint>>` - Mapping of token mint address to token balance in base units
+
+**Example:**
+```javascript
+const tokenBalances = await readOnlyAccount.getTokenBalances([
+  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+  'So11111111111111111111111111111111111111112'
+])
+console.log('Read-only token balances:', tokenBalances)
 ```
 
 ##### `verify(message, signature)`
@@ -457,6 +516,8 @@ console.log('Transfer fee estimate:', quote.fee, 'lamports')
 
 ```typescript
 interface SolanaWalletConfig {
+  provider?: string | string[];
+  /** Deprecated alias for provider. provider takes precedence when both are set. */
   rpcUrl?: string | string[];
   commitment?: 'processed' | 'confirmed' | 'finalized';
   retries?: number;

--- a/sdk/wallet-modules/wallet-solana/configuration.md
+++ b/sdk/wallet-modules/wallet-solana/configuration.md
@@ -28,7 +28,7 @@ The `WalletManagerSolana` accepts an optional configuration object that defines 
 import WalletManagerSolana from '@tetherto/wdk-wallet-solana'
 
 const config = {
-  rpcUrl: 'https://api.mainnet-beta.solana.com', // Solana RPC endpoint
+  provider: 'https://api.mainnet-beta.solana.com', // Recommended: Solana RPC endpoint
   transferMaxFee: 10000000 // Optional: Maximum fee in lamports
 }
 
@@ -43,7 +43,7 @@ Accounts are obtained through the `WalletManagerSolana` instance using `getAccou
 import WalletManagerSolana from '@tetherto/wdk-wallet-solana'
 
 const accountConfig = {
-  rpcUrl: 'https://api.mainnet-beta.solana.com',
+  provider: 'https://api.mainnet-beta.solana.com',
   transferMaxFee: 10000000 // Optional: Maximum fee in lamports
 }
 
@@ -58,9 +58,9 @@ const customAccount = await wallet.getAccountByPath("0'/0'/5'")
 
 ## Configuration Options
 
-### rpcUrl
+### provider
 
-The `rpcUrl` option specifies one Solana RPC endpoint or an ordered list of endpoints for blockchain interactions.
+The `provider` option specifies one Solana RPC endpoint or an ordered list of endpoints for blockchain interactions.
 
 **Type:** `string | string[]` (optional)
 
@@ -70,17 +70,17 @@ The `rpcUrl` option specifies one Solana RPC endpoint or an ordered list of endp
 ```javascript
 // Single endpoint
 const config = {
-  rpcUrl: 'https://api.mainnet-beta.solana.com'
+  provider: 'https://api.mainnet-beta.solana.com'
 }
 
 // Devnet
 const config = {
-  rpcUrl: 'https://api.devnet.solana.com'
+  provider: 'https://api.devnet.solana.com'
 }
 
 // Failover across multiple endpoints
 const config = {
-  rpcUrl: [
+  provider: [
     'https://api.mainnet-beta.solana.com',
     'https://rpc.ankr.com/solana'
   ]
@@ -88,15 +88,21 @@ const config = {
 
 // Custom RPC
 const config = {
-  rpcUrl: 'https://your-custom-rpc-endpoint.com'
+  provider: 'https://your-custom-rpc-endpoint.com'
 }
 ```
 
-When `rpcUrl` is an array, WDK initializes a failover provider and tries the next RPC when the current provider fails.
+When `provider` is an array, WDK initializes a failover provider and tries the next RPC when the current provider fails.
+
+### rpcUrl
+
+The `rpcUrl` option is a deprecated alias for `provider`. Existing apps can keep using `rpcUrl`, but new code should use `provider`. If both keys are set, `provider` takes precedence.
+
+**Type:** `string | string[]` (optional)
 
 ### retries
 
-The `retries` option controls how many times the failover provider retries a request before moving on to the next RPC entry.
+The `retries` option controls additional retry attempts after the initial failover request fails. It applies when `provider` is an ordered array of RPC endpoints. Total attempts are `1 + retries`; if retries exceeds the provider count, WDK loops back through the provider list in round-robin order.
 
 **Type:** `number` (optional)
 
@@ -105,7 +111,7 @@ The `retries` option controls how many times the failover provider retries a req
 **Example:**
 ```javascript
 const config = {
-  rpcUrl: [
+  provider: [
     'https://api.mainnet-beta.solana.com',
     'https://rpc.ankr.com/solana'
   ],
@@ -134,8 +140,8 @@ const config = {
 import WalletManagerSolana from '@tetherto/wdk-wallet-solana'
 
 const config = {
-  // Required for most operations
-  rpcUrl: 'https://api.mainnet-beta.solana.com',
+  // Recommended for operations that query or submit transactions
+  provider: 'https://api.mainnet-beta.solana.com',
   
   // Optional: Fee protection
   transferMaxFee: 10000000 // 0.01 SOL maximum fee

--- a/sdk/wallet-modules/wallet-solana/guides/check-balances.md
+++ b/sdk/wallet-modules/wallet-solana/guides/check-balances.md
@@ -19,7 +19,7 @@ layout:
 
 # Check Balances
 
-This guide explains how to check native SOL and SPL token balances for both owned and read-only accounts.
+This guide explains how to check [owned account balances](#owned-account-balances), [batch SPL token balances](#batch-spl-token-balances), and [read-only account balances](#read-only-account-balances).
 
 ## Owned Account Balances
 
@@ -52,6 +52,26 @@ console.log('SPL token balance:', splTokenBalance)
 Token balances are returned in the token's smallest units. Adjust for the token's decimals when displaying (e.g., USD₮ has 6 decimals).
 {% endhint %}
 
+### Batch SPL Token Balances
+
+You can retrieve multiple SPL token balances in one batch using [`account.getTokenBalances()`](/sdk/wallet-modules/wallet-solana/api-reference#gettokenbalances-tokenaddresses):
+
+{% code title="Get Batch SPL Token Balances" lineNumbers="true" %}
+```javascript
+const tokenBalances = await account.getTokenBalances([
+  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+  'So11111111111111111111111111111111111111112'
+])
+
+console.log('USDT balance:', tokenBalances['Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'])
+console.log('Wrapped SOL balance:', tokenBalances['So11111111111111111111111111111111111111112'])
+```
+{% endcode %}
+
+{% hint style="info" %}
+The returned object maps each token mint address to a `bigint` balance in base units. Missing associated token accounts return `0n`.
+{% endhint %}
+
 ## Read-Only Account Balances
 
 Use [`WalletAccountReadOnlySolana`](/sdk/wallet-modules/wallet-solana/api-reference#walletaccountreadonlysolana) to check balances for any public key without a seed phrase.
@@ -63,7 +83,7 @@ Use [`WalletAccountReadOnlySolana`](/sdk/wallet-modules/wallet-solana/api-refere
 import { WalletAccountReadOnlySolana } from '@tetherto/wdk-wallet-solana'
 
 const readOnlyAccount = new WalletAccountReadOnlySolana('publicKey', {
-  rpcUrl: 'https://api.mainnet-beta.solana.com',
+  provider: 'https://api.mainnet-beta.solana.com',
   commitment: 'confirmed'
 })
 
@@ -78,6 +98,18 @@ console.log('Native balance:', balance, 'lamports')
 ```javascript
 const tokenBalance = await readOnlyAccount.getTokenBalance('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB')
 console.log('Token balance:', tokenBalance)
+```
+{% endcode %}
+
+You can also batch read SPL token balances from a read-only account using [`readOnlyAccount.getTokenBalances()`](/sdk/wallet-modules/wallet-solana/api-reference#gettokenbalances-tokenaddresses):
+
+{% code title="Read-Only Batch Token Balances" lineNumbers="true" %}
+```javascript
+const tokenBalances = await readOnlyAccount.getTokenBalances([
+  'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+  'So11111111111111111111111111111111111111112'
+])
+console.log('Read-only token balances:', tokenBalances)
 ```
 {% endcode %}
 

--- a/sdk/wallet-modules/wallet-solana/guides/getting-started.md
+++ b/sdk/wallet-modules/wallet-solana/guides/getting-started.md
@@ -52,14 +52,14 @@ import WalletManagerSolana, {
 const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
 
 const wallet = new WalletManagerSolana(seedPhrase, {
-  rpcUrl: 'https://api.mainnet-beta.solana.com',
+  provider: 'https://api.mainnet-beta.solana.com',
   commitment: 'confirmed' // Optional: commitment level
 })
 ```
 {% endcode %}
 
 {% hint style="info" %}
-To enable RPC failover, pass `rpcUrl` as an ordered array of endpoints and set `retries` to control how many times WDK retries each provider before moving to the next one.
+To enable RPC failover, pass [`provider`](../configuration.md#provider) as an ordered array of endpoints and set [`retries`](../configuration.md#retries) to control additional failover attempts. `rpcUrl` remains available as a deprecated alias for `provider`.
 {% endhint %}
 
 {% hint style="danger" %}

--- a/sdk/wallet-modules/wallet-solana/guides/send-transactions.md
+++ b/sdk/wallet-modules/wallet-solana/guides/send-transactions.md
@@ -19,7 +19,7 @@ layout:
 
 # Send SOL
 
-This guide explains how to send native SOL, estimate transaction fees, and use dynamic fee rates.
+This guide explains how to [send native SOL](#send-native-sol), [sign a transaction without broadcasting](#sign-a-transaction-without-broadcasting), [estimate transaction fees](#estimate-transaction-fees), [quote or send a TransactionMessage](#quote-or-send-a-transactionmessage), [use dynamic fee rates](#use-dynamic-fee-rates), and [run a complete SOL transfer flow](#complete-example).
 
 {% hint style="warning" %}
 **BigInt Usage:** Always use `BigInt` (the `n` suffix) for monetary values to avoid precision loss with large numbers.
@@ -41,6 +41,20 @@ const result = await account.sendTransaction({
 })
 console.log('Transaction hash:', result.hash)
 console.log('Transaction fee:', result.fee, 'lamports')
+```
+{% endcode %}
+
+## Sign a Transaction Without Broadcasting
+
+Use [`account.signTransaction()`](/sdk/wallet-modules/wallet-solana/api-reference#signtransaction-tx) when you need a fully signed transaction but want another process to review, relay, or submit it.
+
+{% code title="Sign SOL Transaction" lineNumbers="true" %}
+```javascript
+const signedTransaction = await account.signTransaction({
+  to: '11111111111111111111111111111112',
+  value: 1000000000n
+})
+console.log('Signed transaction:', signedTransaction)
 ```
 {% endcode %}
 


### PR DESCRIPTION
## Summary
- Updates `wallet-solana` docs for `@tetherto/wdk-wallet-solana` v1.0.0-beta.8.
- Adds the May 01, 2026 changelog entry for the Solana wallet release.
- Updates Solana configuration examples to prefer `provider`, while keeping `rpcUrl` documented as a deprecated alias.

## Documentation Fixes
- Documents `WalletAccountSolana.signTransaction(tx)` for signing Solana transactions without broadcasting.
- Documents `getTokenBalances(tokenAddresses)` for batch SPL token balance reads on owned and read-only Solana accounts.
- Notes that `toReadOnlyAccount()` reuses the cached read-only account instance after the first call.
- Updates Solana balance and getting-started guides to use the preferred `provider` config key.
- Keeps the `getTokenBalance()` single-RPC optimization and `@tetherto/wdk-failover-provider` v1.0.0-beta.2 bump in the changelog as reader-facing release context.

## Changelog Updates
- May 01, 2026: `wallet-solana` v1.0.0-beta.8.

## Release Links
- [`@tetherto/wdk-wallet-solana` v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.8)
- [Release PR](https://github.com/tetherto/wdk-wallet-solana/pull/63)

## Validation
- `git diff --cached --check`
- Active Markdown link, GitBook block, include, and table render-safety checks for 7 changed Markdown files
- Solana API table and expanded-section check for `signTransaction(tx)` and `getTokenBalances(tokenAddresses)`
- TypeScript public API probe for `@tetherto/wdk-wallet-solana` v1.0.0-beta.8
