### PR TITLE
Update changelog and docs for May WDK releases

### DIFF
--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### May 05, 2026
+
+**Changes**
+- **react-native-secure-storage** ([v1.0.0-beta.3](https://github.com/tetherto/wdk-react-native-secure-storage/releases/tag/v1.0.0-beta.3)): Refresh `expo-crypto` and `expo-local-authentication` dependencies to the current Expo SDK release line and keep dependency overrides limited to development tooling, with no public secure storage API changes.
+
+---
+
 ### May 01, 2026
 
 **What's New**

--- a/overview/changelog.md
+++ b/overview/changelog.md
@@ -24,6 +24,16 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### May 08, 2026
+
+**What's New**
+- **wdk-utils** ([v1.0.0-beta.3](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.3)): Add `validateTronAddress()`, `decodeLightningInvoice()`, and `decodeLnurl()` so wallet UIs can validate Tron addresses and inspect BOLT11 invoices or LNURL strings before starting payment flows.
+
+**Changes**
+- **react-native-core** ([v1.0.0-beta.10](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.10)): Use individual token balance reads when a wallet module does not expose batch token balance fetching, improving multi-chain balance support without changing the hook API.
+
+---
+
 ### May 05, 2026
 
 **Changes**

--- a/tools/react-native-core/README.md
+++ b/tools/react-native-core/README.md
@@ -24,7 +24,7 @@ layout:
 ## Features
 
 - **Hooks-based architecture** - `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, and more
-- **TanStack Query caching** - automatic balance fetching, cache invalidation, and optimistic updates
+- **TanStack Query caching** - automatic balance fetching, per-token fallback for modules without batch balance support, cache invalidation, and optimistic updates
 - **Zustand state management** - persisted wallet state with MMKV storage
 - **Worklet runtime** - runs WDK in an isolated Bare worklet
 - **Biometric authentication** - secure storage with device biometrics
@@ -174,7 +174,7 @@ WdkAppProvider
     +-- useAccount()        - address, send, sign, verify, estimateFee
     +-- useAddresses()      - load and query addresses
     +-- useBalance()        - single balance with TanStack Query
-    +-- useBalancesForWallet() - bulk balance fetch
+    +-- useBalancesForWallet() - bulk balance fetch with per-token fallback
     +-- useRefreshBalance() - invalidate and refetch balances
 ```
 

--- a/tools/react-native-core/api-reference.md
+++ b/tools/react-native-core/api-reference.md
@@ -466,7 +466,7 @@ function BalanceDisplay() {
 
 ## useBalancesForWallet
 
-Hook to fetch balances for multiple assets in a single query. Automatically loads addresses for all required networks before fetching balances.
+Hook to fetch balances for multiple assets in a single query. Automatically loads addresses for all required networks before fetching balances. For non-native assets, the hook tries the wallet module's batch token balance method first, then falls back to individual token balance calls when batch fetching is not available.
 
 ### Parameters
 

--- a/tools/wdk-utils/README.md
+++ b/tools/wdk-utils/README.md
@@ -19,11 +19,12 @@ layout:
 
 # WDK Utils
 
-WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, and UMA identifiers, plus EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, Lightning decoding helpers, plus EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
 
 ## Features
 
-- **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Spark, and UMA inputs before you hand them to a wallet flow.
+- **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Spark, Tron, and UMA inputs before you hand them to a wallet flow.
+- **Lightning decoding helpers**: Decode BOLT11 invoices and LNURL strings before you display or route payment details.
 - **EIP-681 request parsing**: Detect request-shaped EIP-681 strings and parse transfer payloads into `recipient`, `tokenAddress`, `chainId`, and `amountSmallest`.
 - **No runtime setup**: Import the functions you need. The package has no constructor or runtime configuration.
 - **TypeScript support**: The published package ships typed exports for every validator and parser.
@@ -76,4 +77,4 @@ WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, and UM
 
 ## Need Help?
 
-{% include "../.gitbook/includes/support-cards.md" %}
+{% include "../../.gitbook/includes/support-cards.md" %}

--- a/tools/wdk-utils/api-reference.md
+++ b/tools/wdk-utils/api-reference.md
@@ -19,9 +19,12 @@ icon: code
 | `validateEVMAddress(address)` | Validate an EVM address, including EIP-55 checksum rules for mixed-case inputs. | `EvmAddressValidationResult` |
 | `stripLightningPrefix(input)` | Remove a leading `lightning:` prefix before other Lightning validation steps. | `string` |
 | `validateLightningInvoice(address)` | Validate a Lightning invoice string. | `LightningInvoiceValidationResult` |
+| `decodeLightningInvoice(invoice)` | Decode a BOLT11 Lightning invoice into invoice metadata. | `LightningInvoiceDecodingResult` |
 | `validateLnurl(address)` | Validate an LNURL string. | `LnurlValidationResult` |
+| `decodeLnurl(address)` | Decode an LNURL string into its original URL. | `LnurlDecodingResult` |
 | `validateLightningAddress(address)` | Validate a Lightning Address in `user@domain.tld` form. | `LightningAddressValidationResult` |
 | `validateSparkAddress(address)` | Validate a Spark address or a Bitcoin L1 deposit address accepted by Spark flows. | `SparkAddressValidationResult` |
+| `validateTronAddress(address)` | Validate a Tron Base58Check address and prefix byte. | `TronAddressValidationResult` |
 | `validateUmaAddress(address)` | Validate a Universal Money Address. | `UmaAddressValidationResult` |
 | `resolveUmaUsername(uma)` | Split a valid UMA string into `localPart`, `domain`, and `lightningAddress`. | Parsed UMA details or `null`. |
 
@@ -130,6 +133,27 @@ const result = validateLightningInvoice(
 - `{ success: true, type: 'invoice' }`
 - `{ success: false, reason: string }`
 
+#### `decodeLightningInvoice(invoice)`
+
+Decode a BOLT11 Lightning invoice after trimming input and removing any `lightning:` URI prefix.
+
+{% code title="Decode A BOLT11 Invoice" lineNumbers="true" %}
+```javascript
+import { decodeLightningInvoice } from '@tetherto/wdk-utils'
+
+const result = decodeLightningInvoice(
+  'lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs'
+)
+```
+{% endcode %}
+
+`LightningInvoiceDecodingResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice', data: DecodedLightningInvoice }`
+- `{ success: false, reason: string }`
+
+`DecodedLightningInvoice` contains decoded BOLT11 metadata such as `paymentRequest`, `network`, `satoshis`, `millisatoshis`, `timestamp`, `timeExpireDate`, `payeeNodeKey`, `signature`, and `tags` when the invoice includes those fields.
+
 #### `validateLnurl(address)`
 
 Validate an LNURL string that begins with `lnurl1`.
@@ -147,6 +171,25 @@ const result = validateLnurl(
 `LnurlValidationResult` is one of these shapes:
 
 - `{ success: true, type: 'lnurl' }`
+- `{ success: false, reason: string }`
+
+#### `decodeLnurl(address)`
+
+Decode an LNURL string into its original URL. The helper also accepts a leading `lightning:` URI prefix.
+
+{% code title="Decode An LNURL" lineNumbers="true" %}
+```javascript
+import { decodeLnurl } from '@tetherto/wdk-utils'
+
+const result = decodeLnurl(
+  'lnurl1dp68gurn8ghj7ampd3kx2ar0veekzar0wd5xjtnrdakj7tnhv4kxctttdehhwm30d3h82unvwqhhxurj093k7mtxdae8gwfjnztwnf'
+)
+```
+{% endcode %}
+
+`LnurlDecodingResult` is one of these shapes:
+
+- `{ success: true, type: 'lnurl', data: string }`
 - `{ success: false, reason: string }`
 
 #### `validateLightningAddress(address)`
@@ -186,6 +229,23 @@ const l1Deposit = validateSparkAddress(
 `SparkAddressValidationResult` is one of these shapes:
 
 - `{ success: true, type: 'spark' | 'btc' }`
+- `{ success: false, reason: string }`
+
+#### `validateTronAddress(address)`
+
+Validate a Tron Base58Check address. The helper checks the `T` prefix, the 34-character address length, the Tron prefix byte, and the checksum.
+
+{% code title="Validate A Tron Address" lineNumbers="true" %}
+```javascript
+import { validateTronAddress } from '@tetherto/wdk-utils'
+
+const result = validateTronAddress('TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH')
+```
+{% endcode %}
+
+`TronAddressValidationResult` is one of these shapes:
+
+- `{ success: true, type: 'tron' }`
 - `{ success: false, reason: string }`
 
 #### `validateUmaAddress(address)`

--- a/tools/wdk-utils/configuration.md
+++ b/tools/wdk-utils/configuration.md
@@ -28,9 +28,12 @@ import {
   validateBitcoinAddress,
   validateEVMAddress,
   validateLightningInvoice,
+  decodeLightningInvoice,
   validateLnurl,
+  decodeLnurl,
   validateLightningAddress,
   validateSparkAddress,
+  validateTronAddress,
   validateUmaAddress,
   resolveUmaUsername
 } from '@tetherto/wdk-utils'
@@ -39,7 +42,7 @@ import {
 
 ## Import EIP-681 helpers
 
-You can detect and parse token transfer requests using the `beta.2` EIP-681 helpers:
+You can detect and parse token transfer requests using the EIP-681 helpers:
 
 {% code title="Import EIP-681 Helpers" lineNumbers="true" %}
 ```javascript
@@ -54,6 +57,7 @@ import {
 
 - `@tetherto/wdk-utils` exports plain functions. There is no client object to initialize.
 - The package publishes a default module entrypoint through `index.js` and a bare runtime entrypoint through `bare.js`.
+- `decodeLightningInvoice()` returns decoded BOLT11 invoice data, and `decodeLnurl()` returns the decoded URL string when parsing succeeds.
 - `parseEip681Request()` currently supports transfer requests for the schemes implemented in the published runtime: `ethereum`, `pol`, `matic`, `polygon`, `arbitrum`, and `plasma`.
 - `parseEip681Request()` accepts both `uint256` and `value` query parameters for the amount field and normalizes the parsed amount into `amountSmallest`.
 
@@ -66,11 +70,13 @@ You can validate common wallet inputs before handing them to a module:
 import {
   validateBitcoinAddress,
   validateLightningAddress,
+  validateTronAddress,
   validateUmaAddress
 } from '@tetherto/wdk-utils'
 
 const btc = validateBitcoinAddress('bc1qu9yqnhc6wjj6s62s9x0shnl5l2r7gq5cudm94r7mvwv0uw4s7acq0hn9g6')
 const lightning = validateLightningAddress('sprycomfort92@waletofsatoshi.com')
+const tron = validateTronAddress('TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH')
 const uma = validateUmaAddress('$you@uma.money')
 ```
 {% endcode %}


### PR DESCRIPTION
## Summary
- Update the changelog for `wdk-react-native-secure-storage` v1.0.0-beta.3, released on May 5, 2026.
- Add release docs for `wdk-react-native-core` v1.0.0-beta.10, released on May 8, 2026.
- Add release docs for `wdk-utils` v1.0.0-beta.3, released on May 8, 2026.

## Documentation Fixes
- Document that React Native Core balance fetching falls back to individual token balance reads when a wallet module does not expose batch token balance fetching.
- Document the new WDK Utils public helpers: `validateTronAddress()`, `decodeLightningInvoice()`, and `decodeLnurl()`.
- Update WDK Utils imports, runtime notes, examples, and overview text to include Tron validation and Lightning decoding helpers.

## Changelog Updates
- Added `react-native-secure-storage` v1.0.0-beta.3 under May 5, 2026.
- Added `react-native-core` v1.0.0-beta.10 under May 8, 2026.
- Added `wdk-utils` v1.0.0-beta.3 under May 8, 2026.

## Release Links
- https://github.com/tetherto/wdk-react-native-secure-storage/releases/tag/v1.0.0-beta.3
- https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.10
- https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.3
