### PR TITLE
Clarify USDT0 bridge approval requirement

### DIFF
--- a/.claude/skills/wdk/SKILL.md
+++ b/.claude/skills/wdk/SKILL.md
@@ -220,11 +220,17 @@ await velora.swap({ tokenIn: '0x...', tokenOut: '0x...', tokenInAmount: 1000000n
 ### Bridge
 ```javascript
 const bridge = new Usdt0ProtocolEvm(evmAccount, { bridgeMaxFee: 1000000000000000n })
+await evmAccount.approve({
+  token: '0x...',  // USDT0
+  spender: '0x...',  // OFT or bridge spender address
+  amount: 1000000n
+})
 await bridge.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...',
   token: '0x...',  // USDT0
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 })
 ```
 

--- a/ai/x402.md
+++ b/ai/x402.md
@@ -236,16 +236,25 @@ const bridge = new Usdt0ProtocolEvm(account, {
 {% endstep %}
 {% step %}
 
-#### Get a quote (recommended)
+#### Approve and get a quote (recommended)
 
 ```javascript
 const USDT_ETHEREUM = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const USDT0_ETHEREUM_OFT = "0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee";
+const amount = 10000000n; // 10 USD₮ (6 decimals)
+
+await account.approve({
+  token: USDT_ETHEREUM,
+  spender: USDT0_ETHEREUM_OFT,
+  amount,
+});
 
 const quote = await bridge.quoteBridge({
   targetChain: "plasma", // or "stable"
   recipient: await account.getAddress(),
   token: USDT_ETHEREUM,
-  amount: 10000000n, // 10 USD₮ (6 decimals)
+  amount,
+  oftContractAddress: USDT0_ETHEREUM_OFT,
 });
 
 console.log("Total cost:", Number(quote.fee + quote.bridgeFee) / 1e18, "ETH");
@@ -256,12 +265,15 @@ console.log("Total cost:", Number(quote.fee + quote.bridgeFee) / 1e18, "ETH");
 
 #### Execute the bridge
 
+Use the same approved `USDT0_ETHEREUM_OFT` spender when executing the bridge.
+
 ```javascript
 const result = await bridge.bridge({
   targetChain: "plasma", // or "stable"
   recipient: await account.getAddress(),
   token: USDT_ETHEREUM,
-  amount: 10000000n,
+  amount,
+  oftContractAddress: USDT0_ETHEREUM_OFT,
 });
 
 console.log("Bridge tx:", result.hash);

--- a/sdk/bridge-modules/bridge-usdt0-evm/api-reference.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/api-reference.md
@@ -113,8 +113,6 @@ await account.approve({
   token: '0x...', // USDT contract address
   spender: '0x...', // OFT or bridge spender address
   amount: 1000000n
-}, {
-  paymasterToken: { address: '0x...' }
 })
 
 const result2 = await bridgeProtocol.bridge({
@@ -423,8 +421,6 @@ async function gaslessBridge() {
     token: '0x...', // USDT contract address
     spender: '0x...', // OFT or bridge spender address
     amount: 1000000n
-  }, {
-    paymasterToken: { address: '0x...' } // Paymaster token configuration
   })
 
   const result = await bridgeProtocol.bridge({

--- a/sdk/bridge-modules/bridge-usdt0-evm/api-reference.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/api-reference.md
@@ -66,6 +66,8 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 #### `bridge(options, config?)`
 Bridges tokens to a different blockchain using the USD₮0 protocol.
 
+Before calling `bridge()`, approve the token allowance for the source-chain bridge spender. If you pass `oftContractAddress`, use the same address as the approval `spender`.
+
 **Parameters:**
 - `options` (BridgeOptions): Bridge operation options
   - `targetChain` (string): Destination chain name
@@ -88,25 +90,39 @@ Bridges tokens to a different blockchain using the USD₮0 protocol.
 **Example:**
 ```javascript
 // Standard EVM account
+await account.approve({
+  token: '0x...', // USDT contract address
+  spender: '0x...', // OFT or bridge spender address
+  amount: 1000000n
+})
+
 const result = await bridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...', // Recipient address
   token: '0x...', // ₮ contract address
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 })
 
 console.log('Bridge hash:', result.hash)
-console.log('Approve hash:', result.approveHash)
-console.log('Reset allowance hash:', result.resetAllowanceHash) // Only for USDT on Ethereum
 console.log('Total fee:', result.fee)
 console.log('Bridge fee:', result.bridgeFee)
 
 // ERC-4337 account
+await account.approve({
+  token: '0x...', // USDT contract address
+  spender: '0x...', // OFT or bridge spender address
+  amount: 1000000n
+}, {
+  paymasterToken: { address: '0x...' }
+})
+
 const result2 = await bridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...', // Recipient address
   token: '0x...', // USDT contract address
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 }, {
   paymasterToken: { address: '0x...' }, // Paymaster token configuration
   bridgeMaxFee: 1000000000000000n
@@ -119,6 +135,8 @@ console.log('Bridge fee:', result2.bridgeFee)
 
 #### `quoteBridge(options, config?)`
 Estimates the cost of a bridge operation without executing it.
+
+Some providers estimate the same bridge transaction that `bridge()` sends. If that estimate fails because token allowance is missing, approve the source-chain bridge spender before calling `quoteBridge()`.
 
 **Parameters:**
 - `options` (BridgeOptions): Bridge operation options (same as bridge method)
@@ -146,11 +164,18 @@ if (quote.fee + quote.bridgeFee > 1000000000000000n) {
   console.log('Bridge fees too high')
 } else {
   // Proceed with bridge
+  await account.approve({
+    token: '0x...', // USDT contract address
+    spender: '0x...', // OFT or bridge spender address
+    amount: 1000000n
+  })
+
   const result = await bridgeProtocol.bridge({
     targetChain: 'polygon',
     recipient: '0x...', // Recipient address
     token: '0x...', // USDT contract address
-    amount: 1000000n
+    amount: 1000000n,
+    oftContractAddress: '0x...' // Same address used as approval spender
   })
 }
 ```
@@ -177,8 +202,6 @@ interface BridgeResult {
   hash: string;                     // Main bridge transaction hash
   fee: bigint;                      // Total gas cost in wei
   bridgeFee: bigint;                // Bridge protocol fee in wei
-  approveHash?: string;             // Approve transaction hash (standard accounts only)
-  resetAllowanceHash?: string;      // Reset allowance hash (USDT on Ethereum only)
 }
 ```
 
@@ -240,11 +263,18 @@ The bridge protocol throws specific errors for different failure cases:
 
 ```javascript
 try {
+  await account.approve({
+    token: '0x...', // USDT contract address
+    spender: '0x...', // OFT or bridge spender address
+    amount: 1000000n
+  })
+
   const result = await bridgeProtocol.bridge({
     targetChain: 'arbitrum',
     recipient: '0x...', // Recipient address
     token: '0x...', // USDT contract address
-    amount: 1000000n
+    amount: 1000000n,
+    oftContractAddress: '0x...' // Same address used as approval spender
   })
 } catch (error) {
   if (error.message.includes('not supported')) {
@@ -295,11 +325,18 @@ async function bridgeTokens() {
   console.log('Bridge quote:', quote)
   
   // Execute bridge
+  await account.approve({
+    token: '0x...', // USDT contract address
+    spender: '0x...', // OFT or bridge spender address
+    amount: 1000000n
+  })
+
   const result = await bridgeProtocol.bridge({
     targetChain: 'arbitrum',
     recipient: '0x...', // Recipient address
     token: '0x...', // USDT contract address
-    amount: 1000000n
+    amount: 1000000n,
+    oftContractAddress: '0x...' // Same address used as approval spender
   })
   
   console.log('Bridge result:', result)
@@ -311,7 +348,7 @@ async function bridgeTokens() {
 ### Multi-Chain Bridge
 
 ```javascript
-async function bridgeToMultipleChains(bridgeProtocol) {
+async function bridgeToMultipleChains(account, bridgeProtocol) {
   const chains = ['arbitrum', 'polygon', 'ethereum']
   const token = '0x...' // USDT contract address
   const amount = 1000000n
@@ -332,11 +369,18 @@ async function bridgeToMultipleChains(bridgeProtocol) {
       console.log(`Bridge to ${chain}:`, quote)
       
       // Execute bridge
+      await account.approve({
+        token,
+        spender: '0x...', // OFT or bridge spender address for the source route
+        amount
+      })
+
       const result = await bridgeProtocol.bridge({
         targetChain: chain,
         recipient,
         token,
-        amount
+        amount,
+        oftContractAddress: '0x...' // Same address used as approval spender
       })
       
       results.push({ chain, result })
@@ -375,11 +419,20 @@ async function gaslessBridge() {
   })
   
   // Bridge with gasless transactions
+  await account.approve({
+    token: '0x...', // USDT contract address
+    spender: '0x...', // OFT or bridge spender address
+    amount: 1000000n
+  }, {
+    paymasterToken: { address: '0x...' } // Paymaster token configuration
+  })
+
   const result = await bridgeProtocol.bridge({
     targetChain: 'polygon',
     recipient: '0x...', // Recipient address
     token: '0x...', // USDT contract address
-    amount: 1000000n
+    amount: 1000000n,
+    oftContractAddress: '0x...' // Same address used as approval spender
   }, {
     paymasterToken: { address: '0x...' } // Paymaster token configuration
   })
@@ -444,5 +497,3 @@ async function gaslessBridge() {
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
-

--- a/sdk/bridge-modules/bridge-usdt0-evm/configuration.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/configuration.md
@@ -145,8 +145,6 @@ await account.approve({
   token: '0x...', // USDT contract address
   spender: '0x...', // OFT or bridge spender address
   amount: 1000000n
-}, {
-  paymasterToken: { address: '0x...' }
 })
 
 const result = await bridgeProtocol.bridge({
@@ -175,10 +173,6 @@ await account.approve({
   token: '0x...', // USDT contract address
   spender: '0x...', // OFT or bridge spender address
   amount: 1000000n
-}, {
-  paymasterToken: {
-    address: '0x...' // Paymaster token address
-  }
 })
 
 const result = await bridgeProtocol.bridge({
@@ -366,5 +360,4 @@ try {
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
 

--- a/sdk/bridge-modules/bridge-usdt0-evm/configuration.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/configuration.md
@@ -89,11 +89,18 @@ const config = {
 
 // Usage example
 try {
+  await account.approve({
+    token: '0x...', // USDT contract address
+    spender: '0x...', // OFT or bridge spender address
+    amount: 1000000n
+  })
+
   const result = await bridgeProtocol.bridge({
     targetChain: 'arbitrum',
     recipient: '0x...', // Recipient address
     token: '0x...', // USDT contract address
-    amount: 1000000n
+    amount: 1000000n,
+    oftContractAddress: '0x...' // Same address used as approval spender
   })
 } catch (error) {
   if (error.message.includes('Exceeded maximum fee')) {
@@ -134,11 +141,20 @@ When using ERC-4337 accounts, you can override configuration options during brid
 
 ```javascript
 // Bridge with ERC-4337 account
+await account.approve({
+  token: '0x...', // USDT contract address
+  spender: '0x...', // OFT or bridge spender address
+  amount: 1000000n
+}, {
+  paymasterToken: { address: '0x...' }
+})
+
 const result = await bridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...', // Recipient address
   token: '0x...', // USDT contract address
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 }, {
   paymasterToken: { address: '0x...' }, // Paymaster token for gasless transactions
   bridgeMaxFee: 1000000000000000n // Override maximum bridge fee
@@ -155,11 +171,22 @@ The `paymasterToken` option specifies which token to use for paying gas fees in 
 **Example:**
 
 ```javascript
+await account.approve({
+  token: '0x...', // USDT contract address
+  spender: '0x...', // OFT or bridge spender address
+  amount: 1000000n
+}, {
+  paymasterToken: {
+    address: '0x...' // Paymaster token address
+  }
+})
+
 const result = await bridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...', // Recipient address
   token: '0x...', // USDT contract address
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 }, {
   paymasterToken: {
     address: '0x...' // Paymaster token address
@@ -201,6 +228,12 @@ const bridgeOptions = {
   oftContractAddress: '0x...', // Optional custom OFT contract address
   dstEid: 30110 // Optional LayerZero destination endpoint ID override
 }
+
+await account.approve({
+  token: bridgeOptions.token,
+  spender: bridgeOptions.oftContractAddress,
+  amount: bridgeOptions.amount
+})
 
 const result = await bridgeProtocol.bridge(bridgeOptions)
 ```
@@ -252,11 +285,18 @@ The bridge protocol will throw errors for invalid configurations:
 
 ```javascript
 try {
+  await account.approve({
+    token: '0x...', // USDT contract address
+    spender: '0x...', // OFT or bridge spender address
+    amount: 1000000n
+  })
+
   const result = await bridgeProtocol.bridge({
     targetChain: 'invalid-chain',
     recipient: '0x...', // Recipient address
     token: '0x...', // USDT contract address
-    amount: 1000000n
+    amount: 1000000n,
+    oftContractAddress: '0x...' // Same address used as approval spender
   })
 } catch (error) {
   if (error.message.includes('not supported')) {
@@ -326,6 +366,5 @@ try {
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
 
 

--- a/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.md
@@ -23,7 +23,7 @@ This guide covers [prerequisites](#prerequisites) and how to [bridge to Solana](
 
 ## Prerequisites
 
-A [`Usdt0ProtocolEvm`](../api-reference.md#usdt0protocolevm) backed by a non-read-only EVM account, with enough USD₮ (and native gas for non-4337 accounts) on the source chain. Recipient strings must match each network’s address encoding.
+A [`Usdt0ProtocolEvm`](../api-reference.md#usdt0protocolevm) backed by a non-read-only EVM account, with enough USD₮ (and native gas for non-4337 accounts) on the source chain. Approve the source-chain bridge spender before calling [`bridge()`](../api-reference.md#bridge-options-config). Recipient strings must match each network’s address encoding.
 
 ## Bridge to Solana
 
@@ -31,11 +31,22 @@ You can set `targetChain` to `solana` and pass a base58 Solana address as `recip
 
 {% code title="Bridge toward Solana" lineNumbers="true" %}
 ```javascript
+const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const USDT_BRIDGE_SPENDER_ADDRESS = process.env.USDT0_BRIDGE_SPENDER_ADDRESS
+const amount = 1000000n
+
+await account.approve({
+  token: USDT_TOKEN_ADDRESS,
+  spender: USDT_BRIDGE_SPENDER_ADDRESS,
+  amount
+})
+
 const solanaResult = await bridgeProtocol.bridge({
   targetChain: 'solana',
   recipient: 'HyXJcgYpURfDhgzuyRL7zxP4FhLg7LZQMeDrR4MXZcMN',
-  token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  amount: 1000000n
+  token: USDT_TOKEN_ADDRESS,
+  amount,
+  oftContractAddress: USDT_BRIDGE_SPENDER_ADDRESS
 })
 
 console.log('Solana bridge hash:', solanaResult.hash)
@@ -53,11 +64,22 @@ You can set `targetChain` to `ton` and supply a TON user-friendly or raw address
 
 {% code title="Bridge toward TON" lineNumbers="true" %}
 ```javascript
+const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const USDT_BRIDGE_SPENDER_ADDRESS = process.env.USDT0_BRIDGE_SPENDER_ADDRESS
+const amount = 1000000n
+
+await account.approve({
+  token: USDT_TOKEN_ADDRESS,
+  spender: USDT_BRIDGE_SPENDER_ADDRESS,
+  amount
+})
+
 const tonResult = await bridgeProtocol.bridge({
   targetChain: 'ton',
   recipient: 'EQAd31gAUhdO0d0NZsNb_cGl_Maa9PSuNhVLE9z8bBSjX6Gq',
-  token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  amount: 1000000n
+  token: USDT_TOKEN_ADDRESS,
+  amount,
+  oftContractAddress: USDT_BRIDGE_SPENDER_ADDRESS
 })
 
 console.log('TON bridge hash:', tonResult.hash)
@@ -70,11 +92,22 @@ You can set `targetChain` to `tron` and pass a base58Check TRON address (typical
 
 {% code title="Bridge toward TRON" lineNumbers="true" %}
 ```javascript
+const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const USDT_BRIDGE_SPENDER_ADDRESS = process.env.USDT0_BRIDGE_SPENDER_ADDRESS
+const amount = 1000000n
+
+await account.approve({
+  token: USDT_TOKEN_ADDRESS,
+  spender: USDT_BRIDGE_SPENDER_ADDRESS,
+  amount
+})
+
 const tronResult = await bridgeProtocol.bridge({
   targetChain: 'tron',
   recipient: 'TFG4wBaDQ8sHWWP1ACeSGnoNR6RRzevLPt',
-  token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  amount: 1000000n
+  token: USDT_TOKEN_ADDRESS,
+  amount,
+  oftContractAddress: USDT_BRIDGE_SPENDER_ADDRESS
 })
 
 console.log('TRON bridge hash:', tronResult.hash)

--- a/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.md
@@ -25,6 +25,8 @@ This guide covers [prerequisites](#prerequisites) and how to [bridge to Solana](
 
 A [`Usdt0ProtocolEvm`](../api-reference.md#usdt0protocolevm) backed by a non-read-only EVM account, with enough USD₮ (and native gas for non-4337 accounts) on the source chain. Approve the source-chain bridge spender before calling [`bridge()`](../api-reference.md#bridge-options-config). Recipient strings must match each network’s address encoding.
 
+For `USDT_BRIDGE_SPENDER_ADDRESS`, use the source-chain OFT or bridge contract for the route. See [Bridge Tokens](./bridge-tokens.md#prerequisites) for address sources.
+
 ## Bridge to Solana
 
 You can set `targetChain` to `solana` and pass a base58 Solana address as `recipient` when calling [`bridge()`](../api-reference.md#bridge-options-config):

--- a/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens.md
@@ -27,6 +27,8 @@ Complete [Get Started](./get-started.md): an account from [`new WalletAccountEvm
 
 Before calling [`bridge()`](../api-reference.md#bridge-options-config), approve the source-chain bridge spender for the token and amount you want to bridge. If you pass `oftContractAddress`, use the same address as the approval `spender`.
 
+For placeholder values such as `USDT0_OFT_ADDRESS`, use the current token and bridge contract addresses from the [USDT0 deployments](https://docs.usdt0.to/technical-documentation/deployments). For the route mapping used by the WDK package, see the package [`src/config.js`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/blob/main/src/config.js), especially `oftContract`, `legacyMeshContract`, and `xautOftContract`.
+
 ## Run a standard EVM-to-EVM bridge
 
 You can move USD₮ on the source chain toward another EVM chain by calling [`bridge()`](../api-reference.md#bridge-options-config) with `targetChain`, `recipient`, `token`, and `amount` (token base units). Amount `1000000n` is 1 USD₮ when the token uses 6 decimals.

--- a/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens.md
@@ -25,29 +25,40 @@ This guide covers [prerequisites](#prerequisites), how to [run a standard EVM-to
 
 Complete [Get Started](./get-started.md): an account from [`new WalletAccountEvm(seed, path, config?)`](../../../wallet-modules/wallet-evm/api-reference.md#constructor-1) and a bridge from [`new Usdt0ProtocolEvm(account, config?)`](../api-reference.md#constructor). The source chain RPC must match the account network.
 
+Before calling [`bridge()`](../api-reference.md#bridge-options-config), approve the source-chain bridge spender for the token and amount you want to bridge. If you pass `oftContractAddress`, use the same address as the approval `spender`.
+
 ## Run a standard EVM-to-EVM bridge
 
 You can move USD₮ on the source chain toward another EVM chain by calling [`bridge()`](../api-reference.md#bridge-options-config) with `targetChain`, `recipient`, `token`, and `amount` (token base units). Amount `1000000n` is 1 USD₮ when the token uses 6 decimals.
 
 {% code title="Standard EVM bridge" lineNumbers="true" %}
 ```javascript
+const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const USDT0_OFT_ADDRESS = process.env.USDT0_OFT_ADDRESS
+const amount = 1000000n
+
+await account.approve({
+  token: USDT_TOKEN_ADDRESS,
+  spender: USDT0_OFT_ADDRESS,
+  amount
+})
+
 const result = await bridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-  token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  amount: 1000000n
+  token: USDT_TOKEN_ADDRESS,
+  amount,
+  oftContractAddress: USDT0_OFT_ADDRESS
 })
 
 console.log('Bridge transaction hash:', result.hash)
-console.log('Approve hash:', result.approveHash)
-console.log('Reset allowance hash:', result.resetAllowanceHash)
 console.log('Total fee:', result.fee, 'wei')
 console.log('Bridge fee:', result.bridgeFee, 'wei')
 ```
 {% endcode %}
 
 {% hint style="warning" %}
-`resetAllowanceHash` appears for USD₮ on Ethereum when the implementation requires a zero allowance reset before a new approval.
+`bridge()` does not approve token allowance for you. Use a bounded approval for the bridge amount rather than an unlimited allowance.
 {% endhint %}
 
 ## Quote bridge fees
@@ -70,18 +81,32 @@ console.log('Bridge fee:', quote.bridgeFee, 'wei')
 
 Compare `quote.fee` and `quote.bridgeFee` to your risk limits before calling [`bridge()`](../api-reference.md#bridge-options-config).
 
+{% hint style="info" %}
+Some providers estimate the bridge transaction during [`quoteBridge()`](../api-reference.md#quotebridge-options-config). If the estimate fails because allowance is missing, approve the same `token`, `spender`, and `amount` before quoting.
+{% endhint %}
+
 ## Override OFT contract and destination endpoint
 
 You can point [`bridge()`](../api-reference.md#bridge-options-config) at a specific OFT contract and LayerZero destination endpoint ID when auto-resolution is not enough. Supply values from your deployment or integration configuration (environment variables shown for illustration):
 
 {% code title="Custom OFT and dstEid on bridge" lineNumbers="true" %}
 ```javascript
+const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const USDT0_OFT_ADDRESS = process.env.USDT0_OFT_ADDRESS
+const amount = 1000000n
+
+await account.approve({
+  token: USDT_TOKEN_ADDRESS,
+  spender: USDT0_OFT_ADDRESS,
+  amount
+})
+
 const result = await bridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-  token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  amount: 1000000n,
-  oftContractAddress: process.env.USDT0_OFT_ADDRESS,
+  token: USDT_TOKEN_ADDRESS,
+  amount,
+  oftContractAddress: USDT0_OFT_ADDRESS,
   dstEid: Number(process.env.CUSTOM_DST_EID)
 })
 

--- a/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.md
@@ -63,19 +63,33 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 
 ## Run a gasless bridge with paymaster options
 
-You can execute [`bridge()`](../api-reference.md#bridge-options-config) with a second argument that includes `paymasterToken` (and optional `bridgeMaxFee` override) as described in the [methods table](../api-reference.md#methods). User operations bundle approvals and the bridge into a single user-op hash on the result.
+You can execute [`bridge()`](../api-reference.md#bridge-options-config) with a second argument that includes `paymasterToken` (and optional `bridgeMaxFee` override) as described in the [methods table](../api-reference.md#methods). Approve the source-chain bridge spender first, then call [`bridge()`](../api-reference.md#bridge-options-config). Each call returns one hash for the submitted user operation.
 
 {% code title="Gasless bridge with paymasterToken" lineNumbers="true" %}
 ```javascript
+const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const USDT0_OFT_ADDRESS = process.env.USDT0_OFT_ADDRESS
+const amount = 1000000n
+const paymasterToken = { address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9' }
+
+await account.approve({
+  token: USDT_TOKEN_ADDRESS,
+  spender: USDT0_OFT_ADDRESS,
+  amount
+}, {
+  paymasterToken
+})
+
 const result = await bridgeProtocol.bridge(
   {
     targetChain: 'polygon',
     recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-    token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-    amount: 1000000n
+    token: USDT_TOKEN_ADDRESS,
+    amount,
+    oftContractAddress: USDT0_OFT_ADDRESS
   },
   {
-    paymasterToken: { address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9' },
+    paymasterToken,
     bridgeMaxFee: 1000000000000000n
   }
 )
@@ -87,7 +101,7 @@ console.log('Bridge fee:', result.bridgeFee)
 {% endcode %}
 
 {% hint style="info" %}
-Unlike the standard EVM account path, the bundled flow returns a single `hash` for the user operation rather than separate approve and bridge transaction hashes.
+The approval and bridge calls are separate user operations. Persist both hashes if your app needs to audit the complete flow.
 {% endhint %}
 
 {% hint style="warning" %}

--- a/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.md
@@ -76,8 +76,6 @@ await account.approve({
   token: USDT_TOKEN_ADDRESS,
   spender: USDT0_OFT_ADDRESS,
   amount
-}, {
-  paymasterToken
 })
 
 const result = await bridgeProtocol.bridge(

--- a/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors.md
+++ b/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors.md
@@ -32,11 +32,18 @@ You can wrap [`bridge()`](../api-reference.md#bridge-options-config) in `try/cat
 {% code title="Handle bridge errors" lineNumbers="true" %}
 ```javascript
 try {
+  await account.approve({
+    token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    spender: process.env.USDT0_OFT_ADDRESS,
+    amount: 1000000n
+  })
+
   const result = await bridgeProtocol.bridge({
     targetChain: 'arbitrum',
     recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
     token: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-    amount: 1000000n
+    amount: 1000000n,
+    oftContractAddress: process.env.USDT0_OFT_ADDRESS
   })
   console.log('Bridge successful:', result.hash)
 } catch (error) {

--- a/sdk/core-module/api-reference.md
+++ b/sdk/core-module/api-reference.md
@@ -456,11 +456,18 @@ account.registerProtocol('usdt0', Usdt0ProtocolEvm)
 const usdt0 = account.getBridgeProtocol('usdt0')
 
 // Use the protocol
+await account.approve({
+  token: '0x...',
+  spender: '0x...', // OFT or bridge spender address
+  amount: 1000000n
+})
+
 const bridgeResult = await usdt0.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...',
   token: '0x...',
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 })
 ```
 {% endcode %}
@@ -533,6 +540,12 @@ const velora = accountEth.getSwapProtocol('velora')
 const swapResult = await velora.swap(swapOptions)
 
 const usdt0 = accountEth.getBridgeProtocol('usdt0')
+// bridgeOptions.oftContractAddress is the source-chain bridge spender.
+await accountEth.approve({
+  token: bridgeOptions.token,
+  spender: bridgeOptions.oftContractAddress,
+  amount: bridgeOptions.amount
+})
 const bridgeResult = await usdt0.bridge(bridgeOptions)
 
 // Clean up

--- a/sdk/core-module/guides/protocol-integration.md
+++ b/sdk/core-module/guides/protocol-integration.md
@@ -96,18 +96,26 @@ const result = await velora.swap({
 ### Bridging Assets
 
 1. Use `getBridgeProtocol` to access cross-chain bridges.
-2. Call `bridge` from the bridge protocol to send tokens from one protocol to another.
+2. Approve the source-chain bridge spender for the token and amount.
+3. Call `bridge` from the bridge protocol to send tokens from one protocol to another.
 
 {% code title="Bridge Assets" lineNumbers="true" %}
 ```typescript
 const ethAccount = await wdk.getAccount('ethereum', 0)
 const usdt0 = ethAccount.getBridgeProtocol('usdt0')
 
+await ethAccount.approve({
+  token: '0x...', // ERC20 Token Address
+  spender: '0x...', // OFT or bridge spender address
+  amount: 1000000n
+})
+
 const result = await usdt0.bridge({
   targetChain: 'ton',
   recipient: 'UQBla...', // TON address
   token: '0x...', // ERC20 Token Address
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 })
 ```
 {% endcode %}

--- a/skills/wdk/SKILL.md
+++ b/skills/wdk/SKILL.md
@@ -196,7 +196,7 @@ All require human confirmation: `claimDeposit`, `claimStaticDeposit`, `refundSta
 #### Protocol write methods
 
 - **Swap**: `swap` (velora-evm) — may internally approve + reset allowance
-- **Bridge**: `bridge` (usdt0-evm) — may internally approve + reset allowance
+- **Bridge**: `bridge` (usdt0-evm) — requires prior token approval for the source-chain OFT or bridge spender
 - **Lending (Aave)**: `supply`, `withdraw`, `borrow`, `repay`, `setUseReserveAsCollateral`, `setUserEMode`
 - **Fiat (MoonPay)**: `buy`, `sell` (generate signed widget URLs)
 

--- a/skills/wdk/references/protocol-bridge.md
+++ b/skills/wdk/references/protocol-bridge.md
@@ -39,11 +39,18 @@ const quote = await bridge.quoteBridge({
 })
 
 // Then bridge (requires human confirmation)
+await evmAccount.approve({
+  token: '0x...',      // USDT0 token address on source chain
+  spender: '0x...',    // OFT or bridge spender address
+  amount: 1000000n
+})
+
 await bridge.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...',
   token: '0x...',
-  amount: 1000000n
+  amount: 1000000n,
+  oftContractAddress: '0x...' // Same address used as approval spender
 })
 ```
 
@@ -57,7 +64,7 @@ Works with both wallet-evm and wallet-evm-erc-4337 accounts.
 ## How It Works
 
 - Uses **LayerZero OFT** (Omnichain Fungible Token) protocol for cross-chain messaging
-- May internally handle `approve()` + reset allowance for the OFT adapter contract
+- Requires prior token approval for the source-chain OFT or bridge spender
 - Bridge fees include LayerZero messaging fees (paid in native token of source chain)
 - Token addresses differ per chain — see `references/deployments.md` for the full table
 


### PR DESCRIPTION
## Summary
- Updates WDK bridge docs to make the source-chain approval step explicit before `bridge()`.
- Removes stale `approveHash` and `resetAllowanceHash` guidance from the bridge API docs.
- Updates x402, core protocol integration examples, and bundled WDK skill references so they no longer imply the bridge module approves internally.

## Documentation Fixes
- Addresses https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/issues/13.
- Aligns GitBook examples with the current bridge module behavior: approve the token spender first, then execute `bridge()` using the same `oftContractAddress` when supplied.
- Adds a note that `quoteBridge()` can also fail without allowance when providers estimate the bridge send transaction.

## Validation
- Ran stale-term checks for `approveHash`, `resetAllowanceHash`, `internally approve`, `may internally approve`, and bundled approval claims.
- Ran `git diff --check`.
- Ran GitBook block balance checks, fenced-code checks, HTML table checks, and Markdown table structure checks for changed Markdown files.
