### PR TITLE
feat: add fiat module in Module Types

### DIFF
--- a/sdk/get-started.md
+++ b/sdk/get-started.md
@@ -46,7 +46,7 @@ New functionality is added through modules rather than modifying core code. Also
 
 #### Module Types
 
-WDK modules are organized into five main categories, each serving a specific purpose in the blockchain application stack:
+WDK modules are organized into six main categories, each serving a specific purpose in the blockchain application stack:
 
 <table data-view="cards">
 	<thead>
@@ -100,6 +100,15 @@ WDK modules are organized into five main categories, each serving a specific pur
 			<td>DeFi lending and borrowing</td>
 			<td>
 				<a href="./lending-modules/README.md">Lending Modules</a>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<strong>Fiat</strong>
+			</td>
+			<td>Fiat on/off-ramp integrations</td>
+			<td>
+				<a href="./fiat-modules/README.md">Fiat Modules</a>
 			</td>
 		</tr>
 	</tbody>


### PR DESCRIPTION
## Summary
This PR adds a link to the [Fiat module](https://github.com/tetherto/wdk-docs/blob/f9a8e4e7b7f459439647f0c16bcd20821bbb8446/sdk/fiat-modules/README.md) in [Module Types](https://github.com/tetherto/wdk-docs/blob/f9a8e4e7b7f459439647f0c16bcd20821bbb8446/sdk/get-started.md?plain=1#L47-L108) section of [sdk/get-started.md](https://github.com/tetherto/wdk-docs/blob/f9a8e4e7b7f459439647f0c16bcd20821bbb8446/sdk/get-started.md).

## Screenshots
<img width="840" height="416" alt="image" src="https://github.com/user-attachments/assets/532f9f28-8351-41d5-b30a-28e87f3ad14b" />
