### PR TITLE
docs: correct TON gasless configuration

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -114,7 +114,7 @@
       * [Get Started](sdk/wallet-modules/wallet-ton-gasless/guides/get-started.md)
       * [Manage Accounts](sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts.md)
       * [Check Balances](sdk/wallet-modules/wallet-ton-gasless/guides/check-balances.md)
-      * [Send TON](sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.md)
+      * [Native TON Transactions](sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.md)
       * [Transfer Jetton Tokens](sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.md)
       * [Sign and Verify Messages](sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages.md)
       * [Handle Errors](sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.md)

--- a/sdk/wallet-modules/wallet-ton-gasless/README.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/README.md
@@ -19,7 +19,17 @@ layout:
 
 # @tetherto/wdk-wallet-ton-gasless Overview
 
-A simple and secure package to manage gasless transactions on the TON blockchain. This package provides a clean API for creating, managing, and interacting with TON wallets using BIP-39 seed phrases and TON-specific derivation paths, with support for gasless transactions through a paymaster system.
+A simple and secure package to manage gasless Jetton transfers on the TON blockchain. This package provides a clean API for creating, managing, and interacting with TON wallets using BIP-39 seed phrases and TON-specific derivation paths, with support for paymaster-based Jetton transfers.
+
+{% hint style="warning" %}
+
+**Address Compatibility with `@tetherto/wdk-wallet-ton`**
+
+`@tetherto/wdk-wallet-ton-gasless` currently derives `wallet.getAccount(index)` from `m/44'/607'/0'/0/{index}`, while `@tetherto/wdk-wallet-ton` v1.0.0-beta.6+ derives `wallet.getAccount(index)` from `m/44'/607'/{index}'`.
+
+The same seed phrase can therefore produce different default addresses across the two TON modules. Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) when you need to recreate or initialize a specific address.
+
+{% endhint %}
 
 
 ## Features
@@ -29,7 +39,7 @@ A simple and secure package to manage gasless transactions on the TON blockchain
 - **Multi-Account Management**: Create and manage multiple accounts from a single seed phrase
 - **TON Address Support**: Generate and manage TON addresses using V5R1 wallet contracts
 - **Message Signing**: Sign and verify messages using TON cryptography
-- **Gasless Transactions**: Execute transactions without requiring TON for gas fees
+- **Gasless Jetton Transfers**: Execute supported Jetton transfers with fees paid in a paymaster token
 - **Paymaster Integration**: Built-in support for paymaster-based fee delegation
 - **Jetton Support**: Query native TON and Jetton token balances
 - **TypeScript Support**: Full TypeScript definitions included

--- a/sdk/wallet-modules/wallet-ton-gasless/api-reference.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/api-reference.md
@@ -42,10 +42,10 @@ new WalletManagerTonGasless(seed, config)
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (TonGaslessWalletConfig): Configuration object (required)
   - `tonClient` (object | TonClient): TON client configuration or instance
-    - `url` (string): TON Center API URL (e.g., 'https://toncenter.com/api/v3')
+    - `url` (string): TON Center v2 JSON-RPC URL (e.g., 'https://toncenter.com/api/v2/jsonRPC')
     - `secretKey` (string, optional): API key for TON Center
   - `tonApiClient` (object | TonApiClient): TON API client configuration or instance
-    - `url` (string): TON API URL (e.g., 'https://tonapi.io/v2')
+    - `url` (string): TON API base URL (e.g., 'https://tonapi.io')
     - `secretKey` (string, optional): API key for TON API
   - `paymasterToken` (object): Paymaster token configuration
     - `address` (string): Paymaster token contract address
@@ -55,11 +55,11 @@ new WalletManagerTonGasless(seed, config)
 ```javascript
 const wallet = new WalletManagerTonGasless(seedPhrase, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   },
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-tonapi-key'
   },
   paymasterToken: {
@@ -146,7 +146,7 @@ new WalletAccountTonGasless(seed, path, config)
 | `getAddress()` | Returns the account's TON address | `Promise<string>` |
 | `sign(message)` | Signs a message using the account's private key | `Promise<string>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` |
-| `sendTransaction(tx)` | Sends a TON transaction | `Promise<{hash: string, fee: bigint}>` |
+| `sendTransaction(tx)` | Not supported by this module; use `@tetherto/wdk-wallet-ton` for native TON sends | Throws |
 | `transfer(options, config?)` | Transfers tokens using gasless transactions | `Promise<{hash: string, fee: bigint}>` |
 | `quoteTransfer(options, config?)` | Estimates the fee for a token transfer | `Promise<{fee: bigint}>` |
 | `getBalance()` | Returns the native TON balance (in nanotons) | `Promise<bigint>` |
@@ -197,25 +197,11 @@ console.log('Signature valid:', isValid)
 ```
 
 ##### `sendTransaction(tx)`
-Sends a TON transaction.
+Not supported by `@tetherto/wdk-wallet-ton-gasless`.
 
-**Parameters:**
-- `tx` (TonTransaction): The transaction object
-  - `to` (string): Recipient TON address
-  - `value` (number | bigint): Amount in nanotons
-  - `bounceable` (boolean, optional): Whether the address is bounceable
-  - `body` (string | Cell, optional): Optional message body
+Use `@tetherto/wdk-wallet-ton` for native TON sends.
 
-**Returns:** `Promise<{hash: string, fee: bigint}>` - Transaction result
-
-**Example:**
-```javascript
-const result = await account.sendTransaction({
-  to: 'EQ...',
-  value: 1000000000
-})
-console.log('Transaction hash:', result.hash)
-```
+**Throws:** `Method 'sendTransaction(tx)' not supported on ton gasless.`
 
 ##### `transfer(options, config?)`
 Transfers tokens using gasless transactions.
@@ -244,7 +230,7 @@ const result = await account.transfer({
 })
 ```
 
-##### `quoteTransfer(options)`
+##### `quoteTransfer(options, config?)`
 Estimates the fee for a Jetton (TON token) transfer.
 
 **Parameters:**
@@ -256,6 +242,8 @@ Estimates the fee for a Jetton (TON token) transfer.
   - `paymasterToken` (object, optional): Override default paymaster token
 
 **Returns:** `Promise<{fee: bigint}>` - Object containing fee estimate (in paymaster token base units)
+
+`quoteTransfer()` returns a fee estimate only. It does not return a transaction hash.
 
 **Example:**
 ```javascript
@@ -454,6 +442,8 @@ Estimates the fee for a token transfer.
 
 **Returns:** `Promise<{fee: bigint}>` - Object containing fee estimate (in paymaster token base units)
 
+`quoteTransfer()` returns a fee estimate only. It does not return a transaction hash.
+
 **Example:**
 ```javascript
 const quote = await readOnlyAccount.quoteTransfer({
@@ -489,12 +479,12 @@ if (receipt) {
 ```typescript
 interface TonGaslessWalletConfig {
   /**
-   * TON Center client configuration or an instance of TonClient
+   * TON Center v2 JSON-RPC client configuration or an instance of TonClient
    */
   tonClient: TonClientConfig | TonClient;
 
   /**
-   * TON API client configuration or an instance of TonApiClient
+   * TON API base client configuration or an instance of TonApiClient
    */
   tonApiClient: TonApiClientConfig | TonApiClient;
 
@@ -641,4 +631,3 @@ interface KeyPair {
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-

--- a/sdk/wallet-modules/wallet-ton-gasless/configuration.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/configuration.md
@@ -28,12 +28,12 @@ import WalletManagerTonGasless from '@tetherto/wdk-wallet-ton-gasless'
 const config = {
   // Required: TON Center API client
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional, for higher rate limits
   },
   // Required: TON API client (used for gasless transaction relay)
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-tonapi-key' // Optional but recommended
   },
   // Required: Paymaster token used to pay gas fees
@@ -47,6 +47,10 @@ const config = {
 const wallet = new WalletManagerTonGasless(seedPhrase, config) // config is required
 ```
 
+{% hint style="info" %}
+`tonClient.url` must be a TON Center v2 JSON-RPC endpoint because the SDK passes it to `@ton/ton`'s `TonClient`. `tonApiClient.url` must be the TON API base URL; the TON API client appends `/v2/gasless/...` internally.
+{% endhint %}
+
 ## Account Configuration
 
 ```javascript
@@ -55,12 +59,12 @@ import { WalletAccountTonGasless } from '@tetherto/wdk-wallet-ton-gasless'
 const accountConfig = {
   // Required: TON Center API client
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   },
   // Required: TON API client
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-tonapi-key' // Optional but recommended
   },
   // Required: Paymaster token
@@ -82,12 +86,12 @@ import { WalletAccountReadOnlyTonGasless } from '@tetherto/wdk-wallet-ton-gasles
 const readOnlyConfig = {
   // Required: TON Center API client
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   },
   // Required: TON API client
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-tonapi-key' // Optional but recommended
   },
   // Required: Paymaster token
@@ -112,8 +116,8 @@ type TonClientOption = TonClientConfig | TonClient;
 
 interface TonClientConfig {
   /**
-   * TON Center API endpoint URL
-   * @example 'https://toncenter.com/api/v3'
+   * TON Center v2 JSON-RPC endpoint URL
+   * @example 'https://toncenter.com/api/v2/jsonRPC'
    */
   url: string;
 
@@ -137,8 +141,8 @@ type TonApiClientOption = TonApiClientConfig | TonApiClient;
 
 interface TonApiClientConfig {
   /**
-   * TON API endpoint URL
-   * @example 'https://tonapi.io/v2'
+   * TON API base URL
+   * @example 'https://tonapi.io'
    */
   url: string;
 
@@ -150,6 +154,10 @@ interface TonApiClientConfig {
 ```
 
 **Required:** Yes
+
+{% hint style="warning" %}
+Do not include `/v2` in `tonApiClient.url`. Use `https://tonapi.io`, not `https://tonapi.io/v2`, otherwise gasless requests are sent to `/v2/v2/gasless/...`.
+{% endhint %}
 
 ### paymasterToken
 
@@ -168,6 +176,10 @@ interface PaymasterTokenConfig {
 
 **Required:** Yes
 
+{% hint style="warning" %}
+`paymasterToken` must be an object with an `address` field, not a raw string.
+{% endhint %}
+
 **Example:**
 ```javascript
 const config = {
@@ -176,6 +188,12 @@ const config = {
   }
 }
 ```
+
+## Gasless Transfer Prerequisites
+
+Gasless Jetton transfers require the gasless TON account to be initialized on-chain before TON API can estimate and relay the transfer. If the account is still `uninit`, `quoteTransfer()` can fail at the gasless estimate step.
+
+Fund and initialize the gasless account through a supported onboarding flow before relying on gasless transfers for a zero-TON account. Using the non-gasless TON module to deploy the account is not a drop-in workaround unless you explicitly use the same derivation path, because `@tetherto/wdk-wallet-ton` and `@tetherto/wdk-wallet-ton-gasless` currently use different default paths for `getAccount(index)`.
 
 ### transferMaxFee
 
@@ -200,13 +218,13 @@ Here's a complete configuration example with all options:
 const config = {
   // TON Center API client (required)
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   },
   
   // TON API client for gasless relay (required)
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-tonapi-key'
   },
   
@@ -296,8 +314,6 @@ const config = {
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
-
 
 
 

--- a/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances.md
@@ -56,7 +56,7 @@ console.log('Paymaster Jetton balance:', paymasterBalance)
 {% endcode %}
 
 {% hint style="info" %}
-The paymaster token balance determines how many gasless transfers you can execute. Ensure the paymaster has sufficient token balance before initiating gasless transfers.
+The paymaster token balance determines how many gasless transfers the account can execute. Ensure the account has sufficient paymaster token balance before initiating gasless transfers.
 {% endhint %}
 
 ## Read-Only Account Balances
@@ -69,11 +69,11 @@ import { WalletAccountReadOnlyTonGasless } from '@tetherto/wdk-wallet-ton-gasles
 
 const readOnlyAccount = new WalletAccountReadOnlyTonGasless(publicKey, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   },
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-ton-api-key' // Optional
   },
   paymasterToken: {
@@ -97,4 +97,4 @@ console.log('Paymaster token balance:', paymasterBalance)
 
 ## Next Steps
 
-With balance checks in place, learn how to [send TON](./send-transactions.md).
+With balance checks in place, learn how to [transfer Jetton tokens gaslessly](./transfer-tokens.md).

--- a/sdk/wallet-modules/wallet-ton-gasless/guides/get-started.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/guides/get-started.md
@@ -49,11 +49,11 @@ const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon aban
 
 const wallet = new WalletManagerTonGasless(seedPhrase, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   },
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-ton-api-key' // Optional
   },
   paymasterToken: {

--- a/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.md
@@ -19,7 +19,7 @@ layout:
 
 # Handle Errors
 
-This guide covers how to [handle gasless transfer errors](#handle-gasless-transfer-errors) and [handle native TON transaction errors](#handle-native-ton-transaction-errors), plus [best practices](#best-practices) for fee management and memory cleanup.
+This guide covers how to [handle gasless transfer errors](#handle-gasless-transfer-errors) and [handle unsupported native TON sends](#handle-unsupported-native-ton-sends), plus [best practices](#best-practices) for fee management and memory cleanup.
 
 ## Handle Gasless Transfer Errors
 
@@ -43,6 +43,8 @@ try {
     console.error('The recipient address is invalid')
   } else if (error.message.includes('max fee')) {
     console.error('The transfer fee exceeds your configured maximum')
+  } else if (error.message.includes('Failed to parse error response')) {
+    console.error('TON API returned an unexpected error response. Check tonApiClient.url and account initialization.')
   } else {
     console.error('Transfer failed:', error.message)
   }
@@ -50,27 +52,25 @@ try {
 ```
 {% endcode %}
 
-## Handle Native TON Transaction Errors
+## Handle Unsupported Native TON Sends
 
-Native TON transactions sent via [`account.sendTransaction()`](../api-reference.md#sendtransaction-tx) can fail for standard reasons:
+Native TON transactions are not supported by `@tetherto/wdk-wallet-ton-gasless`. Calling [`account.sendTransaction()`](../api-reference.md#sendtransaction-tx) throws:
 
-{% code title="Transaction Error Handling" lineNumbers="true" %}
+{% code title="Unsupported Native TON Send" lineNumbers="true" %}
 ```javascript
 try {
-  const result = await account.sendTransaction({
+  await account.sendTransaction({
     to: 'EQ...',
     value: 1000000000
   })
-  console.log('Transaction hash:', result.hash)
 } catch (error) {
-  if (error.message.includes('insufficient balance')) {
-    console.error('Not enough TON to complete transaction')
-  } else {
-    console.error('Transaction failed:', error.message)
-  }
+  console.error(error.message)
+  // Method 'sendTransaction(tx)' not supported on ton gasless.
 }
 ```
 {% endcode %}
+
+Use `@tetherto/wdk-wallet-ton` when you need to send native TON.
 
 ## Best Practices
 

--- a/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts.md
@@ -25,6 +25,10 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 You can access accounts derived from the default BIP-44 path using [`wallet.getAccount()`](../api-reference.md#getaccount-index):
 
+{% hint style="warning" %}
+The gasless TON module's default `getAccount(index)` path is `m/44'/607'/0'/0/{index}`. The non-gasless TON module's current default path is `m/44'/607'/{index}'`, so the same seed phrase can produce different default addresses in each module.
+{% endhint %}
+
 {% code title="Get Accounts by Index" lineNumbers="true" %}
 ```javascript
 const account = await wallet.getAccount(0)

--- a/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.md
@@ -1,6 +1,6 @@
 ---
-title: Send TON
-description: Send native TON transactions and estimate fees.
+title: Native TON Transactions
+description: Understand native TON transaction support in the gasless TON module.
 layout:
   width: default
   title:
@@ -17,28 +17,19 @@ layout:
     visible: false
 ---
 
-# Send TON
+# Native TON Transactions
 
-This guide explains how to [send native TON](#send-native-ton) and [use dynamic fee rates](#use-dynamic-fee-rates). Native TON sends are not gasless; for gasless Jetton token transfers, see [Transfer Jetton Tokens](./transfer-tokens.md).
+This guide explains native TON transaction support in `@tetherto/wdk-wallet-ton-gasless` and how to [use dynamic fee rates](#use-dynamic-fee-rates). For gasless Jetton token transfers, see [Transfer Jetton Tokens](./transfer-tokens.md).
 
 {% hint style="info" %}
 On TON, values are expressed in nanotons (1 TON = 10^9 nanotons).
 {% endhint %}
 
-## Send Native TON
+## Native TON Sends
 
-You can transfer TON to a recipient address using [`account.sendTransaction()`](../api-reference.md#sendtransaction-tx):
+`account.sendTransaction()` is not supported by the gasless TON module. It throws because this module only relays Jetton transfers through the TON API gasless flow.
 
-{% code title="Send TON" lineNumbers="true" %}
-```javascript
-const result = await account.sendTransaction({
-  to: 'EQ...',
-  value: 1000000000 // 1 TON in nanotons
-})
-console.log('Transaction hash:', result.hash)
-console.log('Transaction fee:', result.fee, 'nanotons')
-```
-{% endcode %}
+Use [`@tetherto/wdk-wallet-ton`](../../wallet-ton/) for native TON transfers. If you need to initialize the same gasless address before its first gasless transfer, make sure the initializer uses the same derivation path as the gasless account.
 
 ## Use Dynamic Fee Rates
 

--- a/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages.md
@@ -52,11 +52,11 @@ import { WalletAccountReadOnlyTonGasless } from '@tetherto/wdk-wallet-ton-gasles
 
 const readOnlyAccount = new WalletAccountReadOnlyTonGasless(publicKey, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   },
   tonApiClient: {
-    url: 'https://tonapi.io/v2',
+    url: 'https://tonapi.io',
     secretKey: 'your-ton-api-key'
   },
   paymasterToken: {

--- a/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.md
@@ -25,6 +25,10 @@ This guide explains how to [transfer Jetton tokens gaslessly](#transfer-tokens-g
 
 You can send Jetton tokens gaslessly using [`account.transfer()`](../api-reference.md#transfer-options-config). Fees are deducted from the configured paymaster token:
 
+{% hint style="warning" %}
+The gasless account must be initialized on-chain before TON API can estimate and relay a gasless transfer. If the account is still `uninit`, `account.quoteTransfer()` can fail at the gasless estimate step, and the TON API client may surface the response as a parse error instead of the underlying HTTP status.
+{% endhint %}
+
 {% code title="Gasless Jetton Transfer" lineNumbers="true" %}
 ```javascript
 const result = await account.transfer({

--- a/sdk/wallet-modules/wallet-ton-gasless/usage.md
+++ b/sdk/wallet-modules/wallet-ton-gasless/usage.md
@@ -20,7 +20,7 @@ layout:
 
 # Usage
 
-The `@tetherto/wdk-wallet-ton-gasless` module provides wallet management for the TON blockchain with gasless transaction support, where transfer fees are paid using a configured paymaster token instead of native TON.
+The `@tetherto/wdk-wallet-ton-gasless` module provides wallet management for the TON blockchain with gasless Jetton transfer support, where transfer fees are paid using a configured paymaster token instead of native TON.
 
 
 <table data-card-size="large" data-view="cards">
@@ -53,9 +53,9 @@ The `@tetherto/wdk-wallet-ton-gasless` module provides wallet management for the
     </tr>
     <tr>
       <td><i class="fa-exchange-alt">:exchange-alt:</i></td>
-      <td><strong>Send TON</strong></td>
-      <td>Send native TON transactions.</td>
-      <td><a href="./guides/send-transactions.md">Send TON</a></td>
+      <td><strong>Native TON Transactions</strong></td>
+      <td>Understand native TON transaction support.</td>
+      <td><a href="./guides/send-transactions.md">Native TON Transactions</a></td>
     </tr>
     <tr>
       <td><i class="fa-coins">:coins:</i></td>

--- a/sdk/wallet-modules/wallet-ton/api-reference.md
+++ b/sdk/wallet-modules/wallet-ton/api-reference.md
@@ -45,7 +45,7 @@ new WalletManagerTon(seed, config)
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (object, optional): Configuration object
   - `tonClient` (object | TonClient, optional): TON client configuration or instance
-    - `url` (string): TON Center API URL (e.g., 'https://toncenter.com/api/v3')
+    - `url` (string): TON Center v2 JSON-RPC URL (e.g., 'https://toncenter.com/api/v2/jsonRPC')
     - `secretKey` (string, optional): API key for TON Center
   - `transferMaxFee` (number | bigint, optional): Maximum fee amount for transfer operations (in nanotons)
 
@@ -54,7 +54,7 @@ new WalletManagerTon(seed, config)
 ```javascript
 const wallet = new WalletManagerTon(seedPhrase, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   },
   transferMaxFee: 1000000000 // Maximum fee in nanotons (1 TON)
@@ -155,7 +155,7 @@ new WalletAccountTon(seed, path, config)
 ```javascript
 const account = new WalletAccountTon(seedPhrase, "0'/0/0", {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   },
   transferMaxFee: 10000000 // Maximum fee in nanotons (e.g., 0.01 TON)
@@ -401,7 +401,7 @@ new WalletAccountReadOnlyTon(publicKey, config)
 ```javascript
 const readOnlyAccount = new WalletAccountReadOnlyTon(publicKey, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   }
 })
@@ -734,4 +734,3 @@ interface TonWalletConfig {
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-

--- a/sdk/wallet-modules/wallet-ton/configuration.md
+++ b/sdk/wallet-modules/wallet-ton/configuration.md
@@ -29,7 +29,7 @@ import WalletManagerTon from '@tetherto/wdk-wallet-ton'
 
 const config = {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   },
   transferMaxFee: 10000000 // Optional: maximum fee in nanotons for transfer operations
@@ -45,7 +45,7 @@ import { WalletAccountTon } from '@tetherto/wdk-wallet-ton'
 
 const accountConfig = {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   },
   transferMaxFee: 10000000 // Optional: maximum fee in nanotons for transfer operations
@@ -66,8 +66,8 @@ type TonClientOption = TonClientConfig | TonClient;
 
 interface TonClientConfig {
   /**
-   * TON Center API endpoint URL
-   * @example 'https://toncenter.com/api/v3'
+   * TON Center v2 JSON-RPC endpoint URL
+   * @example 'https://toncenter.com/api/v2/jsonRPC'
    */
   url: string;
 
@@ -86,14 +86,14 @@ interface TonClientConfig {
 // Basic configuration
 const config = {
   tonClient: { 
-    url: 'https://toncenter.com/api/v3'
+    url: 'https://toncenter.com/api/v2/jsonRPC'
   }
 }
 
 // With API key for higher rate limits
 const config = {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   }
 }
@@ -117,7 +117,7 @@ const config = {
 // Example with both options
 const config = {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   },
   transferMaxFee: 1000000000
@@ -133,7 +133,7 @@ import { WalletAccountReadOnlyTon } from '@tetherto/wdk-wallet-ton'
 
 const readOnlyConfig = {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   }
 }
@@ -145,8 +145,8 @@ const readOnlyAccount = new WalletAccountReadOnlyTon(publicKey, readOnlyConfig)
 
 The TON network (mainnet or testnet) is determined by the TON Center API endpoint URL:
 
-- Mainnet: `https://toncenter.com/api/v3`
-- Testnet: `https://testnet.toncenter.com/api/v3`
+- Mainnet: `https://toncenter.com/api/v2/jsonRPC`
+- Testnet: `https://testnet.toncenter.com/api/v2/jsonRPC`
 
 ## Derivation Paths
 
@@ -243,6 +243,5 @@ Use [`getAccountByPath`](./api-reference.md#getaccountbypathpath) to supply an e
 ### Need Help?
 
 {% include "../../../.gitbook/includes/support-cards.md" %}
-
 
 

--- a/sdk/wallet-modules/wallet-ton/guides/check-balances.md
+++ b/sdk/wallet-modules/wallet-ton/guides/check-balances.md
@@ -58,7 +58,7 @@ import { WalletAccountReadOnlyTon } from '@tetherto/wdk-wallet-ton'
 
 const readOnlyAccount = new WalletAccountReadOnlyTon(publicKey, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   }
 })

--- a/sdk/wallet-modules/wallet-ton/guides/get-started.md
+++ b/sdk/wallet-modules/wallet-ton/guides/get-started.md
@@ -46,7 +46,7 @@ const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon aban
 
 const wallet = new WalletManagerTon(seedPhrase, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key' // Optional
   }
 })

--- a/skills/wdk/references/wallet-ton.md
+++ b/skills/wdk/references/wallet-ton.md
@@ -36,7 +36,7 @@ import WalletManagerTonGasless from '@tetherto/wdk-wallet-ton-gasless'
 
 ## Key Details — wallet-ton
 
-- **Derivation**: BIP-44 (`m/44'/607'/0'/0/{index}`)
+- **Derivation**: BIP-44 (`m/44'/607'/{index}'` in v1.0.0-beta.6+)
 - **Key type**: Ed25519
 - **Wallet contract**: V5R1
 - **Fee unit**: nanotons (1 TON = 1,000,000,000 nanotons)
@@ -51,7 +51,7 @@ import WalletManagerTonGasless from '@tetherto/wdk-wallet-ton-gasless'
 ```javascript
 const wallet = new WalletManagerTon(seedPhrase, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'            // Optional but recommended for production
   },
   transferMaxFee: 1000000000n            // Optional: max fee in nanotons
@@ -60,22 +60,23 @@ const wallet = new WalletManagerTon(seedPhrase, {
 
 ## Key Details — wallet-ton-gasless
 
-- Same derivation and key type as wallet-ton
-- **Gasless**: Paymaster covers transaction fees; user pays in Jettons
-- Requires `tonApiClient` and `paymasterToken` config
+- **Derivation**: BIP-44 (`m/44'/607'/0'/0/{index}`), which differs from wallet-ton v1.0.0-beta.6+ defaults
+- Same key type as wallet-ton
+- **Gasless Jetton transfers**: Paymaster covers transaction fees; user pays in Jettons
+- Requires `tonApiClient` base URL and `paymasterToken.address` config
 - **Jetton-to-Jetton only**: `sendTransaction()` **throws** — use `transfer()` only
-- Fee is typically 0 or covered by paymaster
+- Account must be initialized on-chain before TON API can estimate and relay gasless transfers
 
 ## Configuration — wallet-ton-gasless
 
 ```javascript
 const wallet = new WalletManagerTonGasless(seedPhrase, {
   tonClient: {
-    url: 'https://toncenter.com/api/v3',
+    url: 'https://toncenter.com/api/v2/jsonRPC',
     secretKey: 'your-api-key'
   },
   tonApiClient: {
-    url: 'https://tonapi.io/v3',
+    url: 'https://tonapi.io',
     secretKey: 'your-ton-api-key'
   },
   paymasterToken: {


### PR DESCRIPTION
## Summary
- Correct TON Center examples to use the v2 JSON-RPC endpoint required by `@ton/ton`'s `TonClient`.
- Correct TON Gasless `tonApiClient.url` examples to use the TON API base URL and document why `/v2` must not be included.
- Clarify `paymasterToken` shape, `quoteTransfer()` fee-only return value, unsupported native TON sends in the gasless module, on-chain initialization prerequisites, and default derivation path mismatch between TON modules.
- Update the WDK TON reference notes to match the documented behavior.

## Root cause
The docs mixed TON Center v3 REST-style URLs with `@ton/ton` JSON-RPC client usage, and TON API base URLs with paths that the generated TON API client already appends internally. The gasless docs also implied broader native TON transaction support than the module provides.

## Validation
- `git diff --check upstream/develop..HEAD`
- Searched for stale TON Gasless `/api/v3`, `tonapi.io/v2`, raw-string `paymasterToken`, and quote hash examples. Remaining matches are unrelated swap docs or the non-gasless TON module.
- No repo-root `package.json`, so no local docs build command was available.
