### PR TITLE
docs: use absolute links

### DIFF
--- a/content/docs/ai/mcp-toolkit/configuration.mdx
+++ b/content/docs/ai/mcp-toolkit/configuration.mdx
@@ -64,7 +64,7 @@ server.registerWallet('solana', WalletManagerSolana, {
 })
 ```
 
-Each `registerWallet()` call registers the chain name and makes it available to all wallet tools. For configuration details of each wallet module, see the [Wallet Modules](../../sdk/wallet-modules/) documentation.
+Each `registerWallet()` call registers the chain name and makes it available to all wallet tools. For configuration details of each wallet module, see the [Wallet Modules](/sdk/wallet-modules/) documentation.
 
 ***
 
@@ -75,7 +75,7 @@ Enable optional capabilities before registering their tools:
 | Capability | Method | Requirement | Unlocks |
 | --- | --- | --- | --- |
 | **Pricing** | `server.usePricing()` | None | `PRICING_TOOLS` (2 tools) |
-| **Indexer** | `server.useIndexer({ apiKey })` | [WDK API key](../../tools/indexer-api/get-started/#request-api-key) | `INDEXER_TOOLS` (2 tools) |
+| **Indexer** | `server.useIndexer({ apiKey })` | [WDK API key](/tools/indexer-api/get-started/#request-api-key) | `INDEXER_TOOLS` (2 tools) |
 | **Swap** | `server.registerProtocol(chain, label, SwapProtocol)` | Swap module installed | `SWAP_TOOLS` (2 tools) |
 | **Bridge** | `server.registerProtocol(chain, label, BridgeProtocol)` | Bridge module installed | `BRIDGE_TOOLS` (2 tools) |
 | **Lending** | `server.registerProtocol(chain, label, LendingProtocol)` | Lending module installed | `LENDING_TOOLS` (8 tools) |

--- a/content/docs/ai/mcp-toolkit/get-started.mdx
+++ b/content/docs/ai/mcp-toolkit/get-started.mdx
@@ -285,7 +285,7 @@ server.registerTools([
 | Variable | Required | Description |
 | --- | --- | --- |
 | `WDK_SEED` | Yes | BIP-39 seed phrase for wallet derivation |
-| `WDK_INDEXER_API_KEY` | No | Enables `INDEXER_TOOLS` - [get a key](../../tools/indexer-api/get-started/#request-api-key) |
+| `WDK_INDEXER_API_KEY` | No | Enables `INDEXER_TOOLS` - [get a key](/tools/indexer-api/get-started/#request-api-key) |
 | `MOONPAY_API_KEY` | No | Enables `FIAT_TOOLS` - [MoonPay Dashboard](https://dashboard.moonpay.com/) |
 | `MOONPAY_SECRET_KEY` | No | Required with `MOONPAY_API_KEY` |
 

--- a/content/docs/ai/x402.mdx
+++ b/content/docs/ai/x402.mdx
@@ -271,7 +271,7 @@ USD₮0 arrives on the destination chain within a few minutes.
 </Steps>
 
 <Callout type="info">
-You can bridge from any of 25+ supported EVM chains, not just Ethereum. Point your wallet at the source chain's RPC and use the [USD₮ token address](https://tether.to/es/supported-protocols/) on that chain. See the full [bridge module documentation](../sdk/bridge-modules/bridge-usdt0-evm).
+You can bridge from any of 25+ supported EVM chains, not just Ethereum. Point your wallet at the source chain's RPC and use the [USD₮ token address](https://tether.to/es/supported-protocols/) on that chain. See the full [bridge module documentation](/sdk/bridge-modules/bridge-usdt0-evm).
 </Callout>
 
 ***
@@ -569,6 +569,6 @@ app.use(
 - [Semantic Facilitator Docs](https://docs.semanticpay.io) - API reference for the hosted facilitator
 - [Self-Hosted Facilitator Module](https://www.npmjs.com/package/@semanticio/wdk-wallet-evm-x402-facilitator) - Community in-process facilitator
 - [x402-usdt0 Demo](https://github.com/SemanticPay/x402-usdt0-demo) - Full working buyer + seller demo
-- [WDK EVM Wallet Module](../sdk/wallet-modules/wallet-evm) - WDK EVM wallet documentation
+- [WDK EVM Wallet Module](/sdk/wallet-modules/wallet-evm) - WDK EVM wallet documentation
 - [USD₮0 Deployments](https://docs.usdt0.to/technical-documentation/deployments) - Contract addresses on all chains
 - [EIP-3009 Specification](https://eips.ethereum.org/EIPS/eip-3009) - The authorization standard enabling gasless USD₮ transfers

--- a/content/docs/examples-and-starters/react-native-starter.mdx
+++ b/content/docs/examples-and-starters/react-native-starter.mdx
@@ -12,7 +12,7 @@ The React Native Starter Alpha is an Expo + React Native app showing how to buil
 ***
 
 <Callout type="warn">
-**Prerequisites:** Node.js 22+, and either Xcode (iOS) or Android SDK API 29+ (Android). See the [React Native Quickstart](../start-building/react-native-quickstart#prerequisites) for details.
+**Prerequisites:** Node.js 22+, and either Xcode (iOS) or Android SDK API 29+ (Android). See the [React Native Quickstart](/start-building/react-native-quickstart#prerequisites) for details.
 </Callout>
 
 ### Quickstart
@@ -35,7 +35,7 @@ git clone https://github.com/tetherto/wdk-starter-react-native.git && cd wdk-sta
 cp .env.example .env
 ```
 
-Get your free WDK Indexer API key [here](../tools/indexer-api/get-started) and add it to your `.env` file:
+Get your free WDK Indexer API key [here](/tools/indexer-api/get-started) and add it to your `.env` file:
 
 ```bash
 EXPO_PUBLIC_WDK_INDEXER_BASE_URL=https://wdk-api.tether.io
@@ -68,7 +68,7 @@ npm run android # Android Emulator
 ***
 
 <Callout type="info">
-**Need detailed instructions?** Check out the complete [React Native Quickstart](../start-building/react-native-quickstart) guide for step-by-step setup, configuration, and troubleshooting.
+**Need detailed instructions?** Check out the complete [React Native Quickstart](/start-building/react-native-quickstart) guide for step-by-step setup, configuration, and troubleshooting.
 </Callout>
 
 ### Features
@@ -87,9 +87,9 @@ npm run android # Android Emulator
 
 **Asset Management**
 
-* **Real-Time Balances**: Live balance updates via [WDK Indexer](../tools/indexer-api/)
-* **Transaction History**: Complete transaction tracking and history via [WDK Indexer](../tools/indexer-api/)
-* **Price Conversion**: Real-time fiat pricing via [Pricing Provider](../tools/price-rates/)
+* **Real-Time Balances**: Live balance updates via [WDK Indexer](/tools/indexer-api/)
+* **Transaction History**: Complete transaction tracking and history via [WDK Indexer](/tools/indexer-api/)
+* **Price Conversion**: Real-time fiat pricing via [Pricing Provider](/tools/price-rates/)
 
 **User Experience**
 
@@ -165,24 +165,24 @@ Detailed project structure can be found in the [Github Repository](https://githu
 
 **Customizing the UI**
 
-This starter uses components from the [WDK React Native UI Kit](../ui-kits/react-native-ui-kit/). To customize the look and feel:
+This starter uses components from the [WDK React Native UI Kit](/ui-kits/react-native-ui-kit/). To customize the look and feel:
 
-* [**Theming Guide**](../ui-kits/react-native-ui-kit/theming) - Deep dive into theming capabilities
-* [**Component Reference**](../ui-kits/react-native-ui-kit/api-reference) - Complete component documentation
+* [**Theming Guide**](/ui-kits/react-native-ui-kit/theming) - Deep dive into theming capabilities
+* [**Component Reference**](/ui-kits/react-native-ui-kit/api-reference) - Complete component documentation
 
 **Add new functionality**
 
 This starter provides a solid foundation that you can extend with additional functionality:
 
-* **Add support for other tokens** using wallet modules in the [WDK SDK](../sdk/get-started)
-* **Add DeFi protocols** like swaps, bridges, and lending using [protocol modules](../sdk/get-started)
+* **Add support for other tokens** using wallet modules in the [WDK SDK](/sdk/get-started)
+* **Add DeFi protocols** like swaps, bridges, and lending using [protocol modules](/sdk/get-started)
 
 **Or explore documentation**
 
-* [**WDK SDK Documentation**](../sdk/get-started) - Learn about the underlying SDK
-* [**UI Kit Documentation**](../ui-kits/react-native-ui-kit/get-started) - Customize the interface
-* [**WDK Indexer**](../tools/indexer-api/) - Understand data fetching
-* [**Secret Manager**](../tools/secret-manager/) - Learn about secure key management
+* [**WDK SDK Documentation**](/sdk/get-started) - Learn about the underlying SDK
+* [**UI Kit Documentation**](/ui-kits/react-native-ui-kit/get-started) - Customize the interface
+* [**WDK Indexer**](/tools/indexer-api/) - Understand data fetching
+* [**Secret Manager**](/tools/secret-manager/) - Learn about secure key management
 
 ***
 

--- a/content/docs/overview/about.mdx
+++ b/content/docs/overview/about.mdx
@@ -80,26 +80,26 @@ WDK natively supports a broad set of blockchains and standards out of the box:
 <Tab value="wallet" label="Wallet Modules" default>
 | Blockchain/Module                                               | Support |
 | --------------------------------------------------------------- | ------- |
-| [Bitcoin](../sdk/wallet-modules/wallet-btc/)                    | ✅       |
-| [Ethereum & EVM](../sdk/wallet-modules/wallet-evm/)             | ✅       |
-| [Ethereum ERC-4337](../sdk/wallet-modules/wallet-evm-erc-4337/) | ✅       |
-| [TON](../sdk/wallet-modules/wallet-ton/)                        | ✅       |
-| [TON Gasless](../sdk/wallet-modules/wallet-ton-gasless/)        | ✅       |
-| [TRON](../sdk/wallet-modules/wallet-tron/)                      | ✅       |
-| [TRON Gasfree](../sdk/wallet-modules/wallet-tron-gasfree/)      | ✅       |
-| [Solana](../sdk/wallet-modules/wallet-solana/)                  | ✅       |
-| [Spark/Lightning](../sdk/wallet-modules/wallet-spark/)          | ✅       |
+| [Bitcoin](/sdk/wallet-modules/wallet-btc/)                      | ✅       |
+| [Ethereum & EVM](/sdk/wallet-modules/wallet-evm/)               | ✅       |
+| [Ethereum ERC-4337](/sdk/wallet-modules/wallet-evm-erc-4337/)   | ✅       |
+| [TON](/sdk/wallet-modules/wallet-ton/)                          | ✅       |
+| [TON Gasless](/sdk/wallet-modules/wallet-ton-gasless/)          | ✅       |
+| [TRON](/sdk/wallet-modules/wallet-tron/)                        | ✅       |
+| [TRON Gasfree](/sdk/wallet-modules/wallet-tron-gasfree/)        | ✅       |
+| [Solana](/sdk/wallet-modules/wallet-solana/)                    | ✅       |
+| [Spark/Lightning](/sdk/wallet-modules/wallet-spark/)            | ✅       |
 </Tab>
 <Tab value="defi" label="DeFi Modules">
 | Protocol/Module                                                | Support |
 | -------------------------------------------------------------- | ------- |
-| [velora (EVM)](../sdk/swap-modules/swap-velora-evm/)       | ✅       |
+| [velora (EVM)](/sdk/swap-modules/swap-velora-evm/)             | ✅       |
 | StonFi (TON)                                                   | In progress |
-| [USD₮0 Bridge (EVM)](../sdk/bridge-modules/bridge-usdt0-evm/)  | ✅       |
-| [Aave Lending (EVM)](../sdk/lending-modules/lending-aave-evm/) | ✅       |
+| [USD₮0 Bridge (EVM)](/sdk/bridge-modules/bridge-usdt0-evm/)    | ✅       |
+| [Aave Lending (EVM)](/sdk/lending-modules/lending-aave-evm/)   | ✅       |
 </Tab>
 </Tabs>
 
 The modular architecture allows new chains, tokens, or protocols to be added by implementing dedicated modules.
 
-Ready to start building? Explore our [getting started guide](../start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](../sdk/get-started). 
+Ready to start building? Explore our [getting started guide](/start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](/sdk/get-started).

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -37,7 +37,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### April 30, 2026
 
 **What's New**
-- **[React Native Secure Storage](../tools/react-native-secure-storage/)**: Docs added for `@tetherto/wdk-react-native-secure-storage`, covering keychain-backed wallet credential storage, biometric options, and typed errors.
+- **[React Native Secure Storage](/tools/react-native-secure-storage/)**: Docs added for `@tetherto/wdk-react-native-secure-storage`, covering keychain-backed wallet credential storage, biometric options, and typed errors.
 - **wallet-spark** ([v1.0.0-beta.18](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.18)): Add `signTransaction(tx)` to `WalletAccountSpark` for `IWalletAccount` compatibility, document that standalone signed payloads are unsupported on Spark, reuse the cached read-only account helper, and refresh `@buildonspark/spark-sdk` to `0.7.16` and spark bare SDK to `0.0.66`.
 
 ---
@@ -119,7 +119,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### April 3, 2026
 
 **Changes**
-- **wallet-spark** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.12)): [`WalletAccountReadOnlySpark`](../sdk/wallet-modules/wallet-spark/api-reference#walletaccountreadonlyspark) gained [`getTransfers()`](../sdk/wallet-modules/wallet-spark/api-reference#gettransfersoptions), [`getUnusedDepositAddresses()`](../sdk/wallet-modules/wallet-spark/api-reference#getunuseddepositaddressesoptions) (paginated return type), [`getStaticDepositAddresses()`](../sdk/wallet-modules/wallet-spark/api-reference#getstaticdepositaddresses), [`getUtxosForDepositAddress()`](../sdk/wallet-modules/wallet-spark/api-reference#getutxosfordepositaddressoptions), and [`getSparkInvoices()`](../sdk/wallet-modules/wallet-spark/api-reference#getsparkinvoicesparams) (new parameter type). Removed `sparkScanApiKey` config option and `SparkTransactionReceipt` type after dropping the `@sparkscan/api-node-sdk-client` dependency. [`getTransactionReceipt()`](../sdk/wallet-modules/wallet-spark/api-reference#gettransactionreceipthash) now returns `SparkTransfer` instead. Added [`getAccountByPath()`](../sdk/wallet-modules/wallet-spark/api-reference#getaccountbypathpath) to [`WalletManagerSpark`](../sdk/wallet-modules/wallet-spark/api-reference#walletmanagerspark). SIGNET network support documented. Dependency upgrades: `@buildonspark/spark-sdk` 0.7.3, `@buildonspark/bare` 0.0.53.
+- **wallet-spark** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.12)): [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference#walletaccountreadonlyspark) gained [`getTransfers()`](/sdk/wallet-modules/wallet-spark/api-reference#gettransfersoptions), [`getUnusedDepositAddresses()`](/sdk/wallet-modules/wallet-spark/api-reference#getunuseddepositaddressesoptions) (paginated return type), [`getStaticDepositAddresses()`](/sdk/wallet-modules/wallet-spark/api-reference#getstaticdepositaddresses), [`getUtxosForDepositAddress()`](/sdk/wallet-modules/wallet-spark/api-reference#getutxosfordepositaddressoptions), and [`getSparkInvoices()`](/sdk/wallet-modules/wallet-spark/api-reference#getsparkinvoicesparams) (new parameter type). Removed `sparkScanApiKey` config option and `SparkTransactionReceipt` type after dropping the `@sparkscan/api-node-sdk-client` dependency. [`getTransactionReceipt()`](/sdk/wallet-modules/wallet-spark/api-reference#gettransactionreceipthash) now returns `SparkTransfer` instead. Added [`getAccountByPath()`](/sdk/wallet-modules/wallet-spark/api-reference#getaccountbypathpath) to [`WalletManagerSpark`](/sdk/wallet-modules/wallet-spark/api-reference#walletmanagerspark). SIGNET network support documented. Dependency upgrades: `@buildonspark/spark-sdk` 0.7.3, `@buildonspark/bare` 0.0.53.
 
 ---
 
@@ -133,14 +133,14 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### March 24, 2026
 
 **What's New**
-- **[React Native Core](../tools/react-native-core/)**: Added documentation for `@tetherto/wdk-react-native-core` ([v1.0.0-beta.6](https://github.com/tetherto/wdk-core-react-native/releases/tag/v1.0.0-beta.6)), the hooks-based React Native integration layer for WDK. Includes [API Reference](../tools/react-native-core/api-reference) covering `WdkAppProvider`, `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, and more. Updated [React Native Quickstart](../start-building/react-native-quickstart) with step-by-step integration guide.
+- **[React Native Core](/tools/react-native-core/)**: Added documentation for `@tetherto/wdk-react-native-core` ([v1.0.0-beta.6](https://github.com/tetherto/wdk-core-react-native/releases/tag/v1.0.0-beta.6)), the hooks-based React Native integration layer for WDK. Includes [API Reference](/tools/react-native-core/api-reference) covering `WdkAppProvider`, `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, and more. Updated [React Native Quickstart](/start-building/react-native-quickstart) with step-by-step integration guide.
 
 ---
 
 ### March 12, 2026
 
 **Changes**
-- **wallet-btc** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.6)): Added `dispose()` method to [`WalletAccountReadOnlyBtc`](../sdk/wallet-modules/wallet-btc/api-reference#walletaccountreadonlybtc) for closing internal Electrum connections. Security dependency updates.
+- **wallet-btc** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.6)): Added `dispose()` method to [`WalletAccountReadOnlyBtc`](/sdk/wallet-modules/wallet-btc/api-reference#walletaccountreadonlybtc) for closing internal Electrum connections. Security dependency updates.
 
 ---
 
@@ -156,7 +156,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### March 5, 2026
 
 **What's New**
-- **create-wdk-module**: Added documentation for the [`create-wdk-module`](../tools/create-wdk-module) CLI scaffolding tool. Updated [Community Modules](../sdk/community-modules/) and [SDK Get Started](../sdk/get-started) pages with references to the new tool.
+- **create-wdk-module**: Added documentation for the [`create-wdk-module`](/tools/create-wdk-module) CLI scaffolding tool. Updated [Community Modules](/sdk/community-modules/) and [SDK Get Started](/sdk/get-started) pages with references to the new tool.
 
 ---
 
@@ -170,8 +170,8 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 25, 2026
 
 **Changes**
-- **wallet-evm** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.8)): Added [`getTokenBalances(tokenAddresses)`](../sdk/wallet-modules/wallet-evm/api-reference#gettokenbalancestokenaddresses) to [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm), also available on [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference#walletaccountevm) through inheritance.
-- **wallet-evm-erc-4337** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.5)): Added EIP-712 typed data methods [`signTypedData(typedData)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference#signtypeddatatypeddata) and [`verifyTypedData(typedData, signature)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference#verifytypeddatatypeddata-signature), plus multicall token balance method [`getTokenBalances(tokenAddresses)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference#gettokenbalancestokenaddresses).
+- **wallet-evm** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.8)): Added [`getTokenBalances(tokenAddresses)`](/sdk/wallet-modules/wallet-evm/api-reference#gettokenbalancestokenaddresses) to [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm), also available on [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountevm) through inheritance.
+- **wallet-evm-erc-4337** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.5)): Added EIP-712 typed data methods [`signTypedData(typedData)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#signtypeddatatypeddata) and [`verifyTypedData(typedData, signature)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#verifytypeddatatypeddata-signature), plus multicall token balance method [`getTokenBalances(tokenAddresses)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#gettokenbalancestokenaddresses).
 
 ---
 
@@ -185,22 +185,22 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 20, 2026
 
 **What's New**
-- **[Showcase](../overview/showcase)**: More visibility for our showcase page, we value contributions! Added 4 featured community projects: [wdk-mcp](https://github.com/dieselftw/wdk-mcp), [wdk-starter-browser-extension](https://github.com/base58-io/wdk-starter-browser-extension), [wdk-wallet-evm-x402-facilitator](https://github.com/SemanticPay/wdk-wallet-evm-x402-facilitator), and [x402-usdt0](https://github.com/baghdadgherras/x402-usdt0).
-- **[Community Modules](../sdk/community-modules)**: Added [`@base58-io/wdk-wallet-cosmos`](https://github.com/base58-io/wdk-wallet-cosmos) — wallet module for Cosmos-compatible blockchains by [Base58](https://base58.io/).
+- **[Showcase](/overview/showcase)**: More visibility for our showcase page, we value contributions! Added 4 featured community projects: [wdk-mcp](https://github.com/dieselftw/wdk-mcp), [wdk-starter-browser-extension](https://github.com/base58-io/wdk-starter-browser-extension), [wdk-wallet-evm-x402-facilitator](https://github.com/SemanticPay/wdk-wallet-evm-x402-facilitator), and [x402-usdt0](https://github.com/baghdadgherras/x402-usdt0).
+- **[Community Modules](/sdk/community-modules)**: Added [`@base58-io/wdk-wallet-cosmos`](https://github.com/base58-io/wdk-wallet-cosmos) — wallet module for Cosmos-compatible blockchains by [Base58](https://base58.io/).
 
 ---
 
 ### February 18, 2026
 
 **What's New**
-- **[x402 Payments](../ai/x402)**: New guide for accepting and making instant USD₮ payments over HTTP using WDK self-custodial wallets. Covers the x402 protocol, buyer integration with `@tetherto/wdk-wallet-evm`, seller setup with hosted and self-hosted facilitators, and bridging USD₮ to Plasma and Stable chains.
+- **[x402 Payments](/ai/x402)**: New guide for accepting and making instant USD₮ payments over HTTP using WDK self-custodial wallets. Covers the x402 protocol, buyer integration with `@tetherto/wdk-wallet-evm`, seller setup with hosted and self-hosted facilitators, and bridging USD₮ to Plasma and Stable chains.
 
 ---
 
 ### February 15, 2026
 
 **Changes**
-- **wallet-spark**: Added [`getIdentityKey()`](../sdk/wallet-modules/wallet-spark/api-reference#getidentitykey) method to [`WalletAccountReadOnlySpark`](../sdk/wallet-modules/wallet-spark/api-reference#walletaccountreadonlyspark) for retrieving the account's identity public key ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.10))
+- **wallet-spark**: Added [`getIdentityKey()`](/sdk/wallet-modules/wallet-spark/api-reference#getidentitykey) method to [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference#walletaccountreadonlyspark) for retrieving the account's identity public key ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.10))
 
 ---
 
@@ -214,25 +214,25 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 12, 2026
 
 **What's New**
-- **[Agent Skills](../ai/agent-skills)**: New page covering WDK's agent skill capabilities, self-custodial vs hosted comparison, and platform compatibility with OpenClaw, Claude, Cursor, and other agent platforms.
-- **[OpenClaw Integration](../ai/openclaw)**: New page for installing and configuring the WDK skill in OpenClaw via ClawHub, including security precautions for running agents locally.
+- **[Agent Skills](/ai/agent-skills)**: New page covering WDK's agent skill capabilities, self-custodial vs hosted comparison, and platform compatibility with OpenClaw, Claude, Cursor, and other agent platforms.
+- **[OpenClaw Integration](/ai/openclaw)**: New page for installing and configuring the WDK skill in OpenClaw via ClawHub, including security precautions for running agents locally.
 
 **Changes**
 - **wallet-evm** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.7)): Added [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data support:
-  - Added [`signTypedData(typedData)`](../sdk/wallet-modules/wallet-evm/api-reference#signtypeddatatypeddata) method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference#walletaccountevm) for signing structured data
-  - Added [`verifyTypedData(typedData, signature)`](../sdk/wallet-modules/wallet-evm/api-reference#verifytypeddatatypeddata-signature) method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference#walletaccountevm) and [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm) for verifying typed data signatures
+  - Added [`signTypedData(typedData)`](/sdk/wallet-modules/wallet-evm/api-reference#signtypeddatatypeddata) method to [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountevm) for signing structured data
+  - Added [`verifyTypedData(typedData, signature)`](/sdk/wallet-modules/wallet-evm/api-reference#verifytypeddatatypeddata-signature) method to [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountevm) and [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm) for verifying typed data signatures
 - **wallet-evm-erc-4337** ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.4)):
-  - Added 2 new gas payment modes: [Sponsorship Policy](../sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags) and [Native Coins](../sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags), alongside the existing Paymaster Token mode
-  - Added per-call [config override](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference#config-override) parameter to `sendTransaction`, `transfer`, `quoteSendTransaction`, and `quoteTransfer`
-  - Added [`getUserOperationReceipt(hash)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference#getuseroperationreceipthash) method for retrieving ERC-4337 UserOperation receipts
-  - Added [`ConfigurationError`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference#configurationerror) error type for invalid configuration validation
+  - Added 2 new gas payment modes: [Sponsorship Policy](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags) and [Native Coins](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags), alongside the existing Paymaster Token mode
+  - Added per-call [config override](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#config-override) parameter to `sendTransaction`, `transfer`, `quoteSendTransaction`, and `quoteTransfer`
+  - Added [`getUserOperationReceipt(hash)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#getuseroperationreceipthash) method for retrieving ERC-4337 UserOperation receipts
+  - Added [`ConfigurationError`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#configurationerror) error type for invalid configuration validation
 
 ---
 
 ### February 10, 2026
 
 **What's New**
-- **[MCP Toolkit](../ai/mcp-toolkit)**: New documentation for `@tetherto/wdk-mcp-toolkit` (`v1.0.0-beta.1`). Covers the `WdkMcpServer` class, 35 built-in MCP tools across 7 categories (wallet, pricing, indexer, swap, bridge, lending, fiat), setup wizard, multi-tool configuration, and full API reference.
+- **[MCP Toolkit](/ai/mcp-toolkit)**: New documentation for `@tetherto/wdk-mcp-toolkit` (`v1.0.0-beta.1`). Covers the `WdkMcpServer` class, 35 built-in MCP tools across 7 categories (wallet, pricing, indexer, swap, bridge, lending, fiat), setup wizard, multi-tool configuration, and full API reference.
 
 ---
 
@@ -246,8 +246,8 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 02, 2026
 
 **Changes**
-- **wallet-ton-gasless**: Added `verify` method to [`WalletAccountReadOnlyTonGasless`](../sdk/wallet-modules/wallet-ton-gasless/api-reference#walletaccountreadonlytongasless) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.4))
-- **wallet-tron-gasfree**: Added `verify` method to [`WalletAccountReadOnlyTronGasfree`](../sdk/wallet-modules/wallet-tron-gasfree/api-reference#walletaccountreadonlytrongasfree) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron-gasfree/releases/tag/v1.0.0-beta.4))
+- **wallet-ton-gasless**: Added `verify` method to [`WalletAccountReadOnlyTonGasless`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#walletaccountreadonlytongasless) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.4))
+- **wallet-tron-gasfree**: Added `verify` method to [`WalletAccountReadOnlyTronGasfree`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#walletaccountreadonlytrongasfree) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron-gasfree/releases/tag/v1.0.0-beta.4))
 
 ---
 
@@ -267,27 +267,27 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 **Changes**
 - **wallet-btc** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.5)):
-  - Added `verify` method to [`WalletAccountReadOnlyBtc`](../sdk/wallet-modules/wallet-btc/api-reference#walletaccountreadonlybtc)
-  - Added Pluggable Transport classes: [`ElectrumTcp`](../sdk/wallet-modules/wallet-btc/api-reference#electrumtcp), [`ElectrumTls`](../sdk/wallet-modules/wallet-btc/api-reference#electrumtls), [`ElectrumSsl`](../sdk/wallet-modules/wallet-btc/api-reference#electrumssl), [`ElectrumWs`](../sdk/wallet-modules/wallet-btc/api-reference#electrumws)
-- **wallet-evm**: Added `verify` method to [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.5))
-- **wallet-solana**: Added `verify` method to [`WalletAccountReadOnlySolana`](../sdk/wallet-modules/wallet-solana/api-reference#walletaccountreadonlysolana) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.5))
-- **wallet-ton**: Added `verify` method to [`WalletAccountReadOnlyTon`](../sdk/wallet-modules/wallet-ton/api-reference#walletaccountreadonlyton) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-ton/releases/tag/v1.0.0-beta.7))
-- **wallet-tron**: Added `verify` method to [`WalletAccountReadOnlyTron`](../sdk/wallet-modules/wallet-tron/api-reference#walletaccountreadonlytron) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.4))
-- **wallet-spark**: Added `verify` method to [`WalletAccountReadOnlySpark`](../sdk/wallet-modules/wallet-spark/api-reference#walletaccountreadonlyspark) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.7))
+  - Added `verify` method to [`WalletAccountReadOnlyBtc`](/sdk/wallet-modules/wallet-btc/api-reference#walletaccountreadonlybtc)
+  - Added Pluggable Transport classes: [`ElectrumTcp`](/sdk/wallet-modules/wallet-btc/api-reference#electrumtcp), [`ElectrumTls`](/sdk/wallet-modules/wallet-btc/api-reference#electrumtls), [`ElectrumSsl`](/sdk/wallet-modules/wallet-btc/api-reference#electrumssl), [`ElectrumWs`](/sdk/wallet-modules/wallet-btc/api-reference#electrumws)
+- **wallet-evm**: Added `verify` method to [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.5))
+- **wallet-solana**: Added `verify` method to [`WalletAccountReadOnlySolana`](/sdk/wallet-modules/wallet-solana/api-reference#walletaccountreadonlysolana) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.5))
+- **wallet-ton**: Added `verify` method to [`WalletAccountReadOnlyTon`](/sdk/wallet-modules/wallet-ton/api-reference#walletaccountreadonlyton) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-ton/releases/tag/v1.0.0-beta.7))
+- **wallet-tron**: Added `verify` method to [`WalletAccountReadOnlyTron`](/sdk/wallet-modules/wallet-tron/api-reference#walletaccountreadonlytron) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.4))
+- **wallet-spark**: Added `verify` method to [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference#walletaccountreadonlyspark) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.7))
 
 ---
 
 ### January 23, 2026
 
 **What's New**
-- **wdk-core docs**: Added comprehensive [Core Module Guides](../sdk/core-module/guides/getting-started) covering:
-  - [Getting Started](../sdk/core-module/guides/getting-started) - Installation and instantiation
-  - [Wallet Registration](../sdk/core-module/guides/wallet-registration) - Registering wallet modules for different blockchains
-  - [Account Management](../sdk/core-module/guides/account-management) - Working with accounts and addresses
-  - [Transactions](../sdk/core-module/guides/transactions) - Sending native tokens
-  - [Protocol Integration](../sdk/core-module/guides/protocol-integration) - Using swaps, bridges, and lending protocols
-  - [Middleware](../sdk/core-module/guides/middleware) - Configuring logging and failover protection
-  - [Error Handling](../sdk/core-module/guides/error-handling) - Best practices and memory management
+- **wdk-core docs**: Added comprehensive [Core Module Guides](/sdk/core-module/guides/getting-started) covering:
+  - [Getting Started](/sdk/core-module/guides/getting-started) - Installation and instantiation
+  - [Wallet Registration](/sdk/core-module/guides/wallet-registration) - Registering wallet modules for different blockchains
+  - [Account Management](/sdk/core-module/guides/account-management) - Working with accounts and addresses
+  - [Transactions](/sdk/core-module/guides/transactions) - Sending native tokens
+  - [Protocol Integration](/sdk/core-module/guides/protocol-integration) - Using swaps, bridges, and lending protocols
+  - [Middleware](/sdk/core-module/guides/middleware) - Configuring logging and failover protection
+  - [Error Handling](/sdk/core-module/guides/error-handling) - Best practices and memory management
 - **wdk-core**: Added support for 24-word seed phrases via `WDK.getRandomSeedPhrase(24)`
 - **indexer-api**:
   - Added new `/api/v1/chains` endpoint to list supported blockchains and tokens
@@ -317,13 +317,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### December 23, 2025
 
 **What's New**
-- Added [MoonPay Fiat Module](../sdk/fiat-modules/fiat-moonpay/) for on-ramp and off-ramp functionality
-- Added [Community Modules](../sdk/community-modules/) section to highlight community-built modules
+- Added [MoonPay Fiat Module](/sdk/fiat-modules/fiat-moonpay/) for on-ramp and off-ramp functionality
+- Added [Community Modules](/sdk/community-modules/) section to highlight community-built modules
 
 **Changes**
 - Added this changelog page in the docs!
 - **wallet-spark**: Updated Spark SDK to latest version ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.6))
-- Introduced [All Modules](../sdk/all-modules) page in docs for comprehensive module listings
+- Introduced [All Modules](/sdk/all-modules) page in docs for comprehensive module listings
 - Reorganized documentation structure for better navigation
 
 ---

--- a/content/docs/overview/showcase.mdx
+++ b/content/docs/overview/showcase.mdx
@@ -13,7 +13,7 @@ Tether and the WDK Team do not endorse or assume responsibility for their code, 
 </Callout>
 
 <Callout type="info">
-Looking for community-built WDK modules you can install and use in your project? Check out the [Community Modules](../sdk/community-modules/) page instead.
+Looking for community-built WDK modules you can install and use in your project? Check out the [Community Modules](/sdk/community-modules/) page instead.
 </Callout>
 
 ## Featured Projects

--- a/content/docs/overview/vision.mdx
+++ b/content/docs/overview/vision.mdx
@@ -59,4 +59,4 @@ Join us in building this future. The tools are open-source, the vision is clear,
 
 ***
 
-Ready to start building? Explore our [getting started guide](../start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](../sdk/get-started).
+Ready to start building? Explore our [getting started guide](/start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](/sdk/get-started).

--- a/content/docs/sdk/all-modules.mdx
+++ b/content/docs/sdk/all-modules.mdx
@@ -13,7 +13,7 @@ The orchestrator that manages all WDK modules.
 
 | Module | Description | Documentation |
 |--------|-------------|---------------|
-| [`@tetherto/wdk-core`](https://github.com/tetherto/wdk-core) | Central orchestrator for all WDK modules | [Docs](./core-module/) |
+| [`@tetherto/wdk-core`](https://github.com/tetherto/wdk-core) | Central orchestrator for all WDK modules | [Docs](/sdk/core-module/) |
 
 ## Wallet Modules
 
@@ -21,15 +21,15 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 
 | Module | Blockchain | Description | Documentation |
 |--------|------------|-------------|---------------|
-| [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | Bitcoin SegWit wallet with BIP-39/BIP-44 support | [Docs](./wallet-modules/wallet-btc/) |
-| [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | Ethereum and EVM-compatible chains wallet | [Docs](./wallet-modules/wallet-evm/) |
-| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](./wallet-modules/wallet-evm-erc-4337/) |
-| [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | TON blockchain wallet | [Docs](./wallet-modules/wallet-ton/) |
-| [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | Gasless transactions on TON | [Docs](./wallet-modules/wallet-ton-gasless/) |
-| [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | TRON blockchain wallet | [Docs](./wallet-modules/wallet-tron/) |
-| [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | Gas-free transactions on TRON | [Docs](./wallet-modules/wallet-tron-gasfree/) |
-| [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | Solana blockchain wallet | [Docs](./wallet-modules/wallet-solana/) |
-| [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | Spark/Lightning Bitcoin L2 wallet | [Docs](./wallet-modules/wallet-spark/) |
+| [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | Bitcoin SegWit wallet with BIP-39/BIP-44 support | [Docs](/sdk/wallet-modules/wallet-btc/) |
+| [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | Ethereum and EVM-compatible chains wallet | [Docs](/sdk/wallet-modules/wallet-evm/) |
+| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-erc-4337/) |
+| [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | TON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-ton/) |
+| [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | Gasless transactions on TON | [Docs](/sdk/wallet-modules/wallet-ton-gasless/) |
+| [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | TRON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-tron/) |
+| [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | Gas-free transactions on TRON | [Docs](/sdk/wallet-modules/wallet-tron-gasfree/) |
+| [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | Solana blockchain wallet | [Docs](/sdk/wallet-modules/wallet-solana/) |
+| [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | Spark/Lightning Bitcoin L2 wallet | [Docs](/sdk/wallet-modules/wallet-spark/) |
 
 ## Swap Modules
 
@@ -37,7 +37,7 @@ DEX swap functionality for token exchanges.
 
 | Module | Blockchain | Description | Documentation |
 |--------|------------|-------------|---------------|
-| [`@tetherto/wdk-protocol-swap-velora-evm`](https://github.com/tetherto/wdk-protocol-swap-velora-evm) | EVM | DEX aggregator swap on EVM chains | [Docs](./swap-modules/swap-velora-evm/) |
+| [`@tetherto/wdk-protocol-swap-velora-evm`](https://github.com/tetherto/wdk-protocol-swap-velora-evm) | EVM | DEX aggregator swap on EVM chains | [Docs](/sdk/swap-modules/swap-velora-evm/) |
 
 ## Bridge Modules
 
@@ -45,7 +45,7 @@ Cross-chain bridge functionality for token transfers between blockchains.
 
 | Module | Route | Description | Documentation |
 |--------|-------|-------------|---------------|
-| [`@tetherto/wdk-protocol-bridge-usdt0-evm`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm) | EVM → EVM + Non-EVM | USD₮0 bridging from EVM source chains to EVM and non-EVM destinations | [Docs](./bridge-modules/bridge-usdt0-evm/) |
+| [`@tetherto/wdk-protocol-bridge-usdt0-evm`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm) | EVM → EVM + Non-EVM | USD₮0 bridging from EVM source chains to EVM and non-EVM destinations | [Docs](/sdk/bridge-modules/bridge-usdt0-evm/) |
 
 ## Lending Modules
 
@@ -53,7 +53,7 @@ DeFi lending and borrowing functionality.
 
 | Module | Blockchain | Description | Documentation |
 |--------|------------|-------------|---------------|
-| [`@tetherto/wdk-protocol-lending-aave-evm`](https://github.com/tetherto/wdk-protocol-lending-aave-evm) | EVM | Aave protocol integration for EVM | [Docs](./lending-modules/lending-aave-evm/) |
+| [`@tetherto/wdk-protocol-lending-aave-evm`](https://github.com/tetherto/wdk-protocol-lending-aave-evm) | EVM | Aave protocol integration for EVM | [Docs](/sdk/lending-modules/lending-aave-evm/) |
 
 ## Fiat Modules
 
@@ -61,11 +61,11 @@ On-ramp and off-ramp functionality for fiat currency integration.
 
 | Module | Provider | Description | Documentation |
 |--------|----------|-------------|---------------|
-| [`@tetherto/wdk-protocol-fiat-moonpay`](https://github.com/tetherto/wdk-protocol-fiat-moonpay) | MoonPay | MoonPay integration for fiat on-ramp | [Docs](./fiat-modules/fiat-moonpay/) |
+| [`@tetherto/wdk-protocol-fiat-moonpay`](https://github.com/tetherto/wdk-protocol-fiat-moonpay) | MoonPay | MoonPay integration for fiat on-ramp | [Docs](/sdk/fiat-modules/fiat-moonpay/) |
 
 ## Community Modules
 
-Modules built by the WDK community. See the [Community Modules](./community-modules/) page for more details.
+Modules built by the WDK community. See the [Community Modules](/sdk/community-modules/) page for more details.
 
 | Module | Blockchain | Description | Documentation |
 |--------|------------|-------------|---------------|

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/api-reference.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/api-reference.mdx
@@ -425,13 +425,13 @@ async function gaslessBridge() {
 ```
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="WDK Bridge USD₮0 EVM Protocol Configuration" href="./configuration">
+<Card title="WDK Bridge USD₮0 EVM Protocol Configuration" href="/sdk/bridge-modules/bridge-usdt0-evm/configuration">
 Get started with WDK's Bridge USD₮0 EVM Protocol configuration
 </Card>
-<Card title="WDK Bridge USD₮0 EVM Protocol Usage" href="./usage">
+<Card title="WDK Bridge USD₮0 EVM Protocol Usage" href="/sdk/bridge-modules/bridge-usdt0-evm/usage">
 Get started with WDK's Bridge USD₮0 EVM Protocol usage
 </Card>
 </Cards>

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/configuration.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/configuration.mdx
@@ -292,13 +292,13 @@ try {
 ```
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="WDK Bridge USD₮0 EVM Protocol API" href="./api-reference">
+<Card title="WDK Bridge USD₮0 EVM Protocol API" href="/sdk/bridge-modules/bridge-usdt0-evm/api-reference">
 Get started with WDK's Bridge USD₮0 EVM Protocol API
 </Card>
-<Card title="WDK Bridge USD₮0 EVM Protocol Usage" href="./usage">
+<Card title="WDK Bridge USD₮0 EVM Protocol Usage" href="/sdk/bridge-modules/bridge-usdt0-evm/usage">
 Get started with WDK's Bridge USD₮0 EVM Protocol usage
 </Card>
 </Cards>

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.mdx
@@ -3,17 +3,17 @@ title: Bridge Cross-Ecosystem
 description: Send USD₮0 from EVM toward Solana, TON, or TRON recipients.
 ---
 
-This guide covers [prerequisites](#prerequisites) and how to [bridge to Solana](#bridge-to-solana), [bridge to TON](#bridge-to-ton), and [bridge to TRON](#bridge-to-tron) using [`bridge()`](../api-reference#bridgeoptions-config). The same [`Usdt0ProtocolEvm`](../api-reference#usdt0protocolevm) instance you use for EVM destinations applies; only `targetChain` and `recipient` formats change.
+This guide covers [prerequisites](#prerequisites) and how to [bridge to Solana](#bridge-to-solana), [bridge to TON](#bridge-to-ton), and [bridge to TRON](#bridge-to-tron) using [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config). The same [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#usdt0protocolevm) instance you use for EVM destinations applies; only `targetChain` and `recipient` formats change.
 
 ## Prerequisites
 
-A [`Usdt0ProtocolEvm`](../api-reference#usdt0protocolevm) backed by a non-read-only EVM account, with enough USD₮ (and native gas for non-4337 accounts) on the source chain. Approve the source-chain bridge spender before calling [`bridge()`](../api-reference#bridgeoptions-config). Recipient strings must match each network’s address encoding.
+A [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#usdt0protocolevm) backed by a non-read-only EVM account, with enough USD₮ (and native gas for non-4337 accounts) on the source chain. Approve the source-chain bridge spender before calling [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config). Recipient strings must match each network’s address encoding.
 
-For `USDT_BRIDGE_SPENDER_ADDRESS`, use the source-chain OFT or bridge contract for the route. See [Bridge Tokens](./bridge-tokens#prerequisites) for address sources.
+For `USDT_BRIDGE_SPENDER_ADDRESS`, use the source-chain OFT or bridge contract for the route. See [Bridge Tokens](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens#prerequisites) for address sources.
 
 ## Bridge to Solana
 
-You can set `targetChain` to `solana` and pass a base58 Solana address as `recipient` when calling [`bridge()`](../api-reference#bridgeoptions-config):
+You can set `targetChain` to `solana` and pass a base58 Solana address as `recipient` when calling [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config):
 
 ```javascript title="Bridge toward Solana"
 const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
@@ -44,7 +44,7 @@ Validate Solana addresses (length and base58 alphabet) before bridging. A malfor
 
 ## Bridge to TON
 
-You can set `targetChain` to `ton` and supply a TON user-friendly or raw address string as `recipient` in [`bridge()`](../api-reference#bridgeoptions-config):
+You can set `targetChain` to `ton` and supply a TON user-friendly or raw address string as `recipient` in [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config):
 
 ```javascript title="Bridge toward TON"
 const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
@@ -70,7 +70,7 @@ console.log('TON bridge hash:', tonResult.hash)
 
 ## Bridge to TRON
 
-You can set `targetChain` to `tron` and pass a base58Check TRON address (typically starting with `T`) to [`bridge()`](../api-reference#bridgeoptions-config):
+You can set `targetChain` to `tron` and pass a base58Check TRON address (typically starting with `T`) to [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config):
 
 ```javascript title="Bridge toward TRON"
 const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
@@ -95,9 +95,9 @@ console.log('TRON bridge hash:', tronResult.hash)
 ```
 
 <Callout type="info">
-LayerZero endpoint IDs for these destinations are listed under [Supported chains](../api-reference#supported-chains) in the API reference.
+LayerZero endpoint IDs for these destinations are listed under [Supported chains](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#supported-chains) in the API reference.
 </Callout>
 
 ## Next Steps
 
-Harden integrations with [Handle errors](./handle-errors), or return to [Bridge tokens](./bridge-tokens) for EVM-only flows and quotes.
+Harden integrations with [Handle errors](/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors), or return to [Bridge tokens](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens) for EVM-only flows and quotes.

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens.mdx
@@ -7,15 +7,15 @@ This guide covers [prerequisites](#prerequisites), how to [run a standard EVM-to
 
 ## Prerequisites
 
-Complete [Get Started](./get-started): an account from [`new WalletAccountEvm(seed, path, config?)`](../../../wallet-modules/wallet-evm/api-reference#constructor-1) and a bridge from [`new Usdt0ProtocolEvm(account, config?)`](../api-reference#constructor). The source chain RPC must match the account network.
+Complete [Get Started](/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started): an account from [`new WalletAccountEvm(seed, path, config?)`](/sdk/wallet-modules/wallet-evm/api-reference#constructor-1) and a bridge from [`new Usdt0ProtocolEvm(account, config?)`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#constructor). The source chain RPC must match the account network.
 
-Before calling [`bridge()`](../api-reference#bridgeoptions-config), approve the source-chain bridge spender for the token and amount you want to bridge. If you pass `oftContractAddress`, use the same address as the approval `spender`.
+Before calling [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config), approve the source-chain bridge spender for the token and amount you want to bridge. If you pass `oftContractAddress`, use the same address as the approval `spender`.
 
 For placeholder values such as `USDT0_OFT_ADDRESS`, use the current token and bridge contract addresses from the [USDT0 deployments](https://docs.usdt0.to/technical-documentation/deployments). For the route mapping used by the WDK package, see the package [`src/config.js`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/blob/main/src/config.js), especially `oftContract`, `legacyMeshContract`, and `xautOftContract`.
 
 ## Run a standard EVM-to-EVM bridge
 
-You can move USD₮ on the source chain toward another EVM chain by calling [`bridge()`](../api-reference#bridgeoptions-config) with `targetChain`, `recipient`, `token`, and `amount` (token base units). Amount `1000000n` is 1 USD₮ when the token uses 6 decimals.
+You can move USD₮ on the source chain toward another EVM chain by calling [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) with `targetChain`, `recipient`, `token`, and `amount` (token base units). Amount `1000000n` is 1 USD₮ when the token uses 6 decimals.
 
 ```javascript title="Standard EVM bridge"
 const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
@@ -47,7 +47,7 @@ console.log('Bridge fee:', result.bridgeFee, 'wei')
 
 ## Quote bridge fees
 
-You can estimate gas and protocol fees without sending transactions using [`quoteBridge()`](../api-reference#quotebridgeoptions-config):
+You can estimate gas and protocol fees without sending transactions using [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config):
 
 ```javascript title="Quote before bridging"
 const quote = await bridgeProtocol.quoteBridge({
@@ -61,15 +61,15 @@ console.log('Estimated fee:', quote.fee, 'wei')
 console.log('Bridge fee:', quote.bridgeFee, 'wei')
 ```
 
-Compare `quote.fee` and `quote.bridgeFee` to your risk limits before calling [`bridge()`](../api-reference#bridgeoptions-config).
+Compare `quote.fee` and `quote.bridgeFee` to your risk limits before calling [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config).
 
 <Callout type="info">
-Some providers estimate the bridge transaction during [`quoteBridge()`](../api-reference#quotebridgeoptions-config). If the estimate fails because allowance is missing, approve the same `token`, `spender`, and `amount` before quoting.
+Some providers estimate the bridge transaction during [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config). If the estimate fails because allowance is missing, approve the same `token`, `spender`, and `amount` before quoting.
 </Callout>
 
 ## Override OFT contract and destination endpoint
 
-You can point [`bridge()`](../api-reference#bridgeoptions-config) at a specific OFT contract and LayerZero destination endpoint ID when auto-resolution is not enough. Supply values from your deployment or integration configuration (environment variables shown for illustration):
+You can point [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) at a specific OFT contract and LayerZero destination endpoint ID when auto-resolution is not enough. Supply values from your deployment or integration configuration (environment variables shown for illustration):
 
 ```javascript title="Custom OFT and dstEid on bridge"
 const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
@@ -94,7 +94,7 @@ const result = await bridgeProtocol.bridge({
 console.log('Bridge transaction hash:', result.hash)
 ```
 
-You can obtain matching fee estimates with [`quoteBridge()`](../api-reference#quotebridgeoptions-config) using the same `oftContractAddress` and `dstEid` fields:
+You can obtain matching fee estimates with [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) using the same `oftContractAddress` and `dstEid` fields:
 
 ```javascript title="Quote with OFT overrides"
 const customQuote = await bridgeProtocol.quoteBridge({
@@ -115,7 +115,7 @@ Invalid pairings of `oftContractAddress` and `dstEid` fail at execution time. Va
 
 ## Cap fees with bridgeMaxFee
 
-You can pass `bridgeMaxFee` into the [`new Usdt0ProtocolEvm(account, config?)`](../api-reference#constructor) constructor so [`bridge()`](../api-reference#bridgeoptions-config) rejects operations whose cost exceeds the cap:
+You can pass `bridgeMaxFee` into the [`new Usdt0ProtocolEvm(account, config?)`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#constructor) constructor so [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) rejects operations whose cost exceeds the cap:
 
 ```javascript title="Protocol-level bridgeMaxFee"
 import Usdt0ProtocolEvm from '@tetherto/wdk-protocol-bridge-usdt0-evm'
@@ -126,9 +126,9 @@ const cappedBridge = new Usdt0ProtocolEvm(account, {
 ```
 
 <Callout type="warn">
-If the quote exceeds `bridgeMaxFee`, [`bridge()`](../api-reference#bridgeoptions-config) throws (for example when the message includes `Exceeded maximum fee`). ERC-4337 accounts can also pass `bridgeMaxFee` in the second argument to [`bridge()`](../api-reference#bridgeoptions-config); see [Bridge with ERC-4337](./bridge-with-4337).
+If the quote exceeds `bridgeMaxFee`, [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) throws (for example when the message includes `Exceeded maximum fee`). ERC-4337 accounts can also pass `bridgeMaxFee` in the second argument to [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config); see [Bridge with ERC-4337](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337).
 </Callout>
 
 ## Next Steps
 
-Bridge to Solana, TON, or TRON in [Bridge cross-ecosystem](./bridge-cross-ecosystem), or switch to a smart account in [Bridge with ERC-4337](./bridge-with-4337).
+Bridge to Solana, TON, or TRON in [Bridge cross-ecosystem](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem), or switch to a smart account in [Bridge with ERC-4337](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337).

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.mdx
@@ -12,7 +12,7 @@ This guide covers [prerequisites](#prerequisites), how to [create an ERC-4337 ac
 
 ## Create a WalletAccountEvmErc4337 account
 
-You can construct an ERC-4337 signing account using [`new WalletAccountEvmErc4337(seed, path, config)`](../../../wallet-modules/wallet-evm-erc-4337/api-reference#constructor-1) with chain, provider, bundler, entry point, and paymaster settings:
+You can construct an ERC-4337 signing account using [`new WalletAccountEvmErc4337(seed, path, config)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#constructor-1) with chain, provider, bundler, entry point, and paymaster settings:
 
 ```javascript title="ERC-4337 account on Arbitrum"
 import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -31,7 +31,7 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 })
 ```
 
-You can wrap that account with the [`new Usdt0ProtocolEvm(account, config?)`](../api-reference#constructor) constructor:
+You can wrap that account with the [`new Usdt0ProtocolEvm(account, config?)`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#constructor) constructor:
 
 ```javascript title="Usdt0ProtocolEvm with ERC-4337 account"
 import Usdt0ProtocolEvm from '@tetherto/wdk-protocol-bridge-usdt0-evm'
@@ -43,7 +43,7 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 
 ## Run a gasless bridge with paymaster options
 
-You can execute [`bridge()`](../api-reference#bridgeoptions-config) with a second argument that includes `paymasterToken` (and optional `bridgeMaxFee` override) as described in the [methods table](../api-reference#methods). Approve the source-chain bridge spender first, then call [`bridge()`](../api-reference#bridgeoptions-config). Each call returns one hash for the submitted user operation.
+You can execute [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) with a second argument that includes `paymasterToken` (and optional `bridgeMaxFee` override) as described in the [methods table](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#methods). Approve the source-chain bridge spender first, then call [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config). Each call returns one hash for the submitted user operation.
 
 ```javascript title="Gasless bridge with paymasterToken"
 const USDT_TOKEN_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7'
@@ -86,4 +86,4 @@ Paymaster policies, token addresses, and URLs are service-specific. Confirm supp
 
 ## Next Steps
 
-Bridge to non-EVM chains in [Bridge cross-ecosystem](./bridge-cross-ecosystem). For failure modes and cleanup, read [Handle errors](./handle-errors).
+Bridge to non-EVM chains in [Bridge cross-ecosystem](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem). For failure modes and cleanup, read [Handle errors](/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors).

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started.mdx
@@ -20,7 +20,7 @@ npm install @tetherto/wdk-protocol-bridge-usdt0-evm
 
 ## Create an EVM account
 
-You can construct a signing account using [`new WalletAccountEvm(seed, path, config?)`](../../../wallet-modules/wallet-evm/api-reference) from `@tetherto/wdk-wallet-evm` with an RPC `provider`:
+You can construct a signing account using [`new WalletAccountEvm(seed, path, config?)`](/sdk/wallet-modules/wallet-evm/api-reference) from `@tetherto/wdk-wallet-evm` with an RPC `provider`:
 
 ```javascript title="Create WalletAccountEvm"
 import { WalletAccountEvm } from '@tetherto/wdk-wallet-evm'
@@ -38,7 +38,7 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 ## Instantiate the bridge protocol
 
-You can create a [`Usdt0ProtocolEvm`](../api-reference) instance with the [`new Usdt0ProtocolEvm(account, config?)`](../api-reference) constructor. Optional `bridgeMaxFee` caps the total bridge cost in wei (see [BridgeProtocolConfig](../api-reference)):
+You can create a [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference) instance with the [`new Usdt0ProtocolEvm(account, config?)`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference) constructor. Optional `bridgeMaxFee` caps the total bridge cost in wei (see [BridgeProtocolConfig](/sdk/bridge-modules/bridge-usdt0-evm/api-reference)):
 
 ```javascript title="Construct Usdt0ProtocolEvm"
 import Usdt0ProtocolEvm from '@tetherto/wdk-protocol-bridge-usdt0-evm'
@@ -49,12 +49,12 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 ```
 
 <Callout type="info">
-The account must not be read-only. Read-only accounts cannot call [`bridge()`](../api-reference).
+The account must not be read-only. Read-only accounts cannot call [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference).
 </Callout>
 
 ## Supported chains
 
-Bridge operations use EVM source chains listed in the [API reference](../api-reference). Destination routes include the same EVM set where USD₮0 contracts are deployed, plus Solana (EID 30168), TON (EID 30343), and TRON (EID 30420).
+Bridge operations use EVM source chains listed in the [API reference](/sdk/bridge-modules/bridge-usdt0-evm/api-reference). Destination routes include the same EVM set where USD₮0 contracts are deployed, plus Solana (EID 30168), TON (EID 30343), and TRON (EID 30420).
 
 **Source chains (EVM, `targetChain` keys)**
 
@@ -83,7 +83,7 @@ Bridge operations use EVM source chains listed in the [API reference](../api-ref
 | Unichain | `unichain` | 130 |
 | XLayer | `xlayer` | 196 |
 
-Arbitrum supports ERC-4337 workflows (see [Bridge with ERC-4337](./bridge-with-4337)).
+Arbitrum supports ERC-4337 workflows (see [Bridge with ERC-4337](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337)).
 
 **Non-EVM destinations**
 
@@ -95,4 +95,4 @@ Arbitrum supports ERC-4337 workflows (see [Bridge with ERC-4337](./bridge-with-4
 
 ## Next Steps
 
-Run a standard EVM-to-EVM transfer with [Bridge tokens](./bridge-tokens), or use [Bridge with ERC-4337](./bridge-with-4337) for gasless flows on supported networks.
+Run a standard EVM-to-EVM transfer with [Bridge tokens](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens), or use [Bridge with ERC-4337](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337) for gasless flows on supported networks.

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors.mdx
@@ -7,11 +7,11 @@ This guide describes [errors thrown by the bridge](#errors-from-the-bridge-proto
 
 ## Errors from the bridge protocol
 
-Calls to [`bridge()`](../api-reference#bridgeoptions-config) and [`quoteBridge()`](../api-reference#quotebridgeoptions-config) throw when the account is read-only, no provider is configured, the route is invalid, fees exceed [`bridgeMaxFee`](../api-reference#bridgeprotocolconfig), or the destination matches the source chain. The [API reference](../api-reference#error-handling) lists representative `error.message` substrings.
+Calls to [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) and [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) throw when the account is read-only, no provider is configured, the route is invalid, fees exceed [`bridgeMaxFee`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeprotocolconfig), or the destination matches the source chain. The [API reference](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#error-handling) lists representative `error.message` substrings.
 
 ## Catch and branch on error messages
 
-You can wrap [`bridge()`](../api-reference#bridgeoptions-config) in `try/catch` and inspect `error.message` for stable substrings:
+You can wrap [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) in `try/catch` and inspect `error.message` for stable substrings:
 
 ```javascript title="Handle bridge errors"
 try {
@@ -58,12 +58,12 @@ try {
 ```
 
 <Callout type="info">
-Prefer [`quoteBridge()`](../api-reference#quotebridgeoptions-config) before [`bridge()`](../api-reference#bridgeoptions-config) when you want to fail early on fee or route issues without broadcasting.
+Prefer [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) before [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) when you want to fail early on fee or route issues without broadcasting.
 </Callout>
 
 ## Best practices
 
-You can clear private key material from memory when a session ends by calling [`account.dispose()`](../../../wallet-modules/wallet-evm/api-reference#dispose-1) on [`WalletAccountEvm`](../../../wallet-modules/wallet-evm/api-reference#walletaccountevm), or [`account.dispose()`](../../../wallet-modules/wallet-evm-erc-4337/api-reference#dispose-1) on [`WalletAccountEvmErc4337`](../../../wallet-modules/wallet-evm-erc-4337/api-reference#walletaccountevmerc4337):
+You can clear private key material from memory when a session ends by calling [`account.dispose()`](/sdk/wallet-modules/wallet-evm/api-reference#dispose-1) on [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountevm), or [`account.dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#dispose-1) on [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#walletaccountevmerc4337):
 
 ```javascript title="Dispose EVM account after use"
 account.dispose()
@@ -73,8 +73,8 @@ account.dispose()
 Call dispose only when you no longer need signing for that account instance. Create a new account object for later sessions.
 </Callout>
 
-Combine quoting, fee caps via [`new Usdt0ProtocolEvm(account, config?)`](../api-reference#constructor), and user-facing validation of `targetChain` and `recipient` to reduce avoidable failures.
+Combine quoting, fee caps via [`new Usdt0ProtocolEvm(account, config?)`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#constructor), and user-facing validation of `targetChain` and `recipient` to reduce avoidable failures.
 
 ## Next Steps
 
-Review configuration defaults in [WDK Bridge USD₮0 EVM Protocol Configuration](../configuration) or return to [Get Started](./get-started) for setup.
+Review configuration defaults in [WDK Bridge USD₮0 EVM Protocol Configuration](/sdk/bridge-modules/bridge-usdt0-evm/configuration) or return to [Get Started](/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started) for setup.

--- a/content/docs/sdk/bridge-modules/index.mdx
+++ b/content/docs/sdk/bridge-modules/index.mdx
@@ -13,18 +13,18 @@ Cross-chain bridge functionality for token transfers between blockchains:
 
 | Module | Route | Status | Documentation |
 |--------|-------|--------|---------------|
-| [`@tetherto/wdk-protocol-bridge-usdt0-evm`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm) | EVM → EVM + Non-EVM | ✅ Ready | [Documentation](./bridge-usdt0-evm/) |
-{/*  | [`@tetherto/wdk-protocol-bridge-usdt0-ton`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-ton) | TON ↔ EVM | In progress | [Documentation](./bridge-usdt0-ton/) |  */}
+| [`@tetherto/wdk-protocol-bridge-usdt0-evm`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm) | EVM → EVM + Non-EVM | ✅ Ready | [Documentation](/sdk/bridge-modules/bridge-usdt0-evm/) |
+{/*  | [`@tetherto/wdk-protocol-bridge-usdt0-ton`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-ton) | TON ↔ EVM | In progress | [Documentation](/sdk/bridge-modules/bridge-usdt0-ton/) |  */}
 
 ## Next steps
 
 To get started with WDK modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the modules that best fit your needs from the tables above 
 3. Check specific documentation for modules you wish to use
 
 You can also:
 
-- Learn about key concepts like [Account Abstraction](../../resources/concepts#account-abstraction) and other important definitions
+- Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready

--- a/content/docs/sdk/community-modules/index.mdx
+++ b/content/docs/sdk/community-modules/index.mdx
@@ -30,7 +30,7 @@ Want to extend WDK with your own custom module? Use the `create-wdk-module` CLI 
 npx @tetherto/create-wdk-module@latest
 ```
 
-The CLI generates source files, tests, TypeScript type definitions, and CI workflows for all five module types (wallet, swap, bridge, lending, fiat). See the [Create WDK Module documentation](../../tools/create-wdk-module) for the full guide, CLI options, and generated project structure.
+The CLI generates source files, tests, TypeScript type definitions, and CI workflows for all five module types (wallet, swap, bridge, lending, fiat). See the [Create WDK Module documentation](/tools/create-wdk-module) for the full guide, CLI options, and generated project structure.
 
 You can also:
 

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -552,16 +552,16 @@ interface ILendingProtocol {
 ## Next Steps
 
 <Cards>
-<Card title="WDK Core Configuration" href="./configuration">
+<Card title="WDK Core Configuration" href="/sdk/core-module/configuration">
 Get started with WDK's configuration
 </Card>
-<Card title="WDK Core Usage" href="./usage">
+<Card title="WDK Core Usage" href="/sdk/core-module/usage">
 Get started with WDK's Usage
 </Card>
-<Card title="Wallet Modules" href="../wallet-modules">
+<Card title="Wallet Modules" href="/sdk/wallet-modules">
 Explore blockchain-specific wallet modules
 </Card>
-<Card title="Bridge Modules" href="../bridge-modules">
+<Card title="Bridge Modules" href="/sdk/bridge-modules">
 Cross-chain USD₮0 bridges
 </Card>
 </Cards>

--- a/content/docs/sdk/core-module/guides/account-management.mdx
+++ b/content/docs/sdk/core-module/guides/account-management.mdx
@@ -90,4 +90,4 @@ for (const chain of chains) {
 
 ## Next Steps
 
-Now that you can access your accounts, learn how to [send transactions](./transactions).
+Now that you can access your accounts, learn how to [send transactions](/sdk/core-module/guides/transactions).

--- a/content/docs/sdk/core-module/guides/error-handling.mdx
+++ b/content/docs/sdk/core-module/guides/error-handling.mdx
@@ -32,11 +32,11 @@ Always use `try/catch` blocks when initializing sessions or accessing dynamic fe
 
 ## Memory Management
 
-For security, clear sensitive data from memory when a session is complete. The WDK provides [`dispose()`](../api-reference) for this purpose.
+For security, clear sensitive data from memory when a session is complete. The WDK provides [`dispose()`](/sdk/core-module/api-reference) for this purpose.
 
 ### Disposing the Instance
 
-You can clear every registered wallet using [`dispose()`](../api-reference):
+You can clear every registered wallet using [`dispose()`](/sdk/core-module/api-reference):
 
 ```typescript title="Dispose WDK"
 function endSession(wdk) {
@@ -52,7 +52,7 @@ function endSession(wdk) {
 
 ### Disposing Specific Wallets
 
-You can dispose only the wallets you no longer need using [`dispose()`](../api-reference):
+You can dispose only the wallets you no longer need using [`dispose()`](/sdk/core-module/api-reference):
 
 ```typescript title="Dispose Specific Wallets"
 // Keep the TON wallet registered, but dispose the Ethereum wallet

--- a/content/docs/sdk/core-module/guides/getting-started.mdx
+++ b/content/docs/sdk/core-module/guides/getting-started.mdx
@@ -75,4 +75,4 @@ const wdk = new WDK(existingSeed)
 
 ## Next Steps
 
-With your WDK instance ready, you can now [register wallet modules](./wallet-registration) to interact with specific blockchains like [Ethereum](../../wallet-modules/wallet-evm/), [TON](../../wallet-modules/wallet-ton/), or [Bitcoin](../../wallet-modules/wallet-btc/).
+With your WDK instance ready, you can now [register wallet modules](/sdk/core-module/guides/wallet-registration) to interact with specific blockchains like [Ethereum](/sdk/wallet-modules/wallet-evm/), [TON](/sdk/wallet-modules/wallet-ton/), or [Bitcoin](/sdk/wallet-modules/wallet-btc/).

--- a/content/docs/sdk/core-module/guides/middleware.mdx
+++ b/content/docs/sdk/core-module/guides/middleware.mdx
@@ -64,4 +64,4 @@ const balance = await wallet.getBalance()
 
 ## Next Steps
 
-Learn about [error handling and best practices](./error-handling) to ensure your application is robust and secure.
+Learn about [error handling and best practices](/sdk/core-module/guides/error-handling) to ensure your application is robust and secure.

--- a/content/docs/sdk/core-module/guides/protocol-integration.mdx
+++ b/content/docs/sdk/core-module/guides/protocol-integration.mdx
@@ -102,4 +102,4 @@ const result = await usdt0.bridge({
 
 ## Next Steps
 
-Learn how to [configure middleware](./middleware) to add logging or failover protection to your wallet interactions.
+Learn how to [configure middleware](/sdk/core-module/guides/middleware) to add logging or failover protection to your wallet interactions.

--- a/content/docs/sdk/core-module/guides/transactions.mdx
+++ b/content/docs/sdk/core-module/guides/transactions.mdx
@@ -8,7 +8,7 @@ schemaType: TechArticle
 You can [send native tokens](#send-native-tokens), [sign a transaction without broadcasting it](#sign-without-broadcasting), [handle transaction responses](#handling-responses), and [orchestrate multi-chain payments](#multi-chain-transactions) from WDK wallet accounts.
 
 <Callout type="info">
-**Get Testnet Funds:** To test these transactions without spending real money, ensure you are on a testnet and have obtained funds. See [Testnet Funds & Faucets](../../../resources/concepts#testnet-funds--faucets) for a list of available faucets.
+**Get Testnet Funds:** To test these transactions without spending real money, ensure you are on a testnet and have obtained funds. See [Testnet Funds & Faucets](/resources/concepts#testnet-funds--faucets) for a list of available faucets.
 </Callout>
 
 <Callout type="warn">
@@ -27,7 +27,7 @@ On EVM chains, values are typically expressed in Wei (1 ETH = 10^18 Wei).
 
 The following example will:
 
-1. Retrieve the first Ethereum account (see [Manage Accounts](./account-management))
+1. Retrieve the first Ethereum account (see [Manage Accounts](/sdk/core-module/guides/account-management))
 2. Send 0.001 ETH (1000000000000000 wei) to an account using `sendTransaction`.
 
 ```typescript title="Send ETH"
@@ -64,7 +64,7 @@ console.log('TON transaction:', tonResult.hash)
 
 ## Sign Without Broadcasting
 
-Use [`account.signTransaction()`](../api-reference#signtransactiontx) when your app needs a signed transaction payload but does not want WDK to broadcast it immediately. Wallet modules accept their own transaction shape and may return a module-specific signed payload.
+Use [`account.signTransaction()`](/sdk/core-module/api-reference#signtransactiontx) when your app needs a signed transaction payload but does not want WDK to broadcast it immediately. Wallet modules accept their own transaction shape and may return a module-specific signed payload.
 
 ```typescript title="Sign An EVM Transaction"
 const ethAccount = await wdk.getAccount('ethereum', 0)
@@ -83,7 +83,7 @@ console.log('Signed transaction:', signedTransaction)
 
 ## Handling Responses
 
-The `sendTransaction` method returns a [transaction result object](../api-reference). The most important field is typically `hash`, which represents the transaction ID on the blockchain. You can use this hash to track the status of your payment on a block explorer.
+The `sendTransaction` method returns a [transaction result object](/sdk/core-module/api-reference). The most important field is typically `hash`, which represents the transaction ID on the blockchain. You can use this hash to track the status of your payment on a block explorer.
 
 ## Multi-Chain Transactions
 
@@ -115,4 +115,4 @@ async function sendCrossChainPayments(wdk) {
 
 ## Next Steps
 
-For more complex interactions like swapping tokens or bridging assets, learn how to [integrate protocols](./protocol-integration).
+For more complex interactions like swapping tokens or bridging assets, learn how to [integrate protocols](/sdk/core-module/guides/protocol-integration).

--- a/content/docs/sdk/core-module/guides/wallet-registration.mdx
+++ b/content/docs/sdk/core-module/guides/wallet-registration.mdx
@@ -13,7 +13,7 @@ The WDK uses a builder pattern, allowing you to chain `.registerWallet()` calls.
 
 ### Parameters
 
-The `registerWallet` method (see [API Reference](../api-reference)) requires three arguments:
+The `registerWallet` method (see [API Reference](/sdk/core-module/api-reference)) requires three arguments:
 
 1.  **Symbol**: A unique string identifier for the chain (e.g., `'ethereum'`, `'ton'`). You will use this ID later to retrieve accounts.
 2.  **Manager Class**: The wallet manager class imported from the specific module (e.g., `WalletManagerEvm`).
@@ -21,7 +21,7 @@ The `registerWallet` method (see [API Reference](../api-reference)) requires thr
 
 ## Installation
 
-Install the [wallet managers](../../wallet-modules/) for the blockchains you want to support:
+Install the [wallet managers](/sdk/wallet-modules/) for the blockchains you want to support:
 
 ```bash
 npm install @tetherto/wdk-wallet-evm @tetherto/wdk-wallet-tron @tetherto/wdk-wallet-btc
@@ -41,7 +41,7 @@ import WalletManagerBtc from '@tetherto/wdk-wallet-btc'
 
 ### Register the Wallets
 
-Then, [instantiate WDK](./getting-started#initialize-wdk) and chain the registration calls:
+Then, [instantiate WDK](/sdk/core-module/guides/getting-started#initialize-wdk) and chain the registration calls:
 
 ```typescript title="Register Wallets"
 const wdk = new WDK(seedPhrase)
@@ -73,4 +73,4 @@ const wdk = new WDK(seedPhrase)
 
 ## Next Steps
 
-Once your wallets are registered, you can [manage accounts and specific addresses](./account-management).
+Once your wallets are registered, you can [manage accounts and specific addresses](/sdk/core-module/guides/account-management).

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/api-reference.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/api-reference.mdx
@@ -320,5 +320,5 @@ interface MoonPayQuoteSellParams {
 
 ## Next Steps
 
-- [Configuration](./configuration) - Setup and configuration options
-- [Usage Guide](./usage) - Common usage patterns
+- [Configuration](/sdk/fiat-modules/fiat-moonpay/configuration) - Setup and configuration options
+- [Usage Guide](/sdk/fiat-modules/fiat-moonpay/usage) - Common usage patterns

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/configuration.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/configuration.mdx
@@ -200,5 +200,5 @@ For `sell()`, the widget config uses `MoonPaySellParams` with different options:
 
 ## Next Steps
 
-- [Usage Guide](./usage) - Learn how to integrate MoonPay
-- [API Reference](./api-reference) - Complete API documentation
+- [Usage Guide](/sdk/fiat-modules/fiat-moonpay/usage) - Learn how to integrate MoonPay
+- [API Reference](/sdk/fiat-modules/fiat-moonpay/api-reference) - Complete API documentation

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell.mdx
@@ -3,7 +3,7 @@ title: Buy and Sell
 description: On-ramp, off-ramp, quotes, supported assets, widget options, and custom recipients.
 ---
 
-This guide explains [buying crypto (on-ramp)](#buy-crypto-on-ramp), [selling crypto (off-ramp)](#sell-crypto-off-ramp), [quotes](#get-price-quotes), [supported currencies](#supported-currencies-and-countries), [widget customization](#widget-customization), and [custom recipients](#custom-recipient-addresses). It assumes a [`MoonPayProtocol`](../api-reference) instance named `moonpay`.
+This guide explains [buying crypto (on-ramp)](#buy-crypto-on-ramp), [selling crypto (off-ramp)](#sell-crypto-off-ramp), [quotes](#get-price-quotes), [supported currencies](#supported-currencies-and-countries), [widget customization](#widget-customization), and [custom recipients](#custom-recipient-addresses). It assumes a [`MoonPayProtocol`](/sdk/fiat-modules/fiat-moonpay/api-reference) instance named `moonpay`.
 
 <Callout type="info">
 Amounts use smallest units: fiat in minor units (cents), crypto in on-chain base units (for example wei for ETH).
@@ -11,7 +11,7 @@ Amounts use smallest units: fiat in minor units (cents), crypto in on-chain base
 
 ## Buy crypto (on-ramp)
 
-You can build a signed purchase URL with [`buy()`](../api-reference) when you know the fiat spend:
+You can build a signed purchase URL with [`buy()`](/sdk/fiat-modules/fiat-moonpay/api-reference) when you know the fiat spend:
 
 ```typescript title="Buy with fiat amount"
 const result = await moonpay.buy({
@@ -23,7 +23,7 @@ const result = await moonpay.buy({
 window.open(result.buyUrl, '_blank')
 ```
 
-You can request a fixed crypto amount instead by passing `cryptoAmount` to [`buy()`](../api-reference):
+You can request a fixed crypto amount instead by passing `cryptoAmount` to [`buy()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Buy with crypto amount"
 const result = await moonpay.buy({
@@ -37,7 +37,7 @@ window.open(result.buyUrl, '_blank')
 
 ## Sell crypto (off-ramp)
 
-You can generate a sell widget URL with [`sell()`](../api-reference):
+You can generate a sell widget URL with [`sell()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Sell ETH for USD"
 const result = await moonpay.sell({
@@ -51,7 +51,7 @@ window.open(result.sellUrl, '_blank')
 
 ## Get price quotes
 
-You can preview economics before opening the widget using [`quoteBuy()`](../api-reference):
+You can preview economics before opening the widget using [`quoteBuy()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Buy quote"
 const buyQuote = await moonpay.quoteBuy({
@@ -65,7 +65,7 @@ console.log('Fee:', buyQuote.fee)
 console.log('Exchange rate:', buyQuote.rate)
 ```
 
-You can estimate proceeds for a sell with [`quoteSell()`](../api-reference):
+You can estimate proceeds for a sell with [`quoteSell()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Sell quote"
 const sellQuote = await moonpay.quoteSell({
@@ -79,21 +79,21 @@ console.log('Fiat amount:', sellQuote.fiatAmount)
 
 ## Supported currencies and countries
 
-You can list tradable assets with [`getSupportedCryptoAssets()`](../api-reference):
+You can list tradable assets with [`getSupportedCryptoAssets()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Supported crypto"
 const cryptoAssets = await moonpay.getSupportedCryptoAssets()
 console.log(cryptoAssets)
 ```
 
-You can list fiat currencies with [`getSupportedFiatCurrencies()`](../api-reference):
+You can list fiat currencies with [`getSupportedFiatCurrencies()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Supported fiat"
 const fiatCurrencies = await moonpay.getSupportedFiatCurrencies()
 console.log(fiatCurrencies)
 ```
 
-You can check regional availability with [`getSupportedCountries()`](../api-reference):
+You can check regional availability with [`getSupportedCountries()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Supported countries"
 const countries = await moonpay.getSupportedCountries()
@@ -102,7 +102,7 @@ console.log(countries)
 
 ## Widget customization
 
-You can pass UI options under `config` to [`buy()`](../api-reference) (see [`MoonPayBuyParams`](../api-reference)):
+You can pass UI options under `config` to [`buy()`](/sdk/fiat-modules/fiat-moonpay/api-reference) (see [`MoonPayBuyParams`](/sdk/fiat-modules/fiat-moonpay/api-reference)):
 
 ```typescript title="Themed buy widget"
 const result = await moonpay.buy({
@@ -125,7 +125,7 @@ window.open(result.buyUrl, '_blank')
 
 ## Custom recipient addresses
 
-By default [`buy()`](../api-reference) credits the connected wallet. You can override the destination with `recipient`:
+By default [`buy()`](/sdk/fiat-modules/fiat-moonpay/api-reference) credits the connected wallet. You can override the destination with `recipient`:
 
 ```typescript title="Custom buy recipient"
 const result = await moonpay.buy({
@@ -138,7 +138,7 @@ const result = await moonpay.buy({
 window.open(result.buyUrl, '_blank')
 ```
 
-You can set a refund destination on sells with `refundAddress` on [`sell()`](../api-reference):
+You can set a refund destination on sells with `refundAddress` on [`sell()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Custom sell refund address"
 const result = await moonpay.sell({
@@ -155,4 +155,4 @@ window.open(result.sellUrl, '_blank')
 
 - [Manage transactions](manage-transactions)
 - [Get started](get-started)
-- [API reference](../api-reference)
+- [API reference](/sdk/fiat-modules/fiat-moonpay/api-reference)

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/guides/get-started.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/guides/get-started.mdx
@@ -15,7 +15,7 @@ npm install @tetherto/wdk-protocol-fiat-moonpay
 
 ## Initialize MoonPayProtocol
 
-You can create a fiat ramp client with [`new MoonPayProtocol(account, config)`](../api-reference):
+You can create a fiat ramp client with [`new MoonPayProtocol(account, config)`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Construct MoonPayProtocol"
 import MoonPayProtocol from '@tetherto/wdk-protocol-fiat-moonpay'
@@ -30,7 +30,7 @@ const moonpay = new MoonPayProtocol(walletAccount, {
 Never ship a secret key to browsers. Run server-side signing where your architecture allows, and rotate keys if they leak.
 </Callout>
 
-See [Configuration](../configuration) for `cacheTime` and related options.
+See [Configuration](/sdk/fiat-modules/fiat-moonpay/configuration) for `cacheTime` and related options.
 
 ## Next Steps
 

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions.mdx
@@ -3,11 +3,11 @@ title: Manage Transactions
 description: Poll MoonPay for transaction status and inspect returned details.
 ---
 
-This guide shows how to [check transaction status](#check-transaction-status) and [read transaction details](#read-transaction-details) with [`getTransactionDetail()`](../api-reference). Pass the identifier MoonPay returns after checkout (for example from your redirect URL or webhook payload).
+This guide shows how to [check transaction status](#check-transaction-status) and [read transaction details](#read-transaction-details) with [`getTransactionDetail()`](/sdk/fiat-modules/fiat-moonpay/api-reference). Pass the identifier MoonPay returns after checkout (for example from your redirect URL or webhook payload).
 
 ## Check transaction status
 
-You can read the high-level state of a buy with [`getTransactionDetail()`](../api-reference):
+You can read the high-level state of a buy with [`getTransactionDetail()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Buy transaction status"
 const buyTx = await moonpay.getTransactionDetail(moonpayTransactionId, 'buy')
@@ -19,7 +19,7 @@ console.log('Status:', buyTx.status)
 
 ## Read transaction details
 
-You can load the same record to inspect assets and currencies using [`getTransactionDetail()`](../api-reference):
+You can load the same record to inspect assets and currencies using [`getTransactionDetail()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Buy transaction fields"
 const buyTx = await moonpay.getTransactionDetail(moonpayTransactionId, 'buy')
@@ -29,7 +29,7 @@ console.log('Fiat currency:', buyTx.fiatCurrency)
 console.log('Metadata:', buyTx.metadata)
 ```
 
-You can query a sell the same way by passing `sell` as the direction to [`getTransactionDetail()`](../api-reference):
+You can query a sell the same way by passing `sell` as the direction to [`getTransactionDetail()`](/sdk/fiat-modules/fiat-moonpay/api-reference):
 
 ```typescript title="Sell transaction details"
 const sellTx = await moonpay.getTransactionDetail(moonpayTransactionId, 'sell')
@@ -47,4 +47,4 @@ The second argument defaults to `buy` when omitted; set it explicitly for sell f
 
 - [Buy and sell](buy-and-sell)
 - [Get started](get-started)
-- [Configuration](../configuration)
+- [Configuration](/sdk/fiat-modules/fiat-moonpay/configuration)

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/index.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/index.mdx
@@ -9,7 +9,7 @@ schemaType: TechArticle
 
 A WDK module for integrating MoonPay's fiat on-ramp and off-ramp services. This module generates signed or unsigned widget URLs that allow users to buy and sell cryptocurrency using fiat currencies directly within your application. Provide a `signUrl` callback if you want the protocol to return signed URLs from a trusted backend, or omit it to use the unsigned widget URLs directly.
 
-Get started by reading the [Usage](./usage) guide.
+Get started by reading the [Usage](/sdk/fiat-modules/fiat-moonpay/usage) guide.
 
 <Callout type="info">
 This module requires a MoonPay developer account. [Create your account here](https://dashboard.moonpay.com/signup).

--- a/content/docs/sdk/fiat-modules/index.mdx
+++ b/content/docs/sdk/fiat-modules/index.mdx
@@ -13,7 +13,7 @@ On-ramp and off-ramp functionality for fiat currency integration:
 
 | Module | Provider | Status | Documentation |
 |--------|----------|--------|---------------|
-| [`@tetherto/wdk-protocol-fiat-moonpay`](https://github.com/tetherto/wdk-protocol-fiat-moonpay) | MoonPay | ✅ Ready | [Documentation](./fiat-moonpay/) |
+| [`@tetherto/wdk-protocol-fiat-moonpay`](https://github.com/tetherto/wdk-protocol-fiat-moonpay) | MoonPay | ✅ Ready | [Documentation](/sdk/fiat-modules/fiat-moonpay/) |
 
 ## Features
 
@@ -29,12 +29,12 @@ Fiat modules provide:
 
 To get started with WDK fiat modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the fiat module that best fits your needs from the table above
 3. Check specific documentation for the module you wish to use
 
 You can also:
 
-- Learn about key concepts in our [Concepts](../../resources/concepts) page
-- Explore [wallet modules](../wallet-modules/) to manage user wallets
-- Check our [examples](../../examples-and-starters/react-native-starter) for production-ready implementations
+- Learn about key concepts in our [Concepts](/resources/concepts) page
+- Explore [wallet modules](/sdk/wallet-modules/) to manage user wallets
+- Check our [examples](/examples-and-starters/react-native-starter) for production-ready implementations

--- a/content/docs/sdk/lending-modules/index.mdx
+++ b/content/docs/sdk/lending-modules/index.mdx
@@ -13,7 +13,7 @@ DeFi lending functionality for different lending & borrowing protocols
 
 | Module | Route | Status | Documentation |
 |--------|-------|--------|---------------|
-| [`@tetherto/wdk-protocol-lending-aave-evm`](https://github.com/tetherto/wdk-protocol-lending-aave-evm) | EVM | ✅ Ready | [Documentation](./lending-aave-evm/) |
+| [`@tetherto/wdk-protocol-lending-aave-evm`](https://github.com/tetherto/wdk-protocol-lending-aave-evm) | EVM | ✅ Ready | [Documentation](/sdk/lending-modules/lending-aave-evm/) |
 
 ## Next Steps
 

--- a/content/docs/sdk/lending-modules/lending-aave-evm/api-reference.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/api-reference.mdx
@@ -45,7 +45,7 @@ const aave = new AaveProtocolEvm(account)
 
 ---
 
-When `AaveProtocolEvm` is initialized with an ERC‑4337 smart account, the optional `config` argument on mutating and quote methods accepts the same gas-payment override families documented in [`@tetherto/wdk-wallet-evm-erc-4337`](../../wallet-modules/wallet-evm-erc-4337/api-reference): paymaster token, sponsorship policy, and native coins.
+When `AaveProtocolEvm` is initialized with an ERC‑4337 smart account, the optional `config` argument on mutating and quote methods accepts the same gas-payment override families documented in [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference): paymaster token, sponsorship policy, and native coins.
 
 ### `supply(options, config?)`
 Add tokens to the pool.

--- a/content/docs/sdk/lending-modules/lending-aave-evm/configuration.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/configuration.mdx
@@ -45,9 +45,9 @@ const aave = new AaveProtocolEvm(account)
 
 ## ERC‑4337 (Account Abstraction)
 
-When using ERC‑4337 smart accounts, every mutating method and quote helper accepts an optional `config` override. In `v1.0.0-beta.4`, that override matches the three gas-payment families exposed by [`@tetherto/wdk-wallet-evm-erc-4337`](../../wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins.
+When using ERC‑4337 smart accounts, every mutating method and quote helper accepts an optional `config` override. In `v1.0.0-beta.4`, that override matches the three gas-payment families exposed by [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins.
 
-Use the fields that match the gas-payment mode you want for that call. For the full field-level definitions, see the [`@tetherto/wdk-wallet-evm-erc-4337` configuration docs](../../wallet-modules/wallet-evm-erc-4337/configuration) and [`Config Override`](../../wallet-modules/wallet-evm-erc-4337/api-reference) reference.
+Use the fields that match the gas-payment mode you want for that call. For the full field-level definitions, see the [`@tetherto/wdk-wallet-evm-erc-4337` configuration docs](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) and [`Config Override`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) reference.
 
 ```javascript
 import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/get-started.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/get-started.mdx
@@ -15,7 +15,7 @@ npm install @tetherto/wdk-protocol-lending-aave-evm
 
 ## Create the lending client
 
-You can attach Aave V3 actions to an EVM account from [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) with [`new AaveProtocolEvm(account)`](../api-reference) on [`AaveProtocolEvm`](../api-reference):
+You can attach Aave V3 actions to an EVM account from [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) with [`new AaveProtocolEvm(account)`](/sdk/lending-modules/lending-aave-evm/api-reference) on [`AaveProtocolEvm`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Create AaveProtocolEvm"
 import AaveProtocolEvm from '@tetherto/wdk-protocol-lending-aave-evm'
@@ -31,7 +31,7 @@ const aave = new AaveProtocolEvm(account)
 ## Prerequisites
 
 <Callout type="info">
-**Token balance:** To supply or repay, hold the ERC-20 in the wallet. **Gas:** Keep native balance (ETH on Ethereum, and so on) for transaction fees unless you use sponsored ERC-4337 flows. **Networks:** This module targets mainnet deployments; confirm your RPC matches [supported networks](../configuration).
+**Token balance:** To supply or repay, hold the ERC-20 in the wallet. **Gas:** Keep native balance (ETH on Ethereum, and so on) for transaction fees unless you use sponsored ERC-4337 flows. **Networks:** This module targets mainnet deployments; confirm your RPC matches [supported networks](/sdk/lending-modules/lending-aave-evm/configuration).
 </Callout>
 
 Use contract addresses for Aave-supported reserves. On Ethereum mainnet, USD₮ uses `0xdAC17F958D2ee523a2206206994597C13D831ec7` (use `USDT` in code identifiers and literals).

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/handle-errors.mdx
@@ -7,7 +7,7 @@ This guide explains how to [handle operation errors](#operation-errors) and foll
 
 ## Operation errors
 
-You can catch failures from [`supply()`](../api-reference), [`withdraw()`](../api-reference), [`borrow()`](../api-reference), and [`repay()`](../api-reference) with `try/catch`:
+You can catch failures from [`supply()`](/sdk/lending-modules/lending-aave-evm/api-reference), [`withdraw()`](/sdk/lending-modules/lending-aave-evm/api-reference), [`borrow()`](/sdk/lending-modules/lending-aave-evm/api-reference), and [`repay()`](/sdk/lending-modules/lending-aave-evm/api-reference) with `try/catch`:
 
 ```javascript title="Handle a failed supply"
 try {
@@ -23,7 +23,7 @@ try {
 }
 ```
 
-You can isolate quote failures from [`quoteSupply()`](../api-reference) (or the other `quote*` methods) when you only need an estimate:
+You can isolate quote failures from [`quoteSupply()`](/sdk/lending-modules/lending-aave-evm/api-reference) (or the other `quote*` methods) when you only need an estimate:
 
 ```javascript title="Handle quote errors"
 try {
@@ -38,7 +38,7 @@ try {
 ```
 
 <Callout type="info">
-See [Rules & Notes](../api-reference) for address and amount validation expectations.
+See [Rules & Notes](/sdk/lending-modules/lending-aave-evm/api-reference) for address and amount validation expectations.
 </Callout>
 
 ## Best Practices
@@ -56,10 +56,10 @@ try {
 }
 ```
 
-For ERC-4337 accounts, use [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) on the smart-account type. Clear references to [`AaveProtocolEvm`](../api-reference) when the session ends.
+For ERC-4337 accounts, use [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) on the smart-account type. Clear references to [`AaveProtocolEvm`](/sdk/lending-modules/lending-aave-evm/api-reference) when the session ends.
 
 ## Next Steps
 
 - [Lending operations](lending-operations)
 - [Get started](get-started)
-- [API reference](../api-reference)
+- [API reference](/sdk/lending-modules/lending-aave-evm/api-reference)

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/lending-operations.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/lending-operations.mdx
@@ -3,11 +3,11 @@ title: Lending Operations
 description: Supply, withdraw, borrow, repay, quote fees, use ERC-4337, and read account data.
 ---
 
-This guide walks through [supply](#supply), [withdraw](#withdraw), [borrow](#borrow), [repay](#repay), [quotes](#quotes-before-sending), [ERC-4337 usage](#erc-4337-smart-accounts), and [reading account data](#reading-account-data). It assumes an [`AaveProtocolEvm`](../api-reference) instance named `aave` and the USD₮ contract on Ethereum mainnet `0xdAC17F958D2ee523a2206206994597C13D831ec7`.
+This guide walks through [supply](#supply), [withdraw](#withdraw), [borrow](#borrow), [repay](#repay), [quotes](#quotes-before-sending), [ERC-4337 usage](#erc-4337-smart-accounts), and [reading account data](#reading-account-data). It assumes an [`AaveProtocolEvm`](/sdk/lending-modules/lending-aave-evm/api-reference) instance named `aave` and the USD₮ contract on Ethereum mainnet `0xdAC17F958D2ee523a2206206994597C13D831ec7`.
 
 ## Supply
 
-You can deposit reserves into the pool using [`supply()`](../api-reference):
+You can deposit reserves into the pool using [`supply()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Supply USDT"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -18,7 +18,7 @@ console.log('Supply tx hash:', tx.hash)
 
 ## Withdraw
 
-You can remove supplied liquidity using [`withdraw()`](../api-reference):
+You can remove supplied liquidity using [`withdraw()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Withdraw USDT"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -29,7 +29,7 @@ console.log('Withdraw tx hash:', tx.hash)
 
 ## Borrow
 
-You can draw debt against your collateral using [`borrow()`](../api-reference):
+You can draw debt against your collateral using [`borrow()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Borrow USDT"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -40,7 +40,7 @@ console.log('Borrow tx hash:', tx.hash)
 
 ## Repay
 
-You can pay down debt using [`repay()`](../api-reference):
+You can pay down debt using [`repay()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Repay USDT"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -51,7 +51,7 @@ console.log('Repay tx hash:', tx.hash)
 
 ## Quotes before sending
 
-You can estimate the supply fee with [`quoteSupply()`](../api-reference):
+You can estimate the supply fee with [`quoteSupply()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Quote supply fee"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -60,7 +60,7 @@ const supplyQuote = await aave.quoteSupply({ token: USDT, amount: 1000000n })
 console.log('Supply fee (wei):', supplyQuote.fee)
 ```
 
-You can estimate the withdraw fee with [`quoteWithdraw()`](../api-reference):
+You can estimate the withdraw fee with [`quoteWithdraw()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Quote withdraw fee"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -69,7 +69,7 @@ const withdrawQuote = await aave.quoteWithdraw({ token: USDT, amount: 1000000n }
 console.log('Withdraw fee (wei):', withdrawQuote.fee)
 ```
 
-You can estimate the borrow fee with [`quoteBorrow()`](../api-reference):
+You can estimate the borrow fee with [`quoteBorrow()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Quote borrow fee"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -78,7 +78,7 @@ const borrowQuote = await aave.quoteBorrow({ token: USDT, amount: 1000000n })
 console.log('Borrow fee (wei):', borrowQuote.fee)
 ```
 
-You can estimate the repay fee with [`quoteRepay()`](../api-reference):
+You can estimate the repay fee with [`quoteRepay()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Quote repay fee"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -93,7 +93,7 @@ Health factor and collateralization limits still apply. A quote does not guarant
 
 ## ERC-4337 smart accounts
 
-You can run the same methods through [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and pass a second `config` argument to override per-call gas payment settings. In `v1.0.0-beta.4`, the lending methods accept the same override families as the wallet module: paymaster token, sponsorship policy, and native coins. See the [ERC-4337 config override](../api-reference) section for the full field list.
+You can run the same methods through [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and pass a second `config` argument to override per-call gas payment settings. In `v1.0.0-beta.4`, the lending methods accept the same override families as the wallet module: paymaster token, sponsorship policy, and native coins. See the [ERC-4337 config override](/sdk/lending-modules/lending-aave-evm/api-reference) section for the full field list.
 
 ```javascript title="Supply with paymaster"
 import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -129,7 +129,7 @@ Use token addresses that exist on the same chain as the smart account RPC.
 
 ## Reading account data
 
-You can inspect collateral, debt, and health using [`getAccountData()`](../api-reference):
+You can inspect collateral, debt, and health using [`getAccountData()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Read Aave account data"
 const data = await aave.getAccountData()
@@ -148,4 +148,4 @@ console.log({
 
 - [Handle errors](handle-errors)
 - [Get started](get-started)
-- [API reference](../api-reference)
+- [API reference](/sdk/lending-modules/lending-aave-evm/api-reference)

--- a/content/docs/sdk/swap-modules/index.mdx
+++ b/content/docs/sdk/swap-modules/index.mdx
@@ -13,18 +13,18 @@ DeFi swap functionality for token exchanges across different DEXs:
 
 | Module | Blockchain | Status | Documentation |
 |--------|------------|--------|---------------|
-| [`@tetherto/wdk-protocol-swap-velora-evm`](https://github.com/tetherto/wdk-protocol-swap-velora-evm) | EVM | ✅ Ready | [Documentation](./swap-velora-evm/) |
+| [`@tetherto/wdk-protocol-swap-velora-evm`](https://github.com/tetherto/wdk-protocol-swap-velora-evm) | EVM | ✅ Ready | [Documentation](/sdk/swap-modules/swap-velora-evm/) |
 | `@tetherto/wdk-protocol-swap-stonfi-ton` | TON | In progress | Coming soon |
 
 ## Next steps
 
 To get started with WDK modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the modules that best fit your needs from the tables above 
 3. Check specific documentation for modules you wish to use
 
 You can also:
 
-- Learn about key concepts like [Account Abstraction](../../resources/concepts#account-abstraction) and other important definitions
+- Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/execute-swaps.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/execute-swaps.mdx
@@ -3,7 +3,7 @@ title: Execute Swaps
 description: Run exact-input swaps, exact-output swaps, and swaps with ERC-4337 accounts.
 ---
 
-This guide explains how to run a [basic exact-input swap](#basic-exact-input-swap), an [exact-output swap](#exact-output-swap), and a [swap from an ERC-4337 smart account](#swap-with-erc-4337). You should already have a [`VeloraProtocolEvm`](../api-reference) instance.
+This guide explains how to run a [basic exact-input swap](#basic-exact-input-swap), an [exact-output swap](#exact-output-swap), and a [swap from an ERC-4337 smart account](#swap-with-erc-4337). You should already have a [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) instance.
 
 <Callout type="warn">
 Swaps spend tokens and gas on-chain. Use amounts you control and an RPC you trust.
@@ -11,7 +11,7 @@ Swaps spend tokens and gas on-chain. Use amounts you control and an RPC you trus
 
 ## Basic exact-input swap
 
-You can sell an exact amount of the input token using [`swap()`](../api-reference):
+You can sell an exact amount of the input token using [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Exact input: USDT to WETH"
 const result = await swapProtocol.swap({
@@ -28,7 +28,7 @@ console.log('Tokens bought (base units):', result.tokenOutAmount)
 
 ## Exact output swap
 
-You can receive an exact amount of the output token by passing `tokenOutAmount` to [`swap()`](../api-reference):
+You can receive an exact amount of the output token by passing `tokenOutAmount` to [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Exact output amount"
 const result = await swapProtocol.swap({
@@ -44,7 +44,7 @@ console.log('Tokens bought (base units):', result.tokenOutAmount)
 
 ## Swap with ERC-4337
 
-You can perform a user-operation-backed swap by constructing [`VeloraProtocolEvm`](../api-reference) with [`WalletAccountEvmErc4337`](../../../wallet-modules/wallet-evm-erc-4337/api-reference) and passing paymaster options to [`swap()`](../api-reference):
+You can perform a user-operation-backed swap by constructing [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) with [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and passing paymaster options to [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Swap with smart account and paymaster"
 import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -78,6 +78,6 @@ Token addresses must match the chain your account uses (for example, mainnet USD
 
 ## Next Steps
 
-- [Get swap quotes](get-swap-quotes) before sending
-- [Handle errors](handle-errors)
-- [Get started](get-started) if you still need setup
+- [Get swap quotes](/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes) before sending
+- [Handle errors](/sdk/swap-modules/swap-velora-evm/guides/handle-errors)
+- [Get started](/sdk/swap-modules/swap-velora-evm/guides/get-started) if you still need setup

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-started.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-started.mdx
@@ -19,7 +19,7 @@ You also need an EVM wallet account from [`@tetherto/wdk-wallet-evm`](https://ww
 
 ## Create the swap protocol
 
-You can construct a swap client with [`new VeloraProtocolEvm(account, config?)`](../api-reference) on top of [`VeloraProtocolEvm`](../api-reference):
+You can construct a swap client with [`new VeloraProtocolEvm(account, config?)`](/sdk/swap-modules/swap-velora-evm/api-reference) on top of [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Create VeloraProtocolEvm"
 import VeloraProtocolEvm from '@tetherto/wdk-protocol-swap-velora-evm'
@@ -34,14 +34,14 @@ const swapProtocol = new VeloraProtocolEvm(account, {
 })
 ```
 
-Optional `swapMaxFee` caps the total gas fee in wei for swaps. See [configuration](../configuration) for environment-specific settings.
+Optional `swapMaxFee` caps the total gas fee in wei for swaps. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for environment-specific settings.
 
 ## Supported networks
 
-Velora routing works on EVM networks the aggregator supports, including **Ethereum**, **Polygon**, **Arbitrum**, and other chains where Velora exposes liquidity. Use an RPC endpoint for the network your [`WalletAccountEvm`](../../../wallet-modules/wallet-evm/api-reference) is configured for so [`swap()`](../api-reference) and [`quoteSwap()`](../api-reference) target the correct chain.
+Velora routing works on EVM networks the aggregator supports, including **Ethereum**, **Polygon**, **Arbitrum**, and other chains where Velora exposes liquidity. Use an RPC endpoint for the network your [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) is configured for so [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) and [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) target the correct chain.
 
 ## Next Steps
 
-- [Execute swaps](execute-swaps)
-- [Get swap quotes](get-swap-quotes)
-- [Handle errors](handle-errors)
+- [Execute swaps](/sdk/swap-modules/swap-velora-evm/guides/execute-swaps)
+- [Get swap quotes](/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes)
+- [Handle errors](/sdk/swap-modules/swap-velora-evm/guides/handle-errors)

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes.mdx
@@ -3,11 +3,11 @@ title: Get Swap Quotes
 description: Estimate fees and amounts with quoteSwap before executing a swap.
 ---
 
-This guide shows how to [quote before swapping](#quote-before-swapping) and use quotes for [fee estimation](#fee-estimation). Quotes use [`quoteSwap()`](../api-reference), which works with read-only accounts as well as signing accounts.
+This guide shows how to [quote before swapping](#quote-before-swapping) and use quotes for [fee estimation](#fee-estimation). Quotes use [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference), which works with read-only accounts as well as signing accounts.
 
 ## Quote before swapping
 
-You can preview fee and token amounts for the same parameters you would pass to [`swap()`](../api-reference) using [`quoteSwap()`](../api-reference):
+You can preview fee and token amounts for the same parameters you would pass to [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) using [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Quote exact input swap"
 const quote = await swapProtocol.quoteSwap({
@@ -21,7 +21,7 @@ console.log('Tokens in (base units):', quote.tokenInAmount)
 console.log('Tokens out (base units):', quote.tokenOutAmount)
 ```
 
-You can quote an exact-output style trade the same way by passing `tokenOutAmount` instead of `tokenInAmount` to [`quoteSwap()`](../api-reference):
+You can quote an exact-output style trade the same way by passing `tokenOutAmount` instead of `tokenInAmount` to [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Quote exact output swap"
 const quote = await swapProtocol.quoteSwap({
@@ -36,7 +36,7 @@ console.log('Required token in (base units):', quote.tokenInAmount)
 
 ## Fee estimation
 
-You can read `quote.fee` from [`quoteSwap()`](../api-reference) as the estimated total swap fee in wei before calling [`swap()`](../api-reference):
+You can read `quote.fee` from [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) as the estimated total swap fee in wei before calling [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Quote fee before deciding"
 const quote = await swapProtocol.quoteSwap({
@@ -49,7 +49,7 @@ const maxFee = 200000000000000n
 console.log('Quoted fee (wei):', quote.fee, 'cap:', maxFee)
 ```
 
-You can compare that estimate to `swapMaxFee` on [`VeloraProtocolEvm`](../api-reference) and only then call [`swap()`](../api-reference) when the quote is within your cap:
+You can compare that estimate to `swapMaxFee` on [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) and only then call [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) when the quote is within your cap:
 
 ```javascript title="Swap when fee is under cap"
 const maxFee = 200000000000000n
@@ -70,11 +70,11 @@ if (quote.fee <= maxFee) {
 ```
 
 <Callout type="info">
-On-chain conditions can change between quote and execution. The executed [`swap()`](../api-reference) may still differ slightly from the last [`quoteSwap()`](../api-reference) result.
+On-chain conditions can change between quote and execution. The executed [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) may still differ slightly from the last [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) result.
 </Callout>
 
 ## Next Steps
 
-- [Execute swaps](execute-swaps)
-- [Handle errors](handle-errors)
-- [Get started](get-started)
+- [Execute swaps](/sdk/swap-modules/swap-velora-evm/guides/execute-swaps)
+- [Handle errors](/sdk/swap-modules/swap-velora-evm/guides/handle-errors)
+- [Get started](/sdk/swap-modules/swap-velora-evm/guides/get-started)

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/handle-errors.mdx
@@ -7,7 +7,7 @@ This guide covers [swap errors](#swap-errors), [quote errors](#quote-errors), an
 
 ## Swap errors
 
-You can detect failed swaps by wrapping [`swap()`](../api-reference) in `try/catch` and inspecting `error.message`:
+You can detect failed swaps by wrapping [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) in `try/catch` and inspecting `error.message`:
 
 ```javascript title="Handle swap failures"
 try {
@@ -38,7 +38,7 @@ Match string fragments only as a convenience; production apps should prefer stab
 
 ## Quote errors
 
-You can handle failures from [`quoteSwap()`](../api-reference) the same way, including provider or routing errors:
+You can handle failures from [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) the same way, including provider or routing errors:
 
 ```javascript title="Handle quote failures"
 try {
@@ -53,11 +53,11 @@ try {
 }
 ```
 
-Common causes are listed under [Errors](../api-reference) in the API reference (liquidity, fee cap, read-only send attempts, RPC issues).
+Common causes are listed under [Errors](/sdk/swap-modules/swap-velora-evm/api-reference) in the API reference (liquidity, fee cap, read-only send attempts, RPC issues).
 
 ## Best Practices
 
-You can clear signing material when a session ends by calling [`dispose()`](../../../wallet-modules/wallet-evm/api-reference) on each [`WalletAccountEvm`](../../../wallet-modules/wallet-evm/api-reference), or [`dispose()`](../../../wallet-modules/wallet-evm/api-reference) on [`WalletManagerEvm`](../../../wallet-modules/wallet-evm/api-reference) if you use a manager:
+You can clear signing material when a session ends by calling [`dispose()`](/sdk/wallet-modules/wallet-evm/api-reference) on each [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference), or [`dispose()`](/sdk/wallet-modules/wallet-evm/api-reference) on [`WalletManagerEvm`](/sdk/wallet-modules/wallet-evm/api-reference) if you use a manager:
 
 ```javascript title="Dispose wallet accounts"
 try {
@@ -71,10 +71,10 @@ try {
 }
 ```
 
-If you use an ERC-4337 account, call [`dispose()`](../../../wallet-modules/wallet-evm-erc-4337/api-reference) on that account type per its API reference. Drop references to your [`VeloraProtocolEvm`](../api-reference) instance when you no longer need it.
+If you use an ERC-4337 account, call [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) on that account type per its API reference. Drop references to your [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) instance when you no longer need it.
 
 ## Next Steps
 
-- [Get swap quotes](get-swap-quotes)
-- [Execute swaps](execute-swaps)
-- [API reference](../api-reference)
+- [Get swap quotes](/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes)
+- [Execute swaps](/sdk/swap-modules/swap-velora-evm/guides/execute-swaps)
+- [API reference](/sdk/swap-modules/swap-velora-evm/api-reference)

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -38,28 +38,28 @@ Standard wallet implementations that use native blockchain tokens for transactio
 
 | Module | Blockchain | Status | Documentation |
 |--------|------------|--------|---------------|
-| [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | ✅ Ready | [Documentation](./wallet-evm) |
-| [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | ✅ Ready | [Documentation](./wallet-ton) |
-| [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | ✅ Ready | [Documentation](./wallet-btc) |
-| [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | ✅ Ready | [Documentation](./wallet-spark) |
-| [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | ✅ Ready | [Documentation](./wallet-tron) |
-| [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | ✅ Ready | [Documentation](./wallet-solana) |
+| [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm) |
+| [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-ton) |
+| [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-btc) |
+| [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-spark) |
+| [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-tron) |
+| [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-solana) |
 | `@tetherto/wdk-wallet-ark` | Ark | In progress | - |
 
 ## Account Abstraction Wallet Modules
 
-Wallet implementations that support [Account Abstraction](../../resources/concepts#account-abstraction) for gasless transactions using paymaster tokens like USD₮:
+Wallet implementations that support [Account Abstraction](/resources/concepts#account-abstraction) for gasless transactions using paymaster tokens like USD₮:
 
 | Module | Blockchain | Status | Documentation |
 |--------|------------|--------|---------------|
-| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ✅ Ready | [Documentation](./wallet-evm-erc-4337) |
-| [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | ✅ Ready | [Documentation](./wallet-ton-gasless) |
-| [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | ✅ Ready | [Documentation](./wallet-tron-gasfree) |
+| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-erc-4337) |
+| [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-ton-gasless) |
+| [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-tron-gasfree) |
 | `@tetherto/wdk-wallet-solana-jupiterz` | Solana | In progress | - |
 
 ## Community Wallet Modules
 
-Wallet modules developed by the community. See the [Community Modules](../community-modules/) page for more details.
+Wallet modules developed by the community. See the [Community Modules](/sdk/community-modules/) page for more details.
 
 <Callout type="warn">
 Community modules are developed and maintained independently. Use your own judgment and proceed at your own risk.
@@ -73,11 +73,11 @@ Community modules are developed and maintained independently. Use your own judgm
 
 To get started with WDK modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the modules that best fit your needs from the tables above 
 3. Check specific documentation for modules you wish to use
 
 You can also:
 
-- Learn about key concepts like [Account Abstraction](../../resources/concepts#account-abstraction) and other important definitions
+- Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready

--- a/content/docs/sdk/wallet-modules/wallet-btc/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/api-reference.mdx
@@ -696,16 +696,16 @@ interface MempoolElectrumConfig {
 ```
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="React Native Quickstart" href="../../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="WDK Bitcoin Wallet Usage" href="./usage">
+<Card title="WDK Bitcoin Wallet Usage" href="/sdk/wallet-modules/wallet-btc/usage">
 Get started with WDK's Bitcoin Wallet Usage
 </Card>
-<Card title="WDK Bitcoin Wallet Configuration" href="./configuration">
+<Card title="WDK Bitcoin Wallet Configuration" href="/sdk/wallet-modules/wallet-btc/configuration">
 Get started with WDK's Bitcoin Wallet Configuration
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-btc/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/configuration.mdx
@@ -238,9 +238,9 @@ The `network` option specifies which Bitcoin network to use.
 **Type:** `string`
 
 **Values:**
-- `"bitcoin"` - Bitcoin [mainnet](../../../resources/concepts#mainnet) (production)
-- `"testnet"` - Bitcoin [testnet](../../../resources/concepts#testnet) (development)
-- `"regtest"` - Bitcoin [regtest](../../../resources/concepts#regtest) (local testing)
+- `"bitcoin"` - Bitcoin [mainnet](/resources/concepts#mainnet) (production)
+- `"testnet"` - Bitcoin [testnet](/resources/concepts#testnet) (development)
+- `"regtest"` - Bitcoin [regtest](/resources/concepts#regtest) (local testing)
 
 **Default:** `"bitcoin"`
 
@@ -258,8 +258,8 @@ The `bip` option specifies the address type derivation standard to use.
 **Type:** `number`
 
 **Values:**
-- `84` - [BIP-84](../../../resources/concepts#bip-84-native-segwit) (P2WPKH / Native SegWit) - addresses start with `bc1` (mainnet) or `tb1` (testnet)
-- `44` - [BIP-44](../../../resources/concepts#bip-44-multi-account-hierarchy) (P2PKH / Legacy) - addresses start with `1` (mainnet) or `m`/`n` (testnet)
+- `84` - [BIP-84](/resources/concepts#bip-84-native-segwit) (P2WPKH / Native SegWit) - addresses start with `bc1` (mainnet) or `tb1` (testnet)
+- `44` - [BIP-44](/resources/concepts#bip-44-multi-account-hierarchy) (P2PKH / Legacy) - addresses start with `1` (mainnet) or `m`/`n` (testnet)
 
 **Default:** `84`
 
@@ -391,7 +391,7 @@ The default derivation path was updated in v1.0.0-beta.4 to use BIP-84 (Native S
 
 If you're upgrading from an earlier version, existing wallets created with the old path will generate different addresses. Make sure to migrate any existing wallets or use the old path explicitly if needed for compatibility.
 
-Use [`getAccountByPath`](./api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets.
+Use [`getAccountByPath`](/sdk/wallet-modules/wallet-btc/api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets.
 </Callout>
 
 ## Complete Configuration Example
@@ -436,16 +436,16 @@ wallet.dispose()
 - Consider using multiple backup servers
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="React Native Quickstart" href="../../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="WDK BTC Wallet Usage" href="./usage">
+<Card title="WDK BTC Wallet Usage" href="/sdk/wallet-modules/wallet-btc/usage">
 Get started with WDK's BTC Wallet Usage
 </Card>
-<Card title="WDK BTC Wallet API" href="./api-reference">
+<Card title="WDK BTC Wallet API" href="/sdk/wallet-modules/wallet-btc/api-reference">
 Get started with WDK's BTC Wallet API
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-btc/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/guides/check-balances.mdx
@@ -7,7 +7,7 @@ This guide explains how to check [native BTC balances](#native-btc-balance), [ma
 
 ## Native BTC Balance
 
-You can retrieve the confirmed balance in satoshis using [`account.getBalance()`](../api-reference):
+You can retrieve the confirmed balance in satoshis using [`account.getBalance()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Get Native BTC Balance"
 const balance = await account.getBalance()
@@ -15,12 +15,12 @@ console.log('Total balance:', balance, 'satoshis')
 ```
 
 <Callout type="info">
-On Bitcoin, balances are expressed in satoshis (1 BTC = 100,000,000 satoshis). The [`getBalance()`](../api-reference) method returns the total balance, including unconfirmed funds when present.
+On Bitcoin, balances are expressed in satoshis (1 BTC = 100,000,000 satoshis). The [`getBalance()`](/sdk/wallet-modules/wallet-btc/api-reference) method returns the total balance, including unconfirmed funds when present.
 </Callout>
 
 ## Maximum Spendable Amount
 
-You can check the maximum amount available to send in a single transaction using [`account.getMaxSpendable()`](../api-reference):
+You can check the maximum amount available to send in a single transaction using [`account.getMaxSpendable()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Get Maximum Spendable"
 const { amount, fee } = await account.getMaxSpendable()
@@ -34,7 +34,7 @@ The maximum spendable amount can differ from the total balance due to transactio
 
 ## Read-Only Account Balances
 
-You can check balances for any Bitcoin address without a seed phrase using [`WalletAccountReadOnlyBtc`](../api-reference):
+You can check balances for any Bitcoin address without a seed phrase using [`WalletAccountReadOnlyBtc`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Create Read-Only Account"
 import { WalletAccountReadOnlyBtc, ElectrumTcp } from '@tetherto/wdk-wallet-btc'
@@ -50,7 +50,7 @@ const readOnlyAccount = new WalletAccountReadOnlyBtc('bc1qxy2kgdygjrsqtzq2n0yrf2
 })
 ```
 
-You can retrieve the balance from a read-only account using [`readOnlyAccount.getBalance()`](../api-reference):
+You can retrieve the balance from a read-only account using [`readOnlyAccount.getBalance()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Read-Only Balance"
 const balance = await readOnlyAccount.getBalance()
@@ -58,13 +58,13 @@ console.log('Read-only account balance:', balance, 'satoshis')
 ```
 
 <Callout type="info">
-Read-only accounts follow the same balance behavior as owned accounts: [`getBalance()`](../api-reference) includes unconfirmed funds when present.
+Read-only accounts follow the same balance behavior as owned accounts: [`getBalance()`](/sdk/wallet-modules/wallet-btc/api-reference) includes unconfirmed funds when present.
 </Callout>
 
 <Callout type="info">
-You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](../api-reference).
+You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-btc/api-reference).
 </Callout>
 
 ## Next Steps
 
-With balance checks in place, learn how to [send BTC](./send-transactions).
+With balance checks in place, learn how to [send BTC](/sdk/wallet-modules/wallet-btc/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-btc/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/guides/get-started.mdx
@@ -18,7 +18,7 @@ npm install @tetherto/wdk-wallet-btc
 
 ## 2. Create a Wallet
 
-You can create a new wallet instance using the [`WalletManagerBtc`](../api-reference) constructor with a BIP-39 seed phrase and an Electrum client:
+You can create a new wallet instance using the [`WalletManagerBtc`](/sdk/wallet-modules/wallet-btc/api-reference) constructor with a BIP-39 seed phrase and an Electrum client:
 
 ```javascript title="Create Bitcoin Wallet"
 import WalletManagerBtc, { ElectrumTcp } from '@tetherto/wdk-wallet-btc'
@@ -46,7 +46,7 @@ const wallet = new WalletManagerBtc(seedPhrase, {
 
 ## 3. Get Your First Account
 
-You can retrieve an account at a given index using [`wallet.getAccount()`](../api-reference):
+You can retrieve an account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Get Account"
 const account = await wallet.getAccount(0)
@@ -60,7 +60,7 @@ This implementation uses BIP-84 derivation paths and generates Native SegWit (be
 
 ## 4. (optional) Convert to Read-Only
 
-You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](../api-reference):
+You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Convert to Read-Only"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -68,4 +68,4 @@ const readOnlyAccount = await account.toReadOnlyAccount()
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-btc/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-btc/guides/get-transaction-history.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/guides/get-transaction-history.mdx
@@ -7,7 +7,7 @@ This guide explains how to [retrieve all transfers](#retrieve-all-transfers), [f
 
 ## Retrieve All Transfers
 
-You can retrieve the account's transfer history using [`account.getTransfers()`](../api-reference):
+You can retrieve the account's transfer history using [`account.getTransfers()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Get All Transfers"
 const transfers = await account.getTransfers()
@@ -20,14 +20,14 @@ The default limit is 10 transfers. Change outputs are automatically filtered out
 
 ## Filter by Direction
 
-You can filter transfers by direction using the `direction` option in [`account.getTransfers()`](../api-reference):
+You can filter transfers by direction using the `direction` option in [`account.getTransfers()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Incoming Transfers"
 const incoming = await account.getTransfers({ direction: 'incoming' })
 console.log('Incoming transfers:', incoming)
 ```
 
-You can retrieve outgoing transfers with a custom limit using [`account.getTransfers()`](../api-reference):
+You can retrieve outgoing transfers with a custom limit using [`account.getTransfers()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Outgoing Transfers"
 const outgoing = await account.getTransfers({
@@ -39,7 +39,7 @@ console.log('Outgoing transfers:', outgoing)
 
 ## Paginate Results
 
-You can paginate through transfer history using the `limit` and `skip` options in [`account.getTransfers()`](../api-reference):
+You can paginate through transfer history using the `limit` and `skip` options in [`account.getTransfers()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Paginate Transfers"
 const page = await account.getTransfers({
@@ -52,7 +52,7 @@ console.log('Transfers 11-30:', page)
 
 ## Check Transaction Receipts
 
-You can check whether a specific transaction has been confirmed using [`account.getTransactionReceipt()`](../api-reference):
+You can check whether a specific transaction has been confirmed using [`account.getTransactionReceipt()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Get Transaction Receipt"
 const receipt = await account.getTransactionReceipt('abc123...')
@@ -63,4 +63,4 @@ if (receipt) {
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages).
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-btc/guides/sign-verify-messages).

--- a/content/docs/sdk/wallet-modules/wallet-btc/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/guides/handle-errors.mdx
@@ -7,7 +7,7 @@ This guide explains how to [handle transaction errors](#transaction-errors), [ha
 
 ## Transaction Errors
 
-Transactions sent via [`account.sendTransaction()`](../api-reference) can fail for several reasons. Wrap transaction calls in a `try/catch` block to handle specific error types:
+Transactions sent via [`account.sendTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference) can fail for several reasons. Wrap transaction calls in a `try/catch` block to handle specific error types:
 
 ```javascript title="Handle Transaction Errors"
 try {
@@ -52,7 +52,7 @@ try {
 
 ### Fee Management
 
-You can retrieve current network fee rates using [`wallet.getFeeRates()`](../api-reference):
+You can retrieve current network fee rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Get Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -61,12 +61,12 @@ console.log('Fast fee rate:', feeRates.fast, 'sat/vB')
 ```
 
 <Callout type="info">
-[`wallet.getFeeRates()`](../api-reference) fetches rates from the mempool.space API, while [`account.sendTransaction()`](../api-reference) estimates fees from the connected Electrum server. Use [`getFeeRates()`](../api-reference) for display purposes.
+[`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-btc/api-reference) fetches rates from the mempool.space API, while [`account.sendTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference) estimates fees from the connected Electrum server. Use [`getFeeRates()`](/sdk/wallet-modules/wallet-btc/api-reference) for display purposes.
 </Callout>
 
 ### Dispose of Sensitive Data
 
-For security, clear sensitive data from memory when a session is complete. Use [`account.dispose()`](../api-reference) and [`wallet.dispose()`](../api-reference) to securely wipe private keys:
+For security, clear sensitive data from memory when a session is complete. Use [`account.dispose()`](/sdk/wallet-modules/wallet-btc/api-reference) and [`wallet.dispose()`](/sdk/wallet-modules/wallet-btc/api-reference) to securely wipe private keys:
 
 ```javascript title="Dispose Resources"
 try {
@@ -82,5 +82,5 @@ try {
 ```
 
 <Callout type="warn">
-Always call [`dispose()`](../api-reference) when finished with accounts. Private keys are securely wiped from memory using `sodium_memzero`. Electrum connections are automatically closed. Disposal is irreversible.
+Always call [`dispose()`](/sdk/wallet-modules/wallet-btc/api-reference) when finished with accounts. Private keys are securely wiped from memory using `sodium_memzero`. Electrum connections are automatically closed. Disposal is irreversible.
 </Callout>

--- a/content/docs/sdk/wallet-modules/wallet-btc/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/guides/manage-accounts.mdx
@@ -7,7 +7,7 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 ## Retrieve Accounts by Index
 
-You can retrieve multiple accounts using [`wallet.getAccount()`](../api-reference) with different index values:
+You can retrieve multiple accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-btc/api-reference) with different index values:
 
 ```javascript title="Retrieve Multiple Accounts"
 const account0 = await wallet.getAccount(0)
@@ -19,7 +19,7 @@ const address1 = await account1.getAddress()
 console.log('Account 1 address:', address1)
 ```
 
-You can iterate through multiple accounts using [`wallet.getAccount()`](../api-reference) to inspect addresses and balances in bulk:
+You can iterate through multiple accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-btc/api-reference) to inspect addresses and balances in bulk:
 
 ```javascript title="Iterate Over Accounts"
 for (let i = 0; i < 5; i++) {
@@ -32,7 +32,7 @@ for (let i = 0; i < 5; i++) {
 
 ## Retrieve Account by Custom Derivation Path
 
-You can retrieve an account at a specific derivation path using [`wallet.getAccountByPath()`](../api-reference):
+You can retrieve an account at a specific derivation path using [`wallet.getAccountByPath()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Custom Derivation Path"
 const customAccount = await wallet.getAccountByPath("0'/0/5")
@@ -46,4 +46,4 @@ The default derivation scheme is BIP-84 (Native SegWit): `m/84'/0'/0'/0/{index}`
 
 ## Next Steps
 
-With accounts set up, learn how to [check balances](./check-balances).
+With accounts set up, learn how to [check balances](/sdk/wallet-modules/wallet-btc/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-btc/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/guides/send-transactions.mdx
@@ -7,7 +7,7 @@ This guide explains how to [send BTC](#send-btc), [extend post-broadcast polling
 
 ## Send BTC
 
-You can send Bitcoin to a recipient using [`account.sendTransaction()`](../api-reference#sendtransactionoptions-timeoutms):
+You can send Bitcoin to a recipient using [`account.sendTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference#sendtransactionoptions-timeoutms):
 
 ```javascript title="Send BTC"
 const result = await account.sendTransaction({
@@ -24,7 +24,7 @@ Bitcoin transactions support a single recipient only. Amounts and fees are alway
 
 ## Extend Post-Broadcast Polling
 
-If you want [`account.sendTransaction()`](../api-reference#sendtransactionoptions-timeoutms) to keep polling after broadcast until spent inputs disappear from the unspent-output set, pass the optional `timeoutMs` argument:
+If you want [`account.sendTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference#sendtransactionoptions-timeoutms) to keep polling after broadcast until spent inputs disappear from the unspent-output set, pass the optional `timeoutMs` argument:
 
 ```javascript title="Send BTC With Extended Polling"
 const result = await account.sendTransaction(
@@ -44,7 +44,7 @@ If you omit `timeoutMs`, the wallet uses the default post-broadcast polling wind
 
 ## Sign Without Broadcasting
 
-Use [`account.signTransaction()`](../api-reference#signtransactionoptions) when your app needs a signed raw Bitcoin transaction but does not want WDK to broadcast it immediately.
+Use [`account.signTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference#signtransactionoptions) when your app needs a signed raw Bitcoin transaction but does not want WDK to broadcast it immediately.
 
 ```javascript title="Sign BTC Transaction"
 const signedTransaction = await account.signTransaction({
@@ -62,7 +62,7 @@ console.log('Signed transaction:', signedTransaction)
 
 ## Estimate Fees
 
-You can estimate the fee for a transaction without broadcasting it using [`account.quoteSendTransaction()`](../api-reference#quotesendtransactionoptions):
+You can estimate the fee for a transaction without broadcasting it using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference#quotesendtransactionoptions):
 
 ```javascript title="Estimate Fee"
 const quote = await account.quoteSendTransaction({
@@ -74,7 +74,7 @@ console.log('Estimated fee:', quote.fee, 'satoshis')
 
 ## Send with Custom Fee Rate
 
-You can override automatic fee estimation by providing a `feeRate` in sat/vB to [`account.sendTransaction()`](../api-reference#sendtransactionoptions-timeoutms):
+You can override automatic fee estimation by providing a `feeRate` in sat/vB to [`account.sendTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference#sendtransactionoptions-timeoutms):
 
 ```javascript title="Custom Fee Rate"
 const result = await account.sendTransaction({
@@ -90,7 +90,7 @@ When `feeRate` is provided, the `confirmationTarget` parameter is ignored.
 
 ## Send with Confirmation Target
 
-You can target a specific number of blocks for confirmation using the `confirmationTarget` parameter in [`account.sendTransaction()`](../api-reference#sendtransactionoptions-timeoutms):
+You can target a specific number of blocks for confirmation using the `confirmationTarget` parameter in [`account.sendTransaction()`](/sdk/wallet-modules/wallet-btc/api-reference#sendtransactionoptions-timeoutms):
 
 ```javascript title="Confirmation Target"
 const result = await account.sendTransaction({
@@ -102,4 +102,4 @@ const result = await account.sendTransaction({
 
 ## Next Steps
 
-Learn how to [view transaction history](./get-transaction-history).
+Learn how to [view transaction history](/sdk/wallet-modules/wallet-btc/guides/get-transaction-history).

--- a/content/docs/sdk/wallet-modules/wallet-btc/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/guides/sign-verify-messages.mdx
@@ -7,7 +7,7 @@ This guide explains how to [sign messages](#sign-a-message) and [verify signatur
 
 ## Sign a Message
 
-You can sign a message with the account's private key using [`account.sign()`](../api-reference):
+You can sign a message with the account's private key using [`account.sign()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Sign Message"
 const message = 'Hello, Bitcoin!'
@@ -21,14 +21,14 @@ The signature is returned as a base64-encoded string.
 
 ## Verify a Signature
 
-You can verify that a signature was produced by the corresponding private key using [`account.verify()`](../api-reference):
+You can verify that a signature was produced by the corresponding private key using [`account.verify()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Verify Signature"
 const isValid = await account.verify(message, signature)
 console.log('Signature valid:', isValid)
 ```
 
-You can also verify signatures using a [read-only account](../api-reference). Use [`account.toReadOnlyAccount()`](../api-reference) to create one from an owned account, then call [`readOnlyAccount.verify()`](../api-reference):
+You can also verify signatures using a [read-only account](/sdk/wallet-modules/wallet-btc/api-reference). Use [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-btc/api-reference) to create one from an owned account, then call [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-btc/api-reference):
 
 ```javascript title="Verify with Read-Only Account"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -38,4 +38,4 @@ console.log('Verified with read-only account:', isValid)
 
 ## Next Steps
 
-Learn how to [handle errors and manage resources](./handle-errors).
+Learn how to [handle errors and manage resources](/sdk/wallet-modules/wallet-btc/guides/handle-errors).

--- a/content/docs/sdk/wallet-modules/wallet-btc/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-btc/index.mdx
@@ -17,7 +17,7 @@ The default derivation path was updated in v1.0.0-beta.4 to use BIP-84 (Native S
 
 If you're upgrading from an earlier version, existing wallets created with the old path will generate different addresses. Make sure to migrate any existing wallets or use the old path explicitly if needed for compatibility.
 
-Use [`getAccountByPath`](./api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets.
+Use [`getAccountByPath`](/sdk/wallet-modules/wallet-btc/api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets.
 </Callout>
 
 ## Features
@@ -60,16 +60,16 @@ This package works with Bitcoin networks:
 ## Next Steps
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="WDK Bitcoin Wallet Configuration" href="./configuration">
+<Card title="WDK Bitcoin Wallet Configuration" href="/sdk/wallet-modules/wallet-btc/configuration">
 Get started with WDK's Bitcoin Wallet configuration
 </Card>
-<Card title="WDK Bitcoin Wallet API" href="./api-reference">
+<Card title="WDK Bitcoin Wallet API" href="/sdk/wallet-modules/wallet-btc/api-reference">
 Get started with WDK's Bitcoin Wallet API
 </Card>
-<Card title="WDK Bitcoin Wallet Usage" href="./usage">
+<Card title="WDK Bitcoin Wallet Usage" href="/sdk/wallet-modules/wallet-btc/usage">
 Get started with WDK's Bitcoin Wallet usage
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
@@ -7,7 +7,7 @@ This guide explains how to check [native token balances](#native-token-balance),
 
 ## Native Token Balance
 
-You can retrieve the native token balance (e.g., ETH) using [`account.getBalance()`](../api-reference):
+You can retrieve the native token balance (e.g., ETH) using [`account.getBalance()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Get Native Balance"
 const balance = await account.getBalance()
@@ -16,7 +16,7 @@ console.log('Native balance:', balance, 'wei')
 
 ## ERC-20 Token Balance
 
-You can check the balance of a specific ERC-20 token using [`account.getTokenBalance()`](../api-reference):
+You can check the balance of a specific ERC-20 token using [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Get ERC-20 Balance"
 const tokenBalance = await account.getTokenBalance('0xdAC17F958D2ee523a2206206994597C13D831ec7') // USDT
@@ -25,7 +25,7 @@ console.log('USDT balance:', tokenBalance)
 
 ## Multiple Token Balances
 
-You can check balances for multiple ERC-20 tokens in a single call using [`account.getTokenBalances()`](../api-reference):
+You can check balances for multiple ERC-20 tokens in a single call using [`account.getTokenBalances()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Get Multiple Token Balances"
 const tokenBalances = await account.getTokenBalances([
@@ -37,7 +37,7 @@ console.log('Multi-token balances:', tokenBalances)
 
 ## Paymaster Token Balance
 
-You can check the paymaster token balance used for paying gas fees using [`account.getPaymasterTokenBalance()`](../api-reference):
+You can check the paymaster token balance used for paying gas fees using [`account.getPaymasterTokenBalance()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Get Paymaster Token Balance"
 const paymasterBalance = await account.getPaymasterTokenBalance()
@@ -50,7 +50,7 @@ The paymaster token balance determines how many gasless transactions you can exe
 
 ## Read-Only Account Balances
 
-You can check balances for any smart account address without a seed phrase using [`WalletAccountReadOnlyEvmErc4337`](../api-reference):
+You can check balances for any smart account address without a seed phrase using [`WalletAccountReadOnlyEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Read-Only Balance"
 import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -74,4 +74,4 @@ console.log('Read-only account balance:', balance, 'wei')
 
 ## Next Steps
 
-With balance checks in place, learn how to [send gasless transactions](./send-transactions).
+With balance checks in place, learn how to [send gasless transactions](/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started.mdx
@@ -18,7 +18,7 @@ npm install @tetherto/wdk-wallet-evm-erc-4337
 
 ## 2. Create a Wallet
 
-You can create a new wallet instance using the [`WalletManagerEvmErc4337`](../api-reference) constructor with a BIP-39 seed phrase and ERC-4337 configuration:
+You can create a new wallet instance using the [`WalletManagerEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) constructor with a BIP-39 seed phrase and ERC-4337 configuration:
 
 ```javascript title="Create ERC-4337 Wallet"
 import WalletManagerEvmErc4337 from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -44,12 +44,12 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
 </Callout>
 
 <Callout type="info">
-To use test/mock tokens instead of real funds, see the [testnet configuration section](../configuration#network-specific-configurations).
+To use test/mock tokens instead of real funds, see the [testnet configuration section](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#network-specific-configurations).
 </Callout>
 
 ## 3. Get Your First Account
 
-You can retrieve a smart account at a given index using [`wallet.getAccount()`](../api-reference):
+You can retrieve a smart account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Get Account"
 const account = await wallet.getAccount(0)
@@ -59,7 +59,7 @@ console.log('Smart account address:', address)
 
 ## 4. (optional) Convert to Read-Only
 
-You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](../api-reference):
+You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Convert to Read-Only"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -67,4 +67,4 @@ const readOnlyAccount = await account.toReadOnlyAccount()
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors.mdx
@@ -7,7 +7,7 @@ This guide explains how to [handle transaction errors](#transaction-errors), [ha
 
 ## Transaction Errors
 
-Transactions sent via [`account.sendTransaction()`](../api-reference) can fail when the paymaster token balance is insufficient. Wrap calls in a `try/catch` block:
+Transactions sent via [`account.sendTransaction()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) can fail when the paymaster token balance is insufficient. Wrap calls in a `try/catch` block:
 
 ```javascript title="Handle Transaction Errors"
 try {
@@ -27,7 +27,7 @@ try {
 
 ## Transfer Errors
 
-Token transfers via [`account.transfer()`](../api-reference) can fail due to insufficient balance or exceeding the maximum fee limit:
+Token transfers via [`account.transfer()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) can fail due to insufficient balance or exceeding the maximum fee limit:
 
 ```javascript title="Handle Transfer Errors"
 try {
@@ -52,7 +52,7 @@ try {
 
 ### Fee Management
 
-You can retrieve current network fee rates using [`wallet.getFeeRates()`](../api-reference):
+You can retrieve current network fee rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Get Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -62,7 +62,7 @@ console.log('Fast fee rate:', feeRates.fast)
 
 ### Dispose of Sensitive Data
 
-For security, clear sensitive data from memory when a session is complete. Use [`account.dispose()`](../api-reference) and [`wallet.dispose()`](../api-reference) to securely wipe private keys:
+For security, clear sensitive data from memory when a session is complete. Use [`account.dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and [`wallet.dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) to securely wipe private keys:
 
 ```javascript title="Dispose Resources"
 try {
@@ -78,5 +78,5 @@ try {
 ```
 
 <Callout type="warn">
-Always call [`dispose()`](../api-reference) when finished with accounts. Private keys are securely wiped from memory. Disposal is irreversible.
+Always call [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) when finished with accounts. Private keys are securely wiped from memory. Disposal is irreversible.
 </Callout>

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts.mdx
@@ -7,7 +7,7 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 ## Retrieve Accounts by Index
 
-You can retrieve multiple smart accounts using [`wallet.getAccount()`](../api-reference) with different index values:
+You can retrieve multiple smart accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) with different index values:
 
 ```javascript title="Retrieve Multiple Accounts"
 const account0 = await wallet.getAccount(0)
@@ -21,7 +21,7 @@ console.log('Account 1 address:', address1)
 
 ## Retrieve Account by Custom Derivation Path
 
-You can retrieve an account at a specific derivation path using [`wallet.getAccountByPath()`](../api-reference):
+You can retrieve an account at a specific derivation path using [`wallet.getAccountByPath()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Custom Derivation Path"
 const customAccount = await wallet.getAccountByPath("0'/0/5")
@@ -31,4 +31,4 @@ console.log('Custom account address:', customAddress)
 
 ## Next Steps
 
-With accounts set up, learn how to [check balances](./check-balances).
+With accounts set up, learn how to [check balances](/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
@@ -7,7 +7,7 @@ This guide explains how to [send a gasless transaction](#send-a-gasless-transact
 
 ## Send a Gasless Transaction
 
-You can send a transaction with gas fees paid in the paymaster token using [`account.sendTransaction()`](../api-reference):
+You can send a transaction with gas fees paid in the paymaster token using [`account.sendTransaction()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Send Gasless Transaction"
 const result = await account.sendTransaction({
@@ -24,7 +24,7 @@ ERC-4337 transactions are gasless for the end user. Gas fees are paid through th
 
 ## Estimate Fees
 
-You can estimate the fee for a transaction without broadcasting it using [`account.quoteSendTransaction()`](../api-reference):
+You can estimate the fee for a transaction without broadcasting it using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Estimate Fee"
 const quote = await account.quoteSendTransaction({
@@ -36,7 +36,7 @@ console.log('Estimated fee:', quote.fee)
 
 ## Send with Custom Paymaster Token
 
-You can override the default paymaster token for a specific transaction by passing a config object to [`account.sendTransaction()`](../api-reference):
+You can override the default paymaster token for a specific transaction by passing a config object to [`account.sendTransaction()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Custom Paymaster Token"
 const result = await account.sendTransaction({
@@ -51,4 +51,4 @@ const result = await account.sendTransaction({
 
 ## Next Steps
 
-Learn how to [transfer ERC-20 tokens](./transfer-tokens).
+Learn how to [transfer ERC-20 tokens](/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages.mdx
@@ -7,7 +7,7 @@ This guide explains how to [sign messages](#sign-a-message), [verify signatures]
 
 ## Sign a Message
 
-You can sign a message with the account's private key using [`account.sign()`](../api-reference):
+You can sign a message with the account's private key using [`account.sign()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Sign Message"
 const signature = await account.sign('Hello, ERC-4337!')
@@ -16,7 +16,7 @@ console.log('Signature:', signature)
 
 ## Verify a Signature
 
-You can verify a signature using a read-only account. Use [`account.toReadOnlyAccount()`](../api-reference) to create one, then call [`readOnlyAccount.verify()`](../api-reference):
+You can verify a signature using a read-only account. Use [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) to create one, then call [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Verify Signature"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -26,7 +26,7 @@ console.log('Signature valid:', isValid)
 
 ## Sign Typed Data (EIP-712)
 
-You can sign EIP-712 structured data using [`account.signTypedData()`](../api-reference):
+You can sign EIP-712 structured data using [`account.signTypedData()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Sign Typed Data"
 const typedData = {
@@ -54,7 +54,7 @@ const typedDataSignature = await account.signTypedData(typedData)
 console.log('Typed data signature:', typedDataSignature)
 ```
 
-You can verify typed data signatures using [`readOnlyAccount.verifyTypedData()`](../api-reference):
+You can verify typed data signatures using [`readOnlyAccount.verifyTypedData()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Verify Typed Data"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -64,4 +64,4 @@ console.log('Typed data signature valid:', isValid)
 
 ## Next Steps
 
-Learn how to [handle errors and manage resources](./handle-errors).
+Learn how to [handle errors and manage resources](/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors).

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
@@ -7,7 +7,7 @@ This guide explains how to [transfer ERC-20 tokens](#transfer-erc-20-tokens), [e
 
 ## Transfer ERC-20 Tokens
 
-You can transfer ERC-20 tokens using gasless transactions with [`account.transfer()`](../api-reference):
+You can transfer ERC-20 tokens using gasless transactions with [`account.transfer()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Transfer ERC-20 Tokens"
 const result = await account.transfer({
@@ -21,7 +21,7 @@ console.log('Transfer fee:', result.fee)
 
 ## Estimate Transfer Fees
 
-You can estimate the fee for a token transfer without executing it using [`account.quoteTransfer()`](../api-reference):
+You can estimate the fee for a token transfer without executing it using [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Estimate Transfer Fee"
 const quote = await account.quoteTransfer({
@@ -34,7 +34,7 @@ console.log('Estimated transfer fee:', quote.fee)
 
 ## Transfer with Maximum Fee Limit
 
-You can set a maximum fee for a specific transfer by passing a `transferMaxFee` in the config object to [`account.transfer()`](../api-reference):
+You can set a maximum fee for a specific transfer by passing a `transferMaxFee` in the config object to [`account.transfer()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Transfer with Fee Limit"
 const result = await account.transfer({
@@ -52,4 +52,4 @@ If the estimated fee exceeds `transferMaxFee`, the transfer is cancelled with an
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages).
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages).

--- a/content/docs/sdk/wallet-modules/wallet-evm/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/api-reference.mdx
@@ -964,16 +964,16 @@ interface EvmTransactionReceipt {
 ```
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="React Native Quickstart" href="../../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="WDK EVM Wallet Usage" href="./usage">
+<Card title="WDK EVM Wallet Usage" href="/sdk/wallet-modules/wallet-evm/usage">
 Get started with WDK's EVM Wallet Usage
 </Card>
-<Card title="WDK EVM Wallet Configuration" href="./configuration">
+<Card title="WDK EVM Wallet Configuration" href="/sdk/wallet-modules/wallet-evm/configuration">
 Get started with WDK's EVM Wallet Configuration
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-evm/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/configuration.mdx
@@ -243,16 +243,16 @@ const sepoliaConfig = {
 ## Next Steps
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="React Native Quickstart" href="../../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="WDK EVM Wallet Usage" href="./usage">
+<Card title="WDK EVM Wallet Usage" href="/sdk/wallet-modules/wallet-evm/usage">
 Get started with WDK's EVM Wallet Usage
 </Card>
-<Card title="WDK EVM Wallet API" href="./api-reference">
+<Card title="WDK EVM Wallet API" href="/sdk/wallet-modules/wallet-evm/api-reference">
 Get started with WDK's EVM Wallet API
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/check-balances.mdx
@@ -82,4 +82,4 @@ You can also create a read-only account from an existing owned account using [`a
 
 ## Next Steps
 
-With balance checks in place, learn how to [send transactions](./send-transactions).
+With balance checks in place, learn how to [send transactions](/sdk/wallet-modules/wallet-evm/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/getting-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/getting-started.mdx
@@ -69,9 +69,9 @@ const readOnlyAccount = await account.toReadOnlyAccount()
 </Callout>
 
 <Callout type="info">
-To use test/mock tokens instead of real funds, see the [configuration section](../configuration#network-support).
+To use test/mock tokens instead of real funds, see the [configuration section](/sdk/wallet-modules/wallet-evm/configuration#network-support).
 </Callout>
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-evm/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/manage-accounts.mdx
@@ -60,4 +60,4 @@ async function listAccounts(wallet) {
 
 ## Next Steps
 
-Now that you can access your accounts, learn how to [check balances](./check-balances).
+Now that you can access your accounts, learn how to [check balances](/sdk/wallet-modules/wallet-evm/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/send-transactions.mdx
@@ -99,4 +99,4 @@ console.log('Fee paid:', result.fee, 'wei')
 
 ## Next Steps
 
-To transfer ERC-20 tokens instead of native tokens, see [Transfer ERC-20 Tokens](./transfer-tokens).
+To transfer ERC-20 tokens instead of native tokens, see [Transfer ERC-20 Tokens](/sdk/wallet-modules/wallet-evm/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/sign-verify-messages.mdx
@@ -33,4 +33,4 @@ You can also create a [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-ev
 
 ## Next Steps
 
-For best practices on handling errors, managing fees, and cleaning up memory, see [Error Handling](./error-handling).
+For best practices on handling errors, managing fees, and cleaning up memory, see [Error Handling](/sdk/wallet-modules/wallet-evm/guides/error-handling).

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/transfer-tokens.mdx
@@ -89,4 +89,4 @@ console.log('Fee paid:', result.fee, 'wei')
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages) with your EVM account.
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-evm/guides/sign-verify-messages) with your EVM account.

--- a/content/docs/sdk/wallet-modules/wallet-evm/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/index.mdx
@@ -39,16 +39,16 @@ This package works with any EVM-compatible blockchain, including:
 ## Next Steps
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="WDK EVM Wallet Configuration" href="./configuration">
+<Card title="WDK EVM Wallet Configuration" href="/sdk/wallet-modules/wallet-evm/configuration">
 Get started with WDK's EVM Wallet configuration
 </Card>
-<Card title="WDK EVM Wallet API" href="./api-reference">
+<Card title="WDK EVM Wallet API" href="/sdk/wallet-modules/wallet-evm/api-reference">
 Get started with WDK's EVM Wallet API
 </Card>
-<Card title="WDK EVM Wallet Usage" href="./usage">
+<Card title="WDK EVM Wallet Usage" href="/sdk/wallet-modules/wallet-evm/usage">
 Get started with WDK's EVM Wallet usage
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-solana/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/api-reference.mdx
@@ -528,16 +528,16 @@ interface KeyPair {
 ```
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="React Native Quickstart" href="../../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="WDK Solana Wallet Usage" href="./usage">
+<Card title="WDK Solana Wallet Usage" href="/sdk/wallet-modules/wallet-solana/usage">
 Get started with WDK's Solana Wallet Usage
 </Card>
-<Card title="WDK Solana Wallet Configuration" href="./configuration">
+<Card title="WDK Solana Wallet Configuration" href="/sdk/wallet-modules/wallet-solana/configuration">
 Get started with WDK's Solana Wallet Configuration
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-solana/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/configuration.mdx
@@ -167,7 +167,7 @@ The default derivation path was updated in v1.0.0-beta.4 to match ecosystem conv
 
 If you're upgrading from an earlier version, existing wallets created with the old path will generate different addresses. Make sure to migrate any existing wallets or use the old path explicitly if needed for compatibility.
 
-Use [`getAccountByPath`](./api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets.
+Use [`getAccountByPath`](/sdk/wallet-modules/wallet-solana/api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets.
 </Callout>
 
 ## Security Considerations
@@ -179,16 +179,16 @@ Use [`getAccountByPath`](./api-reference#getaccountbypathpath) to supply an expl
 - Use trusted RPC providers or run your own Solana validator for production applications
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="React Native Quickstart" href="../../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="WDK Solana Wallet Usage" href="./usage">
+<Card title="WDK Solana Wallet Usage" href="/sdk/wallet-modules/wallet-solana/usage">
 Get started with WDK's Solana Wallet Usage
 </Card>
-<Card title="WDK Solana Wallet API" href="./api-reference">
+<Card title="WDK Solana Wallet API" href="/sdk/wallet-modules/wallet-solana/api-reference">
 Get started with WDK's Solana Wallet API
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/account-management.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/account-management.mdx
@@ -57,4 +57,4 @@ async function listAccounts(wallet) {
 
 ## Next Steps
 
-Now that you can access your accounts, learn how to [check balances](./check-balances).
+Now that you can access your accounts, learn how to [check balances](/sdk/wallet-modules/wallet-solana/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/check-balances.mdx
@@ -93,4 +93,4 @@ You can also create a read-only account from an existing owned account using [`a
 
 ## Next Steps
 
-With balance checks in place, learn how to [send SOL](./send-transactions).
+With balance checks in place, learn how to [send SOL](/sdk/wallet-modules/wallet-solana/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/getting-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/getting-started.mdx
@@ -41,7 +41,7 @@ const wallet = new WalletManagerSolana(seedPhrase, {
 ```
 
 <Callout type="info">
-To enable RPC failover, pass [`provider`](../configuration#provider) as an ordered array of endpoints and set [`retries`](../configuration#retries) to control additional failover attempts. `rpcUrl` remains available as a deprecated alias for `provider`.
+To enable RPC failover, pass [`provider`](/sdk/wallet-modules/wallet-solana/configuration#provider) as an ordered array of endpoints and set [`retries`](/sdk/wallet-modules/wallet-solana/configuration#retries) to control additional failover attempts. `rpcUrl` remains available as a deprecated alias for `provider`.
 </Callout>
 
 <Callout type="warn">
@@ -66,4 +66,4 @@ All Solana addresses are base58-encoded public keys. Accounts inherit the provid
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./account-management).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-solana/guides/account-management).

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/send-transactions.mdx
@@ -109,4 +109,4 @@ async function sendSOLTransfer(account, wallet) {
 
 ## Next Steps
 
-To transfer SPL tokens instead of native SOL, see [Transfer SPL Tokens](./transfer-tokens).
+To transfer SPL tokens instead of native SOL, see [Transfer SPL Tokens](/sdk/wallet-modules/wallet-solana/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/sign-verify-messages.mdx
@@ -33,4 +33,4 @@ You can also create a [`WalletAccountReadOnlySolana`](/sdk/wallet-modules/wallet
 
 ## Next Steps
 
-For best practices on handling errors, managing fees, and cleaning up memory, see [Error Handling](./error-handling).
+For best practices on handling errors, managing fees, and cleaning up memory, see [Error Handling](/sdk/wallet-modules/wallet-solana/guides/error-handling).

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/transfer-tokens.mdx
@@ -84,4 +84,4 @@ console.log('Actual fee:', result.fee, 'lamports')
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages) with your Solana account.
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-solana/guides/sign-verify-messages) with your Solana account.

--- a/content/docs/sdk/wallet-modules/wallet-solana/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/index.mdx
@@ -17,7 +17,7 @@ The default derivation path was updated in v1.0.0-beta.4 to match ecosystem conv
 
 If you're upgrading from an earlier version, existing wallets created with the old path will generate different addresses. Make sure to migrate any existing wallets or use the old path explicitly if needed for compatibility.
 
-Use [`getAccountByPath`](./api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets. On Solana, every child segment in a custom path must be hardened.
+Use [`getAccountByPath`](/sdk/wallet-modules/wallet-solana/api-reference#getaccountbypathpath) to supply an explicit derivation path when importing or recreating legacy wallets. On Solana, every child segment in a custom path must be hardened.
 </Callout>
 
 ## Features
@@ -48,16 +48,16 @@ This package works with the Solana blockchain, including:
 ## Next Steps
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="WDK Solana Wallet Configuration" href="./configuration">
+<Card title="WDK Solana Wallet Configuration" href="/sdk/wallet-modules/wallet-solana/configuration">
 Get started with WDK's Solana Wallet configuration
 </Card>
-<Card title="WDK Solana Wallet API" href="./api-reference">
+<Card title="WDK Solana Wallet API" href="/sdk/wallet-modules/wallet-solana/api-reference">
 Get started with WDK's Solana Wallet API
 </Card>
-<Card title="WDK Solana Wallet Usage" href="./usage">
+<Card title="WDK Solana Wallet Usage" href="/sdk/wallet-modules/wallet-solana/usage">
 Get started with WDK's with Solana Wallet usage
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-spark/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/api-reference.mdx
@@ -1204,16 +1204,16 @@ interface RefundStaticDepositOptions {
 ```
 
 <Cards>
-<Card title="Node.js Quickstart" href="../../../start-building/nodejs-bare-quickstart">
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
 Get started with WDK in a Node.js environment
 </Card>
-<Card title="React Native Quickstart" href="../../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="WDK Spark Wallet Usage" href="./usage">
+<Card title="WDK Spark Wallet Usage" href="/sdk/wallet-modules/wallet-spark/usage">
 Get started with WDK's Spark Wallet Usage
 </Card>
-<Card title="WDK Spark Wallet Configuration" href="./configuration">
+<Card title="WDK Spark Wallet Configuration" href="/sdk/wallet-modules/wallet-spark/configuration">
 Get started with WDK's Spark Wallet Configuration
 </Card>
 </Cards>

--- a/content/docs/sdk/wallet-modules/wallet-spark/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/configuration.mdx
@@ -54,7 +54,7 @@ const config = {
 
 ### SparkScan Balance Polling
 
-The `sparkscan` option configures SparkScan-backed balance polling for [`getBalance()`](./api-reference).
+The `sparkscan` option configures SparkScan-backed balance polling for [`getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference).
 
 **Type:** `SparkScanConfig` (optional)
 
@@ -73,11 +73,11 @@ const config = {
 }
 ```
 
-When `sparkscan` is configured, [`getBalance()`](./api-reference) returns SparkScan's soft balance from `btcSoftBalanceSats`.
+When `sparkscan` is configured, [`getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference) returns SparkScan's soft balance from `btcSoftBalanceSats`.
 
 ### Automatic Retry
 
-The `syncAndRetry` option tells [`sendTransaction()`](./api-reference) and [`payLightningInvoice()`](./api-reference) to sync wallet state and retry once after a failure.
+The `syncAndRetry` option tells [`sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference) and [`payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference) to sync wallet state and retry once after a failure.
 
 **Type:** `boolean` (optional)
 
@@ -91,7 +91,7 @@ const config = {
 }
 ```
 
-You can also call [`syncWalletBalance()`](./api-reference) directly when you want to reconcile wallet state before retrying an operation.
+You can also call [`syncWalletBalance()`](/sdk/wallet-modules/wallet-spark/api-reference) directly when you want to reconcile wallet state before retrying an operation.
 
 ## Network Configuration
 
@@ -113,7 +113,7 @@ const regtestConfig = {
 
 ## BIP-44 Derivation Path
 
-Spark uses the [BIP-44](../../../resources/concepts#bip-44-multi-account-hierarchy) coin type 998, resulting in derivation paths like:
+Spark uses the [BIP-44](/resources/concepts#bip-44-multi-account-hierarchy) coin type 998, resulting in derivation paths like:
 - `m/44'/998'/0'/0/0` for MAINNET account index 0
 - `m/44'/998'/0'/0/1` for MAINNET account index 1
 - `m/44'/998'/2'/0/0` for SIGNET account index 0
@@ -124,7 +124,7 @@ The path follows the pattern `m/44'/998'/{networkNumber}'/0/{index}` where:
 - `networkNumber` is 0 for MAINNET, 2 for SIGNET, or 3 for REGTEST
 - `index` is the account index
 
-This ensures compatibility with standard [BIP-44](../../../resources/concepts#bip-44-multi-account-hierarchy) wallets while using Spark's unique coin type identifier.
+This ensures compatibility with standard [BIP-44](/resources/concepts#bip-44-multi-account-hierarchy) wallets while using Spark's unique coin type identifier.
 
 ## Complete Configuration Example
 

--- a/content/docs/sdk/wallet-modules/wallet-spark/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/guides/check-balances.mdx
@@ -7,7 +7,7 @@ This guide explains how to read a [native Spark balance](#native-spark-balance),
 
 ## Native Spark Balance
 
-You can read the account balance in satoshis using [`account.getBalance()`](../api-reference):
+You can read the account balance in satoshis using [`account.getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Native Spark Balance"
 const balance = await account.getBalance()
@@ -19,7 +19,7 @@ console.log('Balance in BTC:', Number(balance) / 100000000)
 Balances are in satoshis (1 BTC = 100,000,000 satoshis).
 </Callout>
 
-If you configure [`sparkscan`](../configuration#sparkscan-balance-polling), [`account.getBalance()`](../api-reference) returns SparkScan's `btcSoftBalanceSats` value instead of the Spark SDK balance:
+If you configure [`sparkscan`](/sdk/wallet-modules/wallet-spark/configuration#sparkscan-balance-polling), [`account.getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference) returns SparkScan's `btcSoftBalanceSats` value instead of the Spark SDK balance:
 
 ```javascript title="SparkScan Balance Polling"
 const wallet = new WalletManagerSpark(seedPhrase, {
@@ -36,7 +36,7 @@ console.log('SparkScan balance:', balance)
 
 ## Token Balance
 
-You can read a specific token balance using [`account.getTokenBalance()`](../api-reference):
+You can read a specific token balance using [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Token Balance"
 const tokenBalance = await account.getTokenBalance('token_address...')
@@ -45,10 +45,10 @@ console.log('Token balance:', tokenBalance)
 
 ## Read-Only Account Balances
 
-1. Construct a [`WalletAccountReadOnlySpark`](../api-reference) instance with the Spark address and optional config.
-2. Call [`readOnlyAccount.getBalance()`](../api-reference).
+1. Construct a [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference) instance with the Spark address and optional config.
+2. Call [`readOnlyAccount.getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference).
 
-You can create a read-only account from a Spark address using the [`WalletAccountReadOnlySpark`](../api-reference) constructor:
+You can create a read-only account from a Spark address using the [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference) constructor:
 
 ```javascript title="Read-Only Account"
 import { WalletAccountReadOnlySpark } from '@tetherto/wdk-wallet-spark'
@@ -58,7 +58,7 @@ const readOnlyAccount = new WalletAccountReadOnlySpark('spark1...', {
 })
 ```
 
-You can read the native balance from that account using [`readOnlyAccount.getBalance()`](../api-reference):
+You can read the native balance from that account using [`readOnlyAccount.getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Read-Only Native Balance"
 const balance = await readOnlyAccount.getBalance()
@@ -66,10 +66,10 @@ console.log('Read-only balance:', balance, 'satoshis')
 ```
 
 <Callout type="info">
-The same [`sparkscan`](../configuration#sparkscan-balance-polling) behavior applies to read-only accounts.
+The same [`sparkscan`](/sdk/wallet-modules/wallet-spark/configuration#sparkscan-balance-polling) behavior applies to read-only accounts.
 </Callout>
 
-You can read a token balance on a read-only account using [`readOnlyAccount.getTokenBalance()`](../api-reference):
+You can read a token balance on a read-only account using [`readOnlyAccount.getTokenBalance()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Read-Only Token Balance"
 const tokenBalance = await readOnlyAccount.getTokenBalance('token_address...')
@@ -77,9 +77,9 @@ console.log('Read-only token balance:', tokenBalance)
 ```
 
 <Callout type="info">
-You can also obtain a read-only handle from an owned account with [`account.toReadOnlyAccount()`](../api-reference).
+You can also obtain a read-only handle from an owned account with [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-spark/api-reference).
 </Callout>
 
 ## Next Steps
 
-With balances verified, learn how to [send Spark and transfer tokens](./send-and-transfer).
+With balances verified, learn how to [send Spark and transfer tokens](/sdk/wallet-modules/wallet-spark/guides/send-and-transfer).

--- a/content/docs/sdk/wallet-modules/wallet-spark/guides/deposits-and-withdrawals.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/guides/deposits-and-withdrawals.mdx
@@ -7,10 +7,10 @@ This guide explains how to [get a single-use deposit address](#get-a-single-use-
 
 ## Get a Single-Use Deposit Address
 
-1. Call [`account.getSingleUseDepositAddress()`](../api-reference).
+1. Call [`account.getSingleUseDepositAddress()`](/sdk/wallet-modules/wallet-spark/api-reference).
 2. Send Bitcoin to the returned on-chain address and wait for confirmation.
 
-You can generate a one-time Bitcoin deposit address using [`account.getSingleUseDepositAddress()`](../api-reference):
+You can generate a one-time Bitcoin deposit address using [`account.getSingleUseDepositAddress()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Single-Use Deposit Address"
 const depositAddress = await account.getSingleUseDepositAddress()
@@ -20,9 +20,9 @@ console.log('Send Bitcoin to:', depositAddress)
 ## Claim Deposits
 
 1. Identify the Bitcoin transaction id that funded the deposit.
-2. Call [`account.claimDeposit()`](../api-reference) with that id.
+2. Call [`account.claimDeposit()`](/sdk/wallet-modules/wallet-spark/api-reference) with that id.
 
-You can credit the wallet after the deposit confirms using [`account.claimDeposit()`](../api-reference):
+You can credit the wallet after the deposit confirms using [`account.claimDeposit()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Claim Single-Use Deposit"
 const txId = 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16'
@@ -32,7 +32,7 @@ console.log('Deposit claimed:', walletLeaves)
 
 ### 1. (optional) Use a static deposit address
 
-You can reuse one on-chain deposit address using [`account.getStaticDepositAddress()`](../api-reference), then credit the wallet with [`account.claimStaticDeposit()`](../api-reference) after the Bitcoin transaction confirms:
+You can reuse one on-chain deposit address using [`account.getStaticDepositAddress()`](/sdk/wallet-modules/wallet-spark/api-reference), then credit the wallet with [`account.claimStaticDeposit()`](/sdk/wallet-modules/wallet-spark/api-reference) after the Bitcoin transaction confirms:
 
 ```javascript title="Static Deposit Flow"
 const staticAddress = await account.getStaticDepositAddress()
@@ -45,12 +45,12 @@ console.log('Static deposit claimed:', staticLeaves)
 ```
 
 <Callout type="info">
-You can list unused single-use addresses with [`account.getUnusedDepositAddresses()`](../api-reference). The method returns a paginated result with `depositAddresses` and `offset` fields.
+You can list unused single-use addresses with [`account.getUnusedDepositAddresses()`](/sdk/wallet-modules/wallet-spark/api-reference). The method returns a paginated result with `depositAddresses` and `offset` fields.
 </Callout>
 
 ## Query Static Deposit Addresses
 
-You can list all existing static deposit addresses using [`account.getStaticDepositAddresses()`](../api-reference):
+You can list all existing static deposit addresses using [`account.getStaticDepositAddresses()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Query Static Deposit Addresses"
 const addresses = await account.getStaticDepositAddresses()
@@ -59,7 +59,7 @@ console.log('Static deposit addresses:', addresses)
 
 ## Query UTXOs for a Deposit Address
 
-You can check confirmed UTXOs for a specific deposit address using [`account.getUtxosForDepositAddress()`](../api-reference):
+You can check confirmed UTXOs for a specific deposit address using [`account.getUtxosForDepositAddress()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Query UTXOs"
 const result = await account.getUtxosForDepositAddress({
@@ -72,10 +72,10 @@ console.log('Offset:', result.offset)
 ## Withdraw to Bitcoin Layer 1
 
 1. Choose a Bitcoin `onchainAddress` and `amountSats`.
-2. Request a cooperative exit quote with [`account.quoteWithdraw()`](../api-reference).
-3. Call [`account.withdraw()`](../api-reference) with the destination and amount.
+2. Request a cooperative exit quote with [`account.quoteWithdraw()`](/sdk/wallet-modules/wallet-spark/api-reference).
+3. Call [`account.withdraw()`](/sdk/wallet-modules/wallet-spark/api-reference) with the destination and amount.
 
-You can request a withdrawal fee quote using [`account.quoteWithdraw()`](../api-reference):
+You can request a withdrawal fee quote using [`account.quoteWithdraw()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Quote Withdrawal"
 const feeQuote = await account.quoteWithdraw({
@@ -85,7 +85,7 @@ const feeQuote = await account.quoteWithdraw({
 console.log('Withdrawal fee quote:', feeQuote)
 ```
 
-You can initiate the withdrawal using [`account.withdraw()`](../api-reference):
+You can initiate the withdrawal using [`account.withdraw()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Withdraw to On-Chain Bitcoin"
 const withdrawal = await account.withdraw({
@@ -96,9 +96,9 @@ console.log('Withdrawal request:', withdrawal)
 ```
 
 <Callout type="info">
-[`withdraw()`](../api-reference) accepts `onchainAddress` and `amountSats`. Run [`quoteWithdraw()`](../api-reference) first to understand the cooperative exit costs before initiating the withdrawal.
+[`withdraw()`](/sdk/wallet-modules/wallet-spark/api-reference) accepts `onchainAddress` and `amountSats`. Run [`quoteWithdraw()`](/sdk/wallet-modules/wallet-spark/api-reference) first to understand the cooperative exit costs before initiating the withdrawal.
 </Callout>
 
 ## Next Steps
 
-Learn how to [handle errors and follow operational best practices](./handle-errors).
+Learn how to [handle errors and follow operational best practices](/sdk/wallet-modules/wallet-spark/guides/handle-errors).

--- a/content/docs/sdk/wallet-modules/wallet-spark/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/guides/get-started.mdx
@@ -24,7 +24,7 @@ The WDK Spark wallet module uses ES Modules (`import` / `export`). Set `"type": 
 
 ## 2. Create a Wallet
 
-You can create a wallet manager using the [`WalletManagerSpark`](../api-reference) constructor with a BIP-39 seed phrase:
+You can create a wallet manager using the [`WalletManagerSpark`](/sdk/wallet-modules/wallet-spark/api-reference) constructor with a BIP-39 seed phrase:
 
 ```javascript title="Create Spark Wallet"
 import WalletManagerSpark from '@tetherto/wdk-wallet-spark'
@@ -52,10 +52,10 @@ The Spark wallet uses `@buildonspark/spark-sdk`. Network options are `MAINNET`, 
 
 ## 3. Get Your First Account
 
-1. Call [`wallet.getAccount()`](../api-reference) with index `0`.
-2. Call [`account.getAddress()`](../api-reference) to read the Spark address.
+1. Call [`wallet.getAccount()`](/sdk/wallet-modules/wallet-spark/api-reference) with index `0`.
+2. Call [`account.getAddress()`](/sdk/wallet-modules/wallet-spark/api-reference) to read the Spark address.
 
-You can retrieve the first account using [`wallet.getAccount()`](../api-reference):
+You can retrieve the first account using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Get First Account"
 const account = await wallet.getAccount(0)
@@ -65,7 +65,7 @@ console.log('Account address:', address)
 
 ## 4. (optional) Convert to Read-Only
 
-You can create a read-only view of the account using [`account.toReadOnlyAccount()`](../api-reference):
+You can create a read-only view of the account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Convert to Read-Only"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -73,4 +73,4 @@ const readOnlyAccount = await account.toReadOnlyAccount()
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-spark/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-spark/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/guides/handle-errors.mdx
@@ -7,7 +7,7 @@ This guide explains how to [handle transaction errors](#transaction-errors), [ha
 
 ## Transaction Errors
 
-Operations such as [`account.sendTransaction()`](../api-reference), [`account.transfer()`](../api-reference), [`account.payLightningInvoice()`](../api-reference), and [`account.withdraw()`](../api-reference) can throw. Wrap each call in `try/catch` and branch on `message` or error type when your runtime allows it:
+Operations such as [`account.sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference), [`account.transfer()`](/sdk/wallet-modules/wallet-spark/api-reference), [`account.payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference), and [`account.withdraw()`](/sdk/wallet-modules/wallet-spark/api-reference) can throw. Wrap each call in `try/catch` and branch on `message` or error type when your runtime allows it:
 
 ```javascript title="Handle Transaction Errors"
 try {
@@ -21,7 +21,7 @@ try {
 }
 ```
 
-You can isolate Lightning failures by wrapping [`account.payLightningInvoice()`](../api-reference):
+You can isolate Lightning failures by wrapping [`account.payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Handle Lightning Errors"
 try {
@@ -56,7 +56,7 @@ try {
 
 ### Fee management
 
-Native Spark sends and token transfers report zero fees, but withdrawals and Lightning payments can charge fees. Use [`wallet.getFeeRates()`](../api-reference) for wallet-level rate placeholders and [`account.quotePayLightningInvoice()`](../api-reference) for Lightning sends:
+Native Spark sends and token transfers report zero fees, but withdrawals and Lightning payments can charge fees. Use [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-spark/api-reference) for wallet-level rate placeholders and [`account.quotePayLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference) for Lightning sends:
 
 ```javascript title="Inspect Spark Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -72,12 +72,12 @@ console.log('Estimated Lightning fee:', Number(lightningFee), 'satoshis')
 ```
 
 <Callout type="info">
-[`quoteWithdraw()`](../api-reference) should run before [`withdraw()`](../api-reference) so you understand cooperative exit costs.
+[`quoteWithdraw()`](/sdk/wallet-modules/wallet-spark/api-reference) should run before [`withdraw()`](/sdk/wallet-modules/wallet-spark/api-reference) so you understand cooperative exit costs.
 </Callout>
 
 ### Dispose of sensitive data
 
-Clear keys from memory when a session ends. Call [`account.dispose()`](../api-reference) for each account and [`wallet.dispose()`](../api-reference) on the manager:
+Clear keys from memory when a session ends. Call [`account.dispose()`](/sdk/wallet-modules/wallet-spark/api-reference) for each account and [`wallet.dispose()`](/sdk/wallet-modules/wallet-spark/api-reference) on the manager:
 
 ```javascript title="Dispose Wallet Resources"
 try {
@@ -93,9 +93,9 @@ try {
 ```
 
 <Callout type="warn">
-After [`dispose()`](../api-reference), the account cannot sign new operations. Call disposal when the wallet UI or job is finished.
+After [`dispose()`](/sdk/wallet-modules/wallet-spark/api-reference), the account cannot sign new operations. Call disposal when the wallet UI or job is finished.
 </Callout>
 
 ## Next Steps
 
-Return to the [Spark wallet usage overview](../usage) or open the [API Reference](../api-reference) for full method signatures.
+Return to the [Spark wallet usage overview](/sdk/wallet-modules/wallet-spark/usage) or open the [API Reference](/sdk/wallet-modules/wallet-spark/api-reference) for full method signatures.

--- a/content/docs/sdk/wallet-modules/wallet-spark/guides/lightning-payments.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/guides/lightning-payments.mdx
@@ -8,9 +8,9 @@ This guide explains how to [create a Lightning invoice](#create-a-lightning-invo
 ## Create a Lightning Invoice
 
 1. Choose an amount in satoshis and an optional memo.
-2. Call [`account.createLightningInvoice()`](../api-reference).
+2. Call [`account.createLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference).
 
-You can create a BOLT11 invoice using [`account.createLightningInvoice()`](../api-reference):
+You can create a BOLT11 invoice using [`account.createLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Create Lightning Invoice"
 const invoice = await account.createLightningInvoice({
@@ -24,9 +24,9 @@ console.log('Lightning invoice:', invoice.invoice)
 
 1. Obtain a BOLT11 `encodedInvoice` string.
 2. Set `maxFeeSats` to cap routing fees.
-3. Call [`account.payLightningInvoice()`](../api-reference).
+3. Call [`account.payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference).
 
-You can pay an invoice using [`account.payLightningInvoice()`](../api-reference):
+You can pay an invoice using [`account.payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Pay Lightning Invoice"
 const payment = await account.payLightningInvoice({
@@ -36,7 +36,7 @@ const payment = await account.payLightningInvoice({
 console.log('Payment result:', payment)
 ```
 
-If you enable [`syncAndRetry`](../configuration#automatic-retry), the wallet syncs state and retries [`account.payLightningInvoice()`](../api-reference) once after a failure:
+If you enable [`syncAndRetry`](/sdk/wallet-modules/wallet-spark/configuration#automatic-retry), the wallet syncs state and retries [`account.payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference) once after a failure:
 
 ```javascript title="Retry Lightning Payment Once"
 const wallet = new WalletManagerSpark(seedPhrase, {
@@ -53,7 +53,7 @@ await account.payLightningInvoice({
 
 ## Estimate Lightning Fees
 
-You can estimate the routing fee before paying using [`account.quotePayLightningInvoice()`](../api-reference):
+You can estimate the routing fee before paying using [`account.quotePayLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Quote Lightning Payment Fee"
 const feeEstimate = await account.quotePayLightningInvoice({
@@ -63,12 +63,12 @@ console.log('Fee estimate:', Number(feeEstimate), 'satoshis')
 ```
 
 <Callout type="info">
-Older references to `getLightningSendFeeEstimate()` map to [`quotePayLightningInvoice()`](../api-reference).
+Older references to `getLightningSendFeeEstimate()` map to [`quotePayLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference).
 </Callout>
 
 ## Fetch a Lightning Send Request
 
-You can load a prior send request by id using [`account.getLightningSendRequest()`](../api-reference):
+You can load a prior send request by id using [`account.getLightningSendRequest()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Get Lightning Send Request"
 const sendRequest = await account.getLightningSendRequest(payment.id)
@@ -78,9 +78,9 @@ if (sendRequest) {
 ```
 
 <Callout type="info">
-Use the `id` from the object returned by [`payLightningInvoice()`](../api-reference).
+Use the `id` from the object returned by [`payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference).
 </Callout>
 
 ## Next Steps
 
-Learn how to [handle Bitcoin layer 1 deposits and withdrawals](./deposits-and-withdrawals).
+Learn how to [handle Bitcoin layer 1 deposits and withdrawals](/sdk/wallet-modules/wallet-spark/guides/deposits-and-withdrawals).

--- a/content/docs/sdk/wallet-modules/wallet-spark/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/guides/manage-accounts.mdx
@@ -7,10 +7,10 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 ## Retrieve Accounts by Index
 
-1. Call [`wallet.getAccount()`](../api-reference) with the account index.
-2. Call [`account.getAddress()`](../api-reference) for each account.
+1. Call [`wallet.getAccount()`](/sdk/wallet-modules/wallet-spark/api-reference) with the account index.
+2. Call [`account.getAddress()`](/sdk/wallet-modules/wallet-spark/api-reference) for each account.
 
-You can retrieve multiple accounts using [`wallet.getAccount()`](../api-reference) with different index values:
+You can retrieve multiple accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-spark/api-reference) with different index values:
 
 ```javascript title="Retrieve Accounts by Index"
 const account0 = await wallet.getAccount(0)
@@ -28,7 +28,7 @@ Accounts use BIP-44 paths `m/44'/998'/{networkNumber}'/0/{index}` where `998` is
 
 ## Retrieve Accounts by Derivation Path
 
-You can retrieve an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](../api-reference):
+You can retrieve an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](/sdk/wallet-modules/wallet-spark/api-reference):
 
 ```javascript title="Retrieve Account by Path"
 const account = await wallet.getAccountByPath("0'/0/0")
@@ -37,12 +37,12 @@ console.log('Account address:', address)
 ```
 
 <Callout type="info">
-The path segment is appended to the base path `m/44'/998'/`. For example, `"0'/0/0"` resolves to `m/44'/998'/0'/0/0` on MAINNET. See [`getAccountByPath()`](../api-reference) in the API reference.
+The path segment is appended to the base path `m/44'/998'/`. For example, `"0'/0/0"` resolves to `m/44'/998'/0'/0/0` on MAINNET. See [`getAccountByPath()`](/sdk/wallet-modules/wallet-spark/api-reference) in the API reference.
 </Callout>
 
 ## Iterate Over Accounts
 
-You can walk a range of indices using [`wallet.getAccount()`](../api-reference) inside a loop:
+You can walk a range of indices using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-spark/api-reference) inside a loop:
 
 ```javascript title="Iterate Over Accounts"
 for (let i = 0; i < 5; i++) {
@@ -55,4 +55,4 @@ for (let i = 0; i < 5; i++) {
 
 ## Next Steps
 
-With accounts set up, learn how to [check balances](./check-balances).
+With accounts set up, learn how to [check balances](/sdk/wallet-modules/wallet-spark/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-spark/guides/send-and-transfer.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/guides/send-and-transfer.mdx
@@ -8,9 +8,9 @@ This guide explains how to [send native Spark](#send-spark), [transfer tokens](#
 ## Send Spark
 
 1. Build the recipient Spark address and amount in satoshis.
-2. Call [`account.sendTransaction()`](../api-reference#sendtransactionto-value).
+2. Call [`account.sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference#sendtransactionto-value).
 
-You can send native Spark (satoshis) using [`account.sendTransaction()`](../api-reference#sendtransactionto-value):
+You can send native Spark (satoshis) using [`account.sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference#sendtransactionto-value):
 
 ```javascript title="Send Native Spark"
 const result = await account.sendTransaction({
@@ -22,14 +22,14 @@ console.log('Transaction fee:', result.fee)
 ```
 
 <Callout type="info">
-On-chain Spark transfers report `fee` as `0`. Memos are not supported on [`sendTransaction()`](../api-reference#sendtransactionto-value). Use valid Spark network addresses.
+On-chain Spark transfers report `fee` as `0`. Memos are not supported on [`sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference#sendtransactionto-value). Use valid Spark network addresses.
 </Callout>
 
 <Callout type="warn">
-[`account.signTransaction()`](../api-reference#signtransactiontx) is exposed for `IWalletAccount` compatibility, but it always throws on Spark. Spark transfers are collaboratively signed with Spark operators, so a standalone signed payload cannot be produced for separate broadcast. Use [`account.sendTransaction()`](../api-reference#sendtransactionto-value) for Spark sends.
+[`account.signTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference#signtransactiontx) is exposed for `IWalletAccount` compatibility, but it always throws on Spark. Spark transfers are collaboratively signed with Spark operators, so a standalone signed payload cannot be produced for separate broadcast. Use [`account.sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference#sendtransactionto-value) for Spark sends.
 </Callout>
 
-If you enable [`syncAndRetry`](../configuration#automatic-retry), the wallet syncs its state and retries [`account.sendTransaction()`](../api-reference#sendtransactionto-value) once after a failure:
+If you enable [`syncAndRetry`](/sdk/wallet-modules/wallet-spark/configuration#automatic-retry), the wallet syncs its state and retries [`account.sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference#sendtransactionto-value) once after a failure:
 
 ```javascript title="Retry Failed Sends Once"
 const wallet = new WalletManagerSpark(seedPhrase, {
@@ -46,7 +46,7 @@ await account.sendTransaction({
 
 ## Transfer Tokens
 
-You can move tokens to another Spark address using [`account.transfer()`](../api-reference#transferoptions):
+You can move tokens to another Spark address using [`account.transfer()`](/sdk/wallet-modules/wallet-spark/api-reference#transferoptions):
 
 ```javascript title="Transfer Tokens"
 const transferResult = await account.transfer({
@@ -66,7 +66,7 @@ Token identifiers use Bech32m (for example `btkn1...`). Amounts use the token’
 
 ### Spark native and token transfer quotes
 
-You can preview the fee for a native send using [`account.quoteSendTransaction()`](../api-reference#quotesendtransactionto-value):
+You can preview the fee for a native send using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference#quotesendtransactionto-value):
 
 ```javascript title="Quote Native Send"
 const quote = await account.quoteSendTransaction({
@@ -76,7 +76,7 @@ const quote = await account.quoteSendTransaction({
 console.log('Estimated fee:', quote.fee)
 ```
 
-You can preview the fee for a token transfer using [`account.quoteTransfer()`](../api-reference#quotetransferoptions):
+You can preview the fee for a token transfer using [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-spark/api-reference#quotetransferoptions):
 
 ```javascript title="Quote Token Transfer"
 const transferQuote = await account.quoteTransfer({
@@ -89,7 +89,7 @@ console.log('Estimated transfer fee:', Number(transferQuote.fee))
 
 ### Wallet-level fee rates
 
-You can read wallet-level fee rate placeholders using [`wallet.getFeeRates()`](../api-reference#getfeerates):
+You can read wallet-level fee rate placeholders using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-spark/api-reference#getfeerates):
 
 ```javascript title="Wallet Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -98,10 +98,10 @@ console.log('Fast:', feeRates.fast)
 ```
 
 <Callout type="info">
-Spark network fees for native sends and token transfers are zero; [`wallet.getFeeRates()`](../api-reference#getfeerates) returns `{ normal: 0n, fast: 0n }`. Lightning flows can still incur fees; see [Lightning payments](./lightning-payments).
+Spark network fees for native sends and token transfers are zero; [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-spark/api-reference#getfeerates) returns `{ normal: 0n, fast: 0n }`. Lightning flows can still incur fees; see [Lightning payments](/sdk/wallet-modules/wallet-spark/guides/lightning-payments).
 </Callout>
 
-If you want to reconcile wallet state before retrying manually, call [`account.syncWalletBalance()`](../api-reference#syncwalletbalance):
+If you want to reconcile wallet state before retrying manually, call [`account.syncWalletBalance()`](/sdk/wallet-modules/wallet-spark/api-reference#syncwalletbalance):
 
 ```javascript title="Sync Wallet Balance"
 await account.syncWalletBalance()
@@ -109,4 +109,4 @@ await account.syncWalletBalance()
 
 ## Next Steps
 
-Learn how to [create and pay Lightning invoices](./lightning-payments).
+Learn how to [create and pay Lightning invoices](/sdk/wallet-modules/wallet-spark/guides/lightning-payments).

--- a/content/docs/sdk/wallet-modules/wallet-spark/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/index.mdx
@@ -14,8 +14,8 @@ A simple and secure package to manage BIP-32 wallets for the Spark blockchain. T
 - **Spark Blockchain Support**: Full integration with the Spark Bitcoin [layer 2](/resources/concepts#layer-2-solutions) network
 - **Lightning Network Integration**: Create and pay [Lightning Network](/resources/concepts#lightning-network) invoices directly
 - **Spark Invoices**: Create and pay Spark invoices for receiving sats and tokens directly on the Spark network
-- **SparkScan Balance Polling**: Use SparkScan-backed balance polling in [`getBalance()`](./api-reference) when `sparkscan` is configured
-- **Sync and Retry**: Optionally sync wallet state and retry failed [`sendTransaction()`](./api-reference) and [`payLightningInvoice()`](./api-reference) calls once
+- **SparkScan Balance Polling**: Use SparkScan-backed balance polling in [`getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference) when `sparkscan` is configured
+- **Sync and Retry**: Optionally sync wallet state and retry failed [`sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference) and [`payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference) calls once
 - **Token Transfers**: Transfer tokens to other Spark addresses
 - **Bitcoin Layer 1 Bridge**: Deposit and withdraw Bitcoin between layer 1 and Spark
 - **Static Deposit Addresses**: Reusable deposit addresses for Bitcoin layer 1 deposits

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances.mdx
@@ -9,7 +9,7 @@ This guide explains how to check [native TON balances](#native-ton-balance), [Je
 
 ## Native TON Balance
 
-You can retrieve the native TON balance using [`account.getBalance()`](../api-reference):
+You can retrieve the native TON balance using [`account.getBalance()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Get Native TON Balance"
 const balance = await account.getBalance()
@@ -18,7 +18,7 @@ console.log('Native TON balance:', balance, 'nanotons')
 
 ## Jetton Token Balance
 
-You can check the balance of a specific Jetton token using [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress):
+You can check the balance of a specific Jetton token using [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#gettokenbalancetokenaddress):
 
 ```javascript title="Get Jetton Token Balance"
 const jettonAddress = 'EQ...' // Jetton contract address
@@ -28,7 +28,7 @@ console.log('Jetton token balance:', jettonBalance)
 
 ## Paymaster Token Balance
 
-You can check the balance of the configured paymaster token using [`account.getPaymasterTokenBalance()`](../api-reference):
+You can check the balance of the configured paymaster token using [`account.getPaymasterTokenBalance()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Get Paymaster Token Balance"
 const paymasterBalance = await account.getPaymasterTokenBalance()
@@ -41,7 +41,7 @@ The paymaster token balance determines how many gasless transfers you can execut
 
 ## Read-Only Account Balances
 
-You can check balances for any public key without a seed phrase using [`WalletAccountReadOnlyTonGasless`](../api-reference):
+You can check balances for any public key without a seed phrase using [`WalletAccountReadOnlyTonGasless`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Create Read-Only Account"
 import { WalletAccountReadOnlyTonGasless } from '@tetherto/wdk-wallet-ton-gasless'
@@ -61,7 +61,7 @@ const readOnlyAccount = new WalletAccountReadOnlyTonGasless(publicKey, {
 })
 ```
 
-You can retrieve balances from a read-only account using [`readOnlyAccount.getBalance()`](../api-reference) and [`readOnlyAccount.getPaymasterTokenBalance()`](../api-reference):
+You can retrieve balances from a read-only account using [`readOnlyAccount.getBalance()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference) and [`readOnlyAccount.getPaymasterTokenBalance()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Read-Only Balances"
 const balance = await readOnlyAccount.getBalance()
@@ -73,4 +73,4 @@ console.log('Paymaster token balance:', paymasterBalance)
 
 ## Next Steps
 
-With balance checks in place, learn how to [send TON](./send-transactions).
+With balance checks in place, learn how to [send TON](/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/get-started.mdx
@@ -20,7 +20,7 @@ npm install @tetherto/wdk-wallet-ton-gasless
 
 ## 2. Create a Gasless Wallet
 
-You can create a new gasless wallet instance using the [`WalletManagerTonGasless`](../api-reference) constructor with a BIP-39 seed phrase, TON client endpoints, and a paymaster token configuration:
+You can create a new gasless wallet instance using the [`WalletManagerTonGasless`](/sdk/wallet-modules/wallet-ton-gasless/api-reference) constructor with a BIP-39 seed phrase, TON client endpoints, and a paymaster token configuration:
 
 ```javascript title="Create Gasless TON Wallet"
 import WalletManagerTonGasless, {
@@ -52,7 +52,7 @@ const wallet = new WalletManagerTonGasless(seedPhrase, {
 
 ## 3. Get Your First Account
 
-You can retrieve an account at a given index using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can retrieve an account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#getaccountindex):
 
 ```javascript title="Get Account"
 const account = await wallet.getAccount(0)
@@ -62,7 +62,7 @@ console.log('Wallet address:', address)
 
 ## 4. (optional) Convert to Read-Only
 
-You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](../api-reference):
+You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Convert to Read-Only"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -70,4 +70,4 @@ const readOnlyAccount = await account.toReadOnlyAccount()
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.mdx
@@ -9,7 +9,7 @@ This guide covers how to [handle gasless transfer errors](#handle-gasless-transf
 
 ## Handle Gasless Transfer Errors
 
-Gasless transfers can fail for reasons specific to the paymaster model. Wrap calls to [`account.transfer()`](../api-reference#transferoptions-config) in `try/catch` blocks:
+Gasless transfers can fail for reasons specific to the paymaster model. Wrap calls to [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config) in `try/catch` blocks:
 
 ```javascript title="Gasless Transfer Error Handling"
 try {
@@ -36,7 +36,7 @@ try {
 
 ## Handle Native TON Transaction Errors
 
-Native TON transactions sent via [`account.sendTransaction()`](../api-reference) can fail for standard reasons:
+Native TON transactions sent via [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference) can fail for standard reasons:
 
 ```javascript title="Transaction Error Handling"
 try {
@@ -58,7 +58,7 @@ try {
 
 ### Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet to prevent gasless transfers from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](../api-reference):
+Set `transferMaxFee` when creating the wallet to prevent gasless transfers from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()
@@ -68,7 +68,7 @@ console.log('Fast fee rate:', feeRates.fast, 'nanotons')
 
 ### Dispose of Sensitive Data
 
-Call [`dispose()`](../api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
+Call [`dispose()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
 
 ```javascript title="Memory Cleanup"
 account.dispose()
@@ -77,5 +77,5 @@ wallet.dispose()
 ```
 
 <Callout type="warn">
-Always call [`dispose()`](../api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
+Always call [`dispose()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
 </Callout>

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts.mdx
@@ -9,7 +9,7 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 ## Retrieve Accounts by Index
 
-You can access accounts derived from the default BIP-44 path using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can access accounts derived from the default BIP-44 path using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#getaccountindex):
 
 ```javascript title="Get Accounts by Index"
 const account = await wallet.getAccount(0)
@@ -23,7 +23,7 @@ console.log('Account 1 address:', address1)
 
 ## Retrieve Account by Custom Derivation Path
 
-You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](../api-reference#getaccountbypathpath):
+You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#getaccountbypathpath):
 
 ```javascript title="Custom Derivation Path"
 const customAccount = await wallet.getAccountByPath("0'/0/5")
@@ -33,7 +33,7 @@ console.log('Custom account address:', customAddress)
 
 ## Iterate Over Multiple Accounts
 
-You can loop through multiple accounts using [`wallet.getAccount()`](../api-reference#getaccountindex) to inspect addresses and balances in bulk:
+You can loop through multiple accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#getaccountindex) to inspect addresses and balances in bulk:
 
 ```javascript title="Multi-Account Iteration"
 async function listAccounts(wallet) {
@@ -54,4 +54,4 @@ async function listAccounts(wallet) {
 
 ## Next Steps
 
-Now that you can access your accounts, learn how to [check balances](./check-balances).
+Now that you can access your accounts, learn how to [check balances](/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.mdx
@@ -5,7 +5,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-This guide explains how to [send native TON](#send-native-ton) and [use dynamic fee rates](#use-dynamic-fee-rates). Native TON sends are not gasless; for gasless Jetton token transfers, see [Transfer Jetton Tokens](./transfer-tokens).
+This guide explains how to [send native TON](#send-native-ton) and [use dynamic fee rates](#use-dynamic-fee-rates). Native TON sends are not gasless; for gasless Jetton token transfers, see [Transfer Jetton Tokens](/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens).
 
 <Callout type="info">
 On TON, values are expressed in nanotons (1 TON = 10^9 nanotons).
@@ -13,7 +13,7 @@ On TON, values are expressed in nanotons (1 TON = 10^9 nanotons).
 
 ## Send Native TON
 
-You can transfer TON to a recipient address using [`account.sendTransaction()`](../api-reference):
+You can transfer TON to a recipient address using [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Send TON"
 const result = await account.sendTransaction({
@@ -26,7 +26,7 @@ console.log('Transaction fee:', result.fee, 'nanotons')
 
 ## Use Dynamic Fee Rates
 
-You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](../api-reference):
+You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference):
 
 ```javascript title="Get Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -36,4 +36,4 @@ console.log('Fast fee rate:', feeRates.fast, 'nanotons')
 
 ## Next Steps
 
-To transfer Jetton tokens with gasless fees (paid in paymaster tokens), see [Transfer Jetton Tokens](./transfer-tokens).
+To transfer Jetton tokens with gasless fees (paid in paymaster tokens), see [Transfer Jetton Tokens](/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages.mdx
@@ -9,7 +9,7 @@ This guide explains how to [sign messages](#sign-a-message) with an owned accoun
 
 ## Sign a Message
 
-You can produce a cryptographic signature for any string message using [`account.sign()`](../api-reference#signmessage):
+You can produce a cryptographic signature for any string message using [`account.sign()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#signmessage):
 
 ```javascript title="Sign a Message"
 const message = 'Hello, TON!'
@@ -19,14 +19,14 @@ console.log('Signature:', signature)
 
 ## Verify a Signature
 
-You can verify that a signature is valid using [`account.verify()`](../api-reference#verifymessage-signature):
+You can verify that a signature is valid using [`account.verify()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#verifymessage-signature):
 
 ```javascript title="Verify a Signature"
 const isValid = await account.verify(message, signature)
 console.log('Signature valid:', isValid)
 ```
 
-You can also create a [`WalletAccountReadOnlyTonGasless`](../api-reference) from any public key to verify signatures without access to the private key:
+You can also create a [`WalletAccountReadOnlyTonGasless`](/sdk/wallet-modules/wallet-ton-gasless/api-reference) from any public key to verify signatures without access to the private key:
 
 ```javascript title="Verify with Read-Only Account"
 import { WalletAccountReadOnlyTonGasless } from '@tetherto/wdk-wallet-ton-gasless'
@@ -51,4 +51,4 @@ console.log('Signature valid:', isValid)
 
 ## Next Steps
 
-For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](./handle-errors).
+For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors).

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.mdx
@@ -9,7 +9,7 @@ This guide explains how to [transfer Jetton tokens gaslessly](#transfer-tokens-g
 
 ## Transfer Tokens (Gasless)
 
-You can send Jetton tokens gaslessly using [`account.transfer()`](../api-reference#transferoptions-config). Fees are deducted from the configured paymaster token:
+You can send Jetton tokens gaslessly using [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config). Fees are deducted from the configured paymaster token:
 
 ```javascript title="Gasless Jetton Transfer"
 const result = await account.transfer({
@@ -23,7 +23,7 @@ console.log('Transfer fee:', result.fee, 'paymaster token units')
 
 ## Override Paymaster Configuration
 
-You can override the default paymaster token and maximum fee on a per-transfer basis by passing a second configuration argument to [`account.transfer()`](../api-reference#transferoptions-config):
+You can override the default paymaster token and maximum fee on a per-transfer basis by passing a second configuration argument to [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config):
 
 ```javascript title="Transfer with Config Override"
 const result = await account.transfer({
@@ -42,7 +42,7 @@ console.log('Transfer fee:', result.fee, 'paymaster token units')
 
 ## Estimate Transfer Fees
 
-You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](../api-reference#quotetransferoptions):
+You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#quotetransferoptions):
 
 ```javascript title="Quote Gasless Transfer"
 const quote = await account.quoteTransfer({
@@ -57,10 +57,10 @@ console.log('Transfer fee estimate:', quote.fee, 'paymaster token units')
 
 Validate balances before transferring:
 
-1. Use [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress) to check Jetton balance.
-2. Use [`account.getPaymasterTokenBalance()`](../api-reference#getpaymastertokenbalance) to verify sufficient paymaster funds.
-3. Use [`account.quoteTransfer()`](../api-reference#quotetransferoptions) to estimate fees.
-4. Execute the transfer with [`account.transfer()`](../api-reference#transferoptions-config):
+1. Use [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#gettokenbalancetokenaddress) to check Jetton balance.
+2. Use [`account.getPaymasterTokenBalance()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#getpaymastertokenbalance) to verify sufficient paymaster funds.
+3. Use [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#quotetransferoptions) to estimate fees.
+4. Execute the transfer with [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config):
 
 ```javascript title="Validated Gasless Transfer"
 async function transferWithValidation(account, jettonAddress, recipient, amount) {
@@ -101,4 +101,4 @@ async function transferWithValidation(account, jettonAddress, recipient, amount)
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages) with your gasless TON account.
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages) with your gasless TON account.

--- a/content/docs/sdk/wallet-modules/wallet-ton/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/configuration.mdx
@@ -144,7 +144,7 @@ The default derivation path was updated in v1.0.0-beta.6 to match ecosystem conv
 
 If you're upgrading from an earlier version, existing wallets created with the old path will generate different addresses. Make sure to migrate any existing wallets or use the old path explicitly if needed for compatibility.
 
-Use [`getAccountByPath`](./api-reference) to supply an explicit derivation path when importing or recreating legacy wallets.
+Use [`getAccountByPath`](/sdk/wallet-modules/wallet-ton/api-reference) to supply an explicit derivation path when importing or recreating legacy wallets.
 </Callout>
 
 ## Security Considerations

--- a/content/docs/sdk/wallet-modules/wallet-ton/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/guides/check-balances.mdx
@@ -9,7 +9,7 @@ This guide explains how to check [native TON balances](#native-ton-balance), [Je
 
 ## Native TON Balance
 
-You can retrieve the native TON balance using [`account.getBalance()`](../api-reference):
+You can retrieve the native TON balance using [`account.getBalance()`](/sdk/wallet-modules/wallet-ton/api-reference):
 
 ```javascript title="Get Native TON Balance"
 const balance = await account.getBalance()
@@ -22,7 +22,7 @@ On TON, values are expressed in nanotons (1 TON = 10^9 nanotons).
 
 ## Jetton Token Balance
 
-You can check the balance of a specific Jetton token using [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress):
+You can check the balance of a specific Jetton token using [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-ton/api-reference#gettokenbalancetokenaddress):
 
 ```javascript title="Get Jetton Token Balance"
 const jettonAddress = 'EQ...' // Jetton contract address
@@ -32,7 +32,7 @@ console.log('Jetton token balance:', jettonBalance)
 
 ## Read-Only Account Balances
 
-You can check balances for any public key without a seed phrase using [`WalletAccountReadOnlyTon`](../api-reference):
+You can check balances for any public key without a seed phrase using [`WalletAccountReadOnlyTon`](/sdk/wallet-modules/wallet-ton/api-reference):
 
 ```javascript title="Create Read-Only Account"
 import { WalletAccountReadOnlyTon } from '@tetherto/wdk-wallet-ton'
@@ -45,7 +45,7 @@ const readOnlyAccount = new WalletAccountReadOnlyTon(publicKey, {
 })
 ```
 
-You can retrieve the native balance from a read-only account using [`readOnlyAccount.getBalance()`](../api-reference):
+You can retrieve the native balance from a read-only account using [`readOnlyAccount.getBalance()`](/sdk/wallet-modules/wallet-ton/api-reference):
 
 ```javascript title="Read-Only Native Balance"
 const balance = await readOnlyAccount.getBalance()
@@ -53,9 +53,9 @@ console.log('Read-only account balance:', balance)
 ```
 
 <Callout type="info">
-You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](../api-reference).
+You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-ton/api-reference).
 </Callout>
 
 ## Next Steps
 
-With balance checks in place, learn how to [send TON](./send-transactions).
+With balance checks in place, learn how to [send TON](/sdk/wallet-modules/wallet-ton/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-ton/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/guides/get-started.mdx
@@ -20,7 +20,7 @@ npm install @tetherto/wdk-wallet-ton
 
 ## 2. Create a Wallet
 
-You can create a new wallet instance using the [`WalletManagerTon`](../api-reference) constructor with a BIP-39 seed phrase and a TON Center client configuration:
+You can create a new wallet instance using the [`WalletManagerTon`](/sdk/wallet-modules/wallet-ton/api-reference) constructor with a BIP-39 seed phrase and a TON Center client configuration:
 
 ```javascript title="Create TON Wallet"
 import WalletManagerTon, { WalletAccountTon, WalletAccountReadOnlyTon } from '@tetherto/wdk-wallet-ton'
@@ -41,7 +41,7 @@ const wallet = new WalletManagerTon(seedPhrase, {
 
 ## 3. Get Your First Account
 
-You can retrieve an account at a given index using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can retrieve an account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-ton/api-reference#getaccountindex):
 
 ```javascript title="Get Account"
 const account = await wallet.getAccount(0)
@@ -51,7 +51,7 @@ console.log('Wallet address:', address)
 
 ## 4. (optional) Convert to Read-Only
 
-You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](../api-reference):
+You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-ton/api-reference):
 
 ```javascript title="Convert to Read-Only"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -59,4 +59,4 @@ const readOnlyAccount = await account.toReadOnlyAccount()
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-ton/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-ton/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/guides/handle-errors.mdx
@@ -9,7 +9,7 @@ This guide covers how to [handle transaction errors](#handle-transaction-errors)
 
 ## Handle Transaction Errors
 
-Wrap transactions in `try/catch` blocks to handle common failure scenarios. Use [`account.sendTransaction()`](../api-reference#sendtransactiontx) with proper error handling:
+Wrap transactions in `try/catch` blocks to handle common failure scenarios. Use [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton/api-reference#sendtransactiontx) with proper error handling:
 
 ```javascript title="Transaction Error Handling"
 try {
@@ -35,7 +35,7 @@ try {
 
 ## Handle Token Transfer Errors
 
-Jetton transfers can fail for multiple reasons, such as insufficient token balances. Use [`account.transfer()`](../api-reference#transferoptions) with error handling:
+Jetton transfers can fail for multiple reasons, such as insufficient token balances. Use [`account.transfer()`](/sdk/wallet-modules/wallet-ton/api-reference#transferoptions) with error handling:
 
 ```javascript title="Token Transfer Error Handling"
 try {
@@ -59,7 +59,7 @@ try {
 
 ### Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet to prevent transactions from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](../api-reference):
+Set `transferMaxFee` when creating the wallet to prevent transactions from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-ton/api-reference):
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()
@@ -69,7 +69,7 @@ console.log('Fast fee rate:', feeRates.fast, 'nanotons')
 
 ### Dispose of Sensitive Data
 
-Call [`dispose()`](../api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
+Call [`dispose()`](/sdk/wallet-modules/wallet-ton/api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
 
 ```javascript title="Memory Cleanup"
 account.dispose()
@@ -78,5 +78,5 @@ wallet.dispose()
 ```
 
 <Callout type="warn">
-Always call [`dispose()`](../api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
+Always call [`dispose()`](/sdk/wallet-modules/wallet-ton/api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
 </Callout>

--- a/content/docs/sdk/wallet-modules/wallet-ton/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/guides/manage-accounts.mdx
@@ -9,7 +9,7 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 ## Retrieve Accounts by Index
 
-You can access accounts derived from the default BIP-44 path using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can access accounts derived from the default BIP-44 path using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-ton/api-reference#getaccountindex):
 
 ```javascript title="Get Accounts by Index"
 const account = await wallet.getAccount(0)
@@ -23,7 +23,7 @@ console.log('Account 1 address:', address1)
 
 ## Retrieve Account by Custom Derivation Path
 
-You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](../api-reference#getaccountbypathpath):
+You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](/sdk/wallet-modules/wallet-ton/api-reference#getaccountbypathpath):
 
 ```javascript title="Custom Derivation Path"
 const customAccount = await wallet.getAccountByPath("0'/0/5")
@@ -33,7 +33,7 @@ console.log('Custom account address:', customAddress)
 
 ## Iterate Over Multiple Accounts
 
-You can loop through multiple accounts using [`wallet.getAccount()`](../api-reference#getaccountindex) to inspect addresses and balances in bulk:
+You can loop through multiple accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-ton/api-reference#getaccountindex) to inspect addresses and balances in bulk:
 
 ```javascript title="Multi-Account Iteration"
 async function listAccounts(wallet) {
@@ -53,4 +53,4 @@ async function listAccounts(wallet) {
 
 ## Next Steps
 
-Now that you can access your accounts, learn how to [check balances](./check-balances).
+Now that you can access your accounts, learn how to [check balances](/sdk/wallet-modules/wallet-ton/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-ton/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/guides/send-transactions.mdx
@@ -13,7 +13,7 @@ On TON, values are expressed in nanotons (1 TON = 10^9 nanotons). Transactions s
 
 ## Send Native TON
 
-You can transfer TON to a recipient address using [`account.sendTransaction()`](../api-reference#sendtransactiontx):
+You can transfer TON to a recipient address using [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton/api-reference#sendtransactiontx):
 
 ```javascript title="Send TON"
 const result = await account.sendTransaction({
@@ -27,7 +27,7 @@ console.log('Transaction fee:', result.fee, 'nanotons')
 
 ## Estimate Transaction Fees
 
-You can get a fee estimate before sending using [`account.quoteSendTransaction()`](../api-reference#quotesendtransactiontx):
+You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-ton/api-reference#quotesendtransactiontx):
 
 ```javascript title="Quote Transaction Fee"
 const quote = await account.quoteSendTransaction({
@@ -40,7 +40,7 @@ console.log('Estimated fee:', quote.fee, 'nanotons')
 
 ## Use Dynamic Fee Rates
 
-You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](../api-reference):
+You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-ton/api-reference):
 
 ```javascript title="Get Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -50,4 +50,4 @@ console.log('Fast fee rate:', feeRates.fast, 'nanotons')
 
 ## Next Steps
 
-To transfer Jetton tokens instead of native TON, see [Transfer Jetton Tokens](./transfer-tokens).
+To transfer Jetton tokens instead of native TON, see [Transfer Jetton Tokens](/sdk/wallet-modules/wallet-ton/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-ton/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/guides/sign-verify-messages.mdx
@@ -9,7 +9,7 @@ This guide explains how to [sign messages](#sign-a-message) with an owned accoun
 
 ## Sign a Message
 
-You can produce a cryptographic signature for any string message using [`account.sign()`](../api-reference#signmessage):
+You can produce a cryptographic signature for any string message using [`account.sign()`](/sdk/wallet-modules/wallet-ton/api-reference#signmessage):
 
 ```javascript title="Sign a Message"
 const message = 'Hello, TON!'
@@ -19,7 +19,7 @@ console.log('Signature:', signature)
 
 ## Verify a Signature
 
-You can verify that a signature was produced by the corresponding private key using [`readOnlyAccount.verify()`](../api-reference#verifymessage-signature):
+You can verify that a signature was produced by the corresponding private key using [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-ton/api-reference#verifymessage-signature):
 
 ```javascript title="Verify a Signature"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -28,9 +28,9 @@ console.log('Signature valid:', isValid)
 ```
 
 <Callout type="info">
-You can also create a [`WalletAccountReadOnlyTon`](../api-reference) from any public key to verify signatures without access to the private key.
+You can also create a [`WalletAccountReadOnlyTon`](/sdk/wallet-modules/wallet-ton/api-reference) from any public key to verify signatures without access to the private key.
 </Callout>
 
 ## Next Steps
 
-For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](./handle-errors).
+For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](/sdk/wallet-modules/wallet-ton/guides/handle-errors).

--- a/content/docs/sdk/wallet-modules/wallet-ton/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/guides/transfer-tokens.mdx
@@ -9,7 +9,7 @@ This guide explains how to [transfer Jetton tokens](#transfer-tokens), [estimate
 
 ## Transfer Tokens
 
-You can send Jetton tokens to a recipient address using [`account.transfer()`](../api-reference#transferoptions):
+You can send Jetton tokens to a recipient address using [`account.transfer()`](/sdk/wallet-modules/wallet-ton/api-reference#transferoptions):
 
 ```javascript title="Transfer Jetton Tokens"
 const transferResult = await account.transfer({
@@ -23,7 +23,7 @@ console.log('Transfer fee:', transferResult.fee, 'nanotons')
 
 ## Estimate Transfer Fees
 
-You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](../api-reference#quotetransferoptions):
+You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-ton/api-reference#quotetransferoptions):
 
 ```javascript title="Quote Token Transfer"
 const transferQuote = await account.quoteTransfer({
@@ -38,9 +38,9 @@ console.log('Transfer fee estimate:', transferQuote.fee, 'nanotons')
 
 Validate addresses and check balances before transferring to catch errors early:
 
-1. Use [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress) to verify sufficient funds.
-2. Use [`account.quoteTransfer()`](../api-reference#quotetransferoptions) to confirm fees.
-3. Execute the transfer with [`account.transfer()`](../api-reference#transferoptions):
+1. Use [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-ton/api-reference#gettokenbalancetokenaddress) to verify sufficient funds.
+2. Use [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-ton/api-reference#quotetransferoptions) to confirm fees.
+3. Execute the transfer with [`account.transfer()`](/sdk/wallet-modules/wallet-ton/api-reference#transferoptions):
 
 ```javascript title="Validated Jetton Transfer"
 async function transferJettonWithValidation(account, jettonAddress, recipient, amount) {
@@ -78,4 +78,4 @@ async function transferJettonWithValidation(account, jettonAddress, recipient, a
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages) with your TON account.
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-ton/guides/sign-verify-messages) with your TON account.

--- a/content/docs/sdk/wallet-modules/wallet-ton/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton/index.mdx
@@ -17,7 +17,7 @@ The default derivation path was updated in v1.0.0-beta.6 to match ecosystem conv
 
 If you're upgrading from an earlier version, existing wallets created with the old path will generate different addresses. Make sure to migrate any existing wallets or use the old path explicitly if needed for compatibility.
 
-Use [`getAccountByPath`](./api-reference) to supply an explicit derivation path when importing or recreating legacy wallets.
+Use [`getAccountByPath`](/sdk/wallet-modules/wallet-ton/api-reference) to supply an explicit derivation path when importing or recreating legacy wallets.
 </Callout>
 
 ## Features

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/check-balances.mdx
@@ -9,7 +9,7 @@ This guide explains how to check [native TRX balances](#native-trx-balance), [TR
 
 ## Native TRX Balance
 
-You can retrieve the native TRX balance using [`account.getBalance()`](../api-reference):
+You can retrieve the native TRX balance using [`account.getBalance()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Get Native TRX Balance"
 const balance = await account.getBalance()
@@ -22,7 +22,7 @@ On Tron, values are expressed in sun (1 TRX = 1,000,000 sun).
 
 ## TRC20 Token Balance
 
-You can check the balance of a specific TRC20 token using [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress):
+You can check the balance of a specific TRC20 token using [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#gettokenbalancetokenaddress):
 
 ```javascript title="Get TRC20 Token Balance"
 const trc20Address = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' // USDT
@@ -32,7 +32,7 @@ console.log('TRC20 token balance:', trc20Balance)
 
 ## Read-Only Account Balances
 
-You can check balances for any Tron address without a seed phrase using [`WalletAccountReadOnlyTronGasfree`](../api-reference):
+You can check balances for any Tron address without a seed phrase using [`WalletAccountReadOnlyTronGasfree`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Create Read-Only Account"
 import { WalletAccountReadOnlyTronGasfree } from '@tetherto/wdk-wallet-tron-gasfree'
@@ -48,7 +48,7 @@ const readOnlyAccount = new WalletAccountReadOnlyTronGasfree('TLyqzVGLV1srkB7dTo
 })
 ```
 
-You can retrieve the native balance from a read-only account using [`readOnlyAccount.getBalance()`](../api-reference):
+You can retrieve the native balance from a read-only account using [`readOnlyAccount.getBalance()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Read-Only Native Balance"
 const balance = await readOnlyAccount.getBalance()
@@ -56,9 +56,9 @@ console.log('Read-only account balance:', balance)
 ```
 
 <Callout type="info">
-You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](../api-reference).
+You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference).
 </Callout>
 
 ## Next Steps
 
-With balance checks in place, learn how to [send TRX](./send-transactions).
+With balance checks in place, learn how to [send TRX](/sdk/wallet-modules/wallet-tron-gasfree/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/get-started.mdx
@@ -20,7 +20,7 @@ npm install @tetherto/wdk-wallet-tron-gasfree
 
 ## 2. Create a Gas-Free Wallet
 
-You can create a new gas-free wallet instance using the [`WalletManagerTronGasfree`](../api-reference) constructor with a BIP-39 seed phrase, Tron RPC provider, and gas-free service configuration:
+You can create a new gas-free wallet instance using the [`WalletManagerTronGasfree`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference) constructor with a BIP-39 seed phrase, Tron RPC provider, and gas-free service configuration:
 
 ```javascript title="Create Gas-Free Tron Wallet"
 import WalletManagerTronGasfree, {
@@ -48,7 +48,7 @@ const wallet = new WalletManagerTronGasfree(seedPhrase, {
 
 ## 3. Get Your First Account
 
-You can retrieve an account at a given index using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can retrieve an account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#getaccountindex):
 
 ```javascript title="Get Account"
 const account = await wallet.getAccount(0)
@@ -58,7 +58,7 @@ console.log('Gas-free account address:', address)
 
 ## 4. (optional) Convert to Read-Only
 
-You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](../api-reference):
+You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Convert to Read-Only"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -70,4 +70,4 @@ All Tron addresses start with `T` and are 34 characters long.
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-tron-gasfree/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/handle-errors.mdx
@@ -9,7 +9,7 @@ This guide covers how to [handle gas-free transfer errors](#handle-gas-free-tran
 
 ## Handle Gas-Free Transfer Errors
 
-Gas-free transfers can fail for reasons including exceeded fee limits or insufficient token balances. Wrap calls to [`account.transfer()`](../api-reference) in `try/catch` blocks:
+Gas-free transfers can fail for reasons including exceeded fee limits or insufficient token balances. Wrap calls to [`account.transfer()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference) in `try/catch` blocks:
 
 ```javascript title="Gas-Free Transfer Error Handling"
 try {
@@ -32,7 +32,7 @@ try {
 
 ## Handle Native TRX Transaction Errors
 
-Native TRX sends via [`account.sendTransaction()`](../api-reference) can fail for standard reasons:
+Native TRX sends via [`account.sendTransaction()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference) can fail for standard reasons:
 
 ```javascript title="Transaction Error Handling"
 try {
@@ -54,7 +54,7 @@ try {
 
 ### Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet or per-transfer to prevent gas-free transfers from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](../api-reference):
+Set `transferMaxFee` when creating the wallet or per-transfer to prevent gas-free transfers from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()
@@ -64,7 +64,7 @@ console.log('Fast fee rate:', feeRates.fast, 'sun')
 
 ### Dispose of Sensitive Data
 
-Call [`dispose()`](../api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
+Call [`dispose()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
 
 ```javascript title="Memory Cleanup"
 account.dispose()
@@ -73,5 +73,5 @@ wallet.dispose()
 ```
 
 <Callout type="warn">
-Always call [`dispose()`](../api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
+Always call [`dispose()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
 </Callout>

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/manage-accounts.mdx
@@ -9,7 +9,7 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 ## Retrieve Accounts by Index
 
-You can access accounts derived from the default BIP-44 path (`m/44'/195'`) using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can access accounts derived from the default BIP-44 path (`m/44'/195'`) using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#getaccountindex):
 
 ```javascript title="Get Accounts by Index"
 const account = await wallet.getAccount(0)
@@ -23,7 +23,7 @@ console.log('Account 1 address:', address1)
 
 ## Retrieve Account by Custom Derivation Path
 
-You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](../api-reference#getaccountbypathpath):
+You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#getaccountbypathpath):
 
 ```javascript title="Custom Derivation Path"
 const customAccount = await wallet.getAccountByPath("0'/0/5")
@@ -33,7 +33,7 @@ console.log('Custom account address:', customAddress)
 
 ## Iterate Over Multiple Accounts
 
-You can iterate through multiple accounts using [`wallet.getAccount()`](../api-reference#getaccountindex) to inspect addresses and balances in bulk:
+You can iterate through multiple accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#getaccountindex) to inspect addresses and balances in bulk:
 
 ```javascript title="Multi-Account Iteration"
 async function listAccounts(wallet) {
@@ -54,4 +54,4 @@ async function listAccounts(wallet) {
 
 ## Next Steps
 
-Now that you can access your accounts, learn how to [check balances](./check-balances).
+Now that you can access your accounts, learn how to [check balances](/sdk/wallet-modules/wallet-tron-gasfree/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/send-transactions.mdx
@@ -5,7 +5,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-This guide explains how to [send native TRX](#send-native-trx), [estimate transaction fees](#estimate-transaction-fees), and [use dynamic fee rates](#use-dynamic-fee-rates). Native TRX sends are not gas-free; for gas-free TRC20 token transfers, see [Transfer TRC20 Tokens](./transfer-tokens).
+This guide explains how to [send native TRX](#send-native-trx), [estimate transaction fees](#estimate-transaction-fees), and [use dynamic fee rates](#use-dynamic-fee-rates). Native TRX sends are not gas-free; for gas-free TRC20 token transfers, see [Transfer TRC20 Tokens](/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens).
 
 <Callout type="info">
 On Tron, values are expressed in sun (1 TRX = 1,000,000 sun).
@@ -13,7 +13,7 @@ On Tron, values are expressed in sun (1 TRX = 1,000,000 sun).
 
 ## Send Native TRX
 
-You can transfer TRX to a recipient address using [`account.sendTransaction()`](../api-reference):
+You can transfer TRX to a recipient address using [`account.sendTransaction()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Send TRX"
 const result = await account.sendTransaction({
@@ -26,7 +26,7 @@ console.log('Fee paid:', result.fee, 'sun')
 
 ## Estimate Transaction Fees
 
-You can get a fee estimate before sending using [`account.quoteSendTransaction()`](../api-reference):
+You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Quote Transaction Fee"
 const quote = await account.quoteSendTransaction({
@@ -38,7 +38,7 @@ console.log('Estimated fee:', quote.fee, 'sun')
 
 ## Use Dynamic Fee Rates
 
-You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](../api-reference):
+You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Get Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -48,4 +48,4 @@ console.log('Fast fee rate:', feeRates.fast, 'sun')
 
 ## Next Steps
 
-To transfer TRC20 tokens with gas-free fees, see [Transfer TRC20 Tokens](./transfer-tokens).
+To transfer TRC20 tokens with gas-free fees, see [Transfer TRC20 Tokens](/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/sign-verify-messages.mdx
@@ -9,7 +9,7 @@ This guide explains how to [sign messages](#sign-a-message) with an owned accoun
 
 ## Sign a Message
 
-You can produce a cryptographic signature for any string message using [`account.sign()`](../api-reference#signmessage):
+You can produce a cryptographic signature for any string message using [`account.sign()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#signmessage):
 
 ```javascript title="Sign a Message"
 const message = 'Hello, Tron!'
@@ -19,7 +19,7 @@ console.log('Signature:', signature)
 
 ## Verify a Signature
 
-You can verify that a signature is valid using [`account.verify()`](../api-reference#verifymessage-signature):
+You can verify that a signature is valid using [`account.verify()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#verifymessage-signature):
 
 ```javascript title="Verify a Signature"
 const isValid = await account.verify(message, signature)
@@ -27,9 +27,9 @@ console.log('Signature valid:', isValid)
 ```
 
 <Callout type="info">
-You can also create a [`WalletAccountReadOnlyTronGasfree`](../api-reference) from any Tron address to verify signatures without access to the private key.
+You can also create a [`WalletAccountReadOnlyTronGasfree`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference) from any Tron address to verify signatures without access to the private key.
 </Callout>
 
 ## Next Steps
 
-For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](./handle-errors).
+For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](/sdk/wallet-modules/wallet-tron-gasfree/guides/handle-errors).

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens.mdx
@@ -9,7 +9,7 @@ This guide explains how to [transfer TRC20 tokens gas-free](#transfer-tokens-gas
 
 ## Transfer Tokens (Gas-Free)
 
-You can send TRC20 tokens gas-free using [`account.transfer()`](../api-reference). The gas-free service handles the fee payment:
+You can send TRC20 tokens gas-free using [`account.transfer()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference). The gas-free service handles the fee payment:
 
 ```javascript title="Gas-Free TRC20 Transfer"
 const transferResult = await account.transfer({
@@ -23,7 +23,7 @@ console.log('Transfer fee:', transferResult.fee, 'token units')
 
 ## Override Fee Limit
 
-You can set a maximum fee for a specific transfer by passing a second configuration object specifying a `transferMaxFee` to [`account.transfer()`](../api-reference):
+You can set a maximum fee for a specific transfer by passing a second configuration object specifying a `transferMaxFee` to [`account.transfer()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Transfer with Fee Limit"
 const result = await account.transfer({
@@ -39,7 +39,7 @@ console.log('Transfer fee:', result.fee, 'token units')
 
 ## Estimate Transfer Fees
 
-You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](../api-reference#quotetransferoptions):
+You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#quotetransferoptions):
 
 ```javascript title="Quote Gas-Free Transfer"
 const transferQuote = await account.quoteTransfer({
@@ -54,9 +54,9 @@ console.log('Transfer fee estimate:', transferQuote.fee, 'token units')
 
 Validate addresses and check balances before transferring:
 
-1. Use [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress) to verify sufficient funds.
-2. Use [`account.quoteTransfer()`](../api-reference#quotetransferoptions) to confirm fees.
-3. Execute the transfer with [`account.transfer()`](../api-reference):
+1. Use [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#gettokenbalancetokenaddress) to verify sufficient funds.
+2. Use [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#quotetransferoptions) to confirm fees.
+3. Execute the transfer with [`account.transfer()`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference):
 
 ```javascript title="Validated Gas-Free Transfer"
 async function transferWithValidation(account, tokenAddress, recipient, amount) {
@@ -94,4 +94,4 @@ async function transferWithValidation(account, tokenAddress, recipient, amount) 
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages) with your gas-free Tron account.
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-tron-gasfree/guides/sign-verify-messages) with your gas-free Tron account.

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/check-balances.mdx
@@ -9,7 +9,7 @@ This guide explains how to check [native TRX balances](#native-trx-balance), [TR
 
 ## Native TRX Balance
 
-You can retrieve the native TRX balance using [`account.getBalance()`](../api-reference):
+You can retrieve the native TRX balance using [`account.getBalance()`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Get Native TRX Balance"
 const balance = await account.getBalance()
@@ -22,7 +22,7 @@ On Tron, values are expressed in sun (1 TRX = 1,000,000 sun).
 
 ## TRC20 Token Balance
 
-You can check the balance of a specific TRC20 token using [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress):
+You can check the balance of a specific TRC20 token using [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-tron/api-reference#gettokenbalancetokenaddress):
 
 ```javascript title="Get TRC20 Token Balance"
 const trc20Address = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' // USDT
@@ -32,7 +32,7 @@ console.log('TRC20 token balance:', trc20Balance)
 
 ## Read-Only Account Balances
 
-You can check balances for any Tron address without a seed phrase using [`WalletAccountReadOnlyTron`](../api-reference):
+You can check balances for any Tron address without a seed phrase using [`WalletAccountReadOnlyTron`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Create Read-Only Account"
 import { WalletAccountReadOnlyTron } from '@tetherto/wdk-wallet-tron'
@@ -42,7 +42,7 @@ const readOnlyAccount = new WalletAccountReadOnlyTron('TLyqzVGLV1srkB7dToTAEqgDS
 })
 ```
 
-You can retrieve the native balance from a read-only account using [`readOnlyAccount.getBalance()`](../api-reference):
+You can retrieve the native balance from a read-only account using [`readOnlyAccount.getBalance()`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Read-Only Native Balance"
 const balance = await readOnlyAccount.getBalance()
@@ -50,9 +50,9 @@ console.log('Read-only account balance:', balance)
 ```
 
 <Callout type="info">
-You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](../api-reference).
+You can also create a read-only account from an existing owned account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-tron/api-reference).
 </Callout>
 
 ## Next Steps
 
-With balance checks in place, learn how to [send TRX](./send-transactions).
+With balance checks in place, learn how to [send TRX](/sdk/wallet-modules/wallet-tron/guides/send-transactions).

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/get-started.mdx
@@ -20,7 +20,7 @@ npm install @tetherto/wdk-wallet-tron
 
 ## 2. Create a Wallet
 
-You can create a new wallet instance using the [`WalletManagerTron`](../api-reference) constructor with a BIP-39 seed phrase and a Tron RPC provider:
+You can create a new wallet instance using the [`WalletManagerTron`](/sdk/wallet-modules/wallet-tron/api-reference) constructor with a BIP-39 seed phrase and a Tron RPC provider:
 
 ```javascript title="Create Tron Wallet"
 import WalletManagerTron, { WalletAccountTron, WalletAccountReadOnlyTron } from '@tetherto/wdk-wallet-tron'
@@ -38,7 +38,7 @@ const wallet = new WalletManagerTron(seedPhrase, {
 
 ## 3. Get Your First Account
 
-You can retrieve an account at a given index using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can retrieve an account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-tron/api-reference#getaccountindex):
 
 ```javascript title="Get Account"
 const account = await wallet.getAccount(0)
@@ -48,7 +48,7 @@ console.log('Wallet address:', address)
 
 ## 4. (optional) Convert to Read-Only
 
-You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](../api-reference):
+You can convert an owned account to a read-only account using [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Convert to Read-Only"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -60,4 +60,4 @@ All Tron addresses start with `T` and are 34 characters long.
 
 ## Next Steps
 
-With your wallet ready, learn how to [manage multiple accounts](./manage-accounts).
+With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modules/wallet-tron/guides/manage-accounts).

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
@@ -9,7 +9,7 @@ This guide covers how to [handle transaction errors](#handle-transaction-errors)
 
 ## Handle Transaction Errors
 
-Wrap transactions in `try/catch` blocks to handle common failure scenarios. Use [`account.sendTransaction()`](../api-reference#sendtransactiontx) with proper error handling:
+Wrap transactions in `try/catch` blocks to handle common failure scenarios. Use [`account.sendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#sendtransactiontx) with proper error handling:
 
 ```javascript title="Transaction Error Handling"
 try {
@@ -32,7 +32,7 @@ try {
 
 ## Handle Token Transfer Errors
 
-TRC20 transfers can fail for additional reasons such as insufficient token balances. Use [`account.transfer()`](../api-reference#transferoptions) with error handling:
+TRC20 transfers can fail for additional reasons such as insufficient token balances. Use [`account.transfer()`](/sdk/wallet-modules/wallet-tron/api-reference#transferoptions) with error handling:
 
 ```javascript title="Token Transfer Error Handling"
 try {
@@ -57,7 +57,7 @@ try {
 
 ### Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet to prevent transactions from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](../api-reference):
+Set `transferMaxFee` when creating the wallet to prevent transactions from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()
@@ -67,7 +67,7 @@ console.log('Fast fee rate:', feeRates.fast, 'sun')
 
 ### Dispose of Sensitive Data
 
-Call [`dispose()`](../api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
+Call [`dispose()`](/sdk/wallet-modules/wallet-tron/api-reference) on accounts and wallet managers to clear private keys and sensitive data from memory when they are no longer needed:
 
 ```javascript title="Memory Cleanup"
 account.dispose()
@@ -76,5 +76,5 @@ wallet.dispose()
 ```
 
 <Callout type="warn">
-Always call [`dispose()`](../api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
+Always call [`dispose()`](/sdk/wallet-modules/wallet-tron/api-reference) in a `finally` block or cleanup handler to ensure sensitive data is cleared even if an error occurs.
 </Callout>

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/manage-accounts.mdx
@@ -9,7 +9,7 @@ This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-in
 
 ## Retrieve Accounts by Index
 
-You can access accounts derived from the default BIP-44 path (`m/44'/195'`) using [`wallet.getAccount()`](../api-reference#getaccountindex):
+You can access accounts derived from the default BIP-44 path (`m/44'/195'`) using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-tron/api-reference#getaccountindex):
 
 ```javascript title="Get Accounts by Index"
 const account = await wallet.getAccount(0)
@@ -23,7 +23,7 @@ console.log('Account 1 address:', address1)
 
 ## Retrieve Account by Custom Derivation Path
 
-You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](../api-reference#getaccountbypathpath):
+You can request an account at a specific BIP-44 derivation path using [`wallet.getAccountByPath()`](/sdk/wallet-modules/wallet-tron/api-reference#getaccountbypathpath):
 
 ```javascript title="Custom Derivation Path"
 const customAccount = await wallet.getAccountByPath("0'/0/5")
@@ -33,7 +33,7 @@ console.log('Custom account address:', customAddress)
 
 ## Iterate Over Multiple Accounts
 
-You can loop through multiple accounts using [`wallet.getAccount()`](../api-reference#getaccountindex) to inspect addresses and balances in bulk:
+You can loop through multiple accounts using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-tron/api-reference#getaccountindex) to inspect addresses and balances in bulk:
 
 ```javascript title="Multi-Account Iteration"
 async function listAccounts(wallet) {
@@ -53,4 +53,4 @@ async function listAccounts(wallet) {
 
 ## Next Steps
 
-Now that you can access your accounts, learn how to [check balances](./check-balances).
+Now that you can access your accounts, learn how to [check balances](/sdk/wallet-modules/wallet-tron/guides/check-balances).

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
@@ -13,7 +13,7 @@ On Tron, values are expressed in sun (1 TRX = 1,000,000 sun).
 
 ## Send Native TRX
 
-You can transfer TRX to a recipient address using [`account.sendTransaction()`](../api-reference#sendtransactiontx):
+You can transfer TRX to a recipient address using [`account.sendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#sendtransactiontx):
 
 ```javascript title="Send TRX"
 const result = await account.sendTransaction({
@@ -26,7 +26,7 @@ console.log('Transaction fee:', result.fee, 'sun')
 
 ## Estimate Transaction Fees
 
-You can get a fee estimate before sending using [`account.quoteSendTransaction()`](../api-reference#quotesendtransactiontx):
+You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx):
 
 ```javascript title="Quote Transaction Fee"
 const quote = await account.quoteSendTransaction({
@@ -38,7 +38,7 @@ console.log('Estimated fee:', quote.fee, 'sun')
 
 ## Use Dynamic Fee Rates
 
-You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](../api-reference):
+You can retrieve current fee rates from the wallet manager using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Get Fee Rates"
 const feeRates = await wallet.getFeeRates()
@@ -48,4 +48,4 @@ console.log('Fast fee rate:', feeRates.fast, 'sun')
 
 ## Next Steps
 
-To transfer TRC20 tokens instead of native TRX, see [Transfer TRC20 Tokens](./transfer-tokens).
+To transfer TRC20 tokens instead of native TRX, see [Transfer TRC20 Tokens](/sdk/wallet-modules/wallet-tron/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/sign-verify-messages.mdx
@@ -9,7 +9,7 @@ This guide explains how to [sign messages](#sign-a-message) with an owned accoun
 
 ## Sign a Message
 
-You can produce a cryptographic signature for any string message using [`account.sign()`](../api-reference#signmessage):
+You can produce a cryptographic signature for any string message using [`account.sign()`](/sdk/wallet-modules/wallet-tron/api-reference#signmessage):
 
 ```javascript title="Sign a Message"
 const message = 'Hello, Tron!'
@@ -19,7 +19,7 @@ console.log('Signature:', signature)
 
 ## Verify a Signature
 
-You can verify that a signature was produced by the corresponding private key using [`readOnlyAccount.verify()`](../api-reference#verifymessage-signature):
+You can verify that a signature was produced by the corresponding private key using [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-tron/api-reference#verifymessage-signature):
 
 ```javascript title="Verify a Signature"
 const readOnlyAccount = await account.toReadOnlyAccount()
@@ -28,9 +28,9 @@ console.log('Signature valid:', isValid)
 ```
 
 <Callout type="info">
-You can also create a [`WalletAccountReadOnlyTron`](../api-reference) from any Tron address to verify signatures without access to the private key.
+You can also create a [`WalletAccountReadOnlyTron`](/sdk/wallet-modules/wallet-tron/api-reference) from any Tron address to verify signatures without access to the private key.
 </Callout>
 
 ## Next Steps
 
-For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](./handle-errors).
+For best practices on handling errors, managing fees, and cleaning up memory, see [Handle Errors](/sdk/wallet-modules/wallet-tron/guides/handle-errors).

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/transfer-tokens.mdx
@@ -9,7 +9,7 @@ This guide explains how to [transfer TRC20 tokens](#transfer-tokens), [estimate 
 
 ## Transfer Tokens
 
-You can send TRC20 tokens to a recipient address using [`account.transfer()`](../api-reference#transferoptions):
+You can send TRC20 tokens to a recipient address using [`account.transfer()`](/sdk/wallet-modules/wallet-tron/api-reference#transferoptions):
 
 ```javascript title="Transfer TRC20 Tokens"
 const transferResult = await account.transfer({
@@ -23,7 +23,7 @@ console.log('Transfer fee:', transferResult.fee, 'sun')
 
 ## Estimate Transfer Fees
 
-You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](../api-reference#quotetransferoptions):
+You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-tron/api-reference#quotetransferoptions):
 
 ```javascript title="Quote Token Transfer"
 const transferQuote = await account.quoteTransfer({
@@ -38,9 +38,9 @@ console.log('Transfer fee estimate:', transferQuote.fee, 'sun')
 
 Validate addresses and check balances before transferring to catch errors early:
 
-1. Use [`account.getTokenBalance()`](../api-reference#gettokenbalancetokenaddress) to verify sufficient funds.
-2. Use [`account.quoteTransfer()`](../api-reference#quotetransferoptions) to confirm fees.
-3. Execute the transfer with [`account.transfer()`](../api-reference#transferoptions):
+1. Use [`account.getTokenBalance()`](/sdk/wallet-modules/wallet-tron/api-reference#gettokenbalancetokenaddress) to verify sufficient funds.
+2. Use [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-tron/api-reference#quotetransferoptions) to confirm fees.
+3. Execute the transfer with [`account.transfer()`](/sdk/wallet-modules/wallet-tron/api-reference#transferoptions):
 
 ```javascript title="Validated TRC20 Transfer"
 async function transferTRC20WithValidation(account, trc20Address, recipient, amount) {
@@ -78,4 +78,4 @@ async function transferTRC20WithValidation(account, trc20Address, recipient, amo
 
 ## Next Steps
 
-Learn how to [sign and verify messages](./sign-verify-messages) with your Tron account.
+Learn how to [sign and verify messages](/sdk/wallet-modules/wallet-tron/guides/sign-verify-messages) with your Tron account.

--- a/content/docs/start-building/nodejs-bare-quickstart.mdx
+++ b/content/docs/start-building/nodejs-bare-quickstart.mdx
@@ -53,7 +53,7 @@ You can try all features without real funds required. You can use the Pimlico or
 [Get mock/test USD₮ on Pimlico](https://dashboard.pimlico.io/test-erc20-faucet)
 [Get mock/test USD₮ on Candide](https://dashboard.candide.dev/faucet)
 
-See the [configuration](../sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
+See the [configuration](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
 </Callout>
 
 ***
@@ -75,10 +75,10 @@ npm install @tetherto/wdk @tetherto/wdk-wallet-evm @tetherto/wdk-wallet-tron @te
 <Callout type="info">
 Learn more about WDK modules:
 
-* [**@tetherto/wdk**](../sdk/core-module/) - The main SDK module
-* [**@tetherto/wdk-wallet-evm**](../sdk/wallet-modules/wallet-evm/) - Ethereum and EVM-compatible chains support
-* [**@tetherto/wdk-wallet-tron**](../sdk/wallet-modules/wallet-tron/) - TRON blockchain support
-* [**@tetherto/wdk-wallet-btc**](../sdk/wallet-modules/wallet-btc/) - Bitcoin blockchain support
+* [**@tetherto/wdk**](/sdk/core-module/) - The main SDK module
+* [**@tetherto/wdk-wallet-evm**](/sdk/wallet-modules/wallet-evm/) - Ethereum and EVM-compatible chains support
+* [**@tetherto/wdk-wallet-tron**](/sdk/wallet-modules/wallet-tron/) - TRON blockchain support
+* [**@tetherto/wdk-wallet-btc**](/sdk/wallet-modules/wallet-btc/) - Bitcoin blockchain support
 </Callout>
 
 ***
@@ -139,9 +139,9 @@ console.log('Wallets registered for Ethereum, TRON, and Bitcoin')
 
 <Callout type="info">
 To learn more about configuring the wallet modules:
-* [Configuring @tetherto/wdk-wallet-evm](../sdk/wallet-modules/wallet-evm/configuration)
-* [Configuring @tetherto/wdk-wallet-tron](../sdk/wallet-modules/wallet-tron/configuration)
-* [Configuring @tetherto/wdk-wallet-btc](../sdk/wallet-modules/wallet-btc/configuration)
+* [Configuring @tetherto/wdk-wallet-evm](/sdk/wallet-modules/wallet-evm/configuration)
+* [Configuring @tetherto/wdk-wallet-tron](/sdk/wallet-modules/wallet-tron/configuration)
+* [Configuring @tetherto/wdk-wallet-btc](/sdk/wallet-modules/wallet-btc/configuration)
 </Callout>
 
 ***

--- a/content/docs/start-building/react-native-quickstart.mdx
+++ b/content/docs/start-building/react-native-quickstart.mdx
@@ -22,7 +22,7 @@ You can try all features without real funds required. You can use the Pimlico or
 - [Get mock/test USD₮ on Pimlico](https://dashboard.pimlico.io/test-erc20-faucet)
 - [Get mock/test USD₮ on Candide](https://dashboard.candide.dev/faucet)
 
-See the [ERC-4337 configuration](../sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
+See the [ERC-4337 configuration](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
 </Callout>
 
 ## Prerequisites
@@ -94,7 +94,7 @@ EXPO_PUBLIC_TRON_API_SECRET=your_tron_api_secret
 ```
 
 <Callout type="info">
-**Where do I get an Indexer API key?** The WDK Indexer is required for transaction history and balance indexing. Get your free API key from the [Indexer API setup guide](../tools/indexer-api/get-started).
+**Where do I get an Indexer API key?** The WDK Indexer is required for transaction history and balance indexing. Get your free API key from the [Indexer API setup guide](/tools/indexer-api/get-started).
 </Callout>
 
 ### Step 4: Run Your App
@@ -255,7 +255,7 @@ export const wdkConfigs: WdkConfigs = {
 ```
 
 <Callout type="info">
-This example uses **Sepolia testnet** with a free public RPC so you can start immediately without API keys. For production or mainnet configuration, see the [Chain Configuration Guide](../sdk/core-module/configuration).
+This example uses **Sepolia testnet** with a free public RPC so you can start immediately without API keys. For production or mainnet configuration, see the [Chain Configuration Guide](/sdk/core-module/configuration).
 </Callout>
 
 ### Step 5: Add WdkAppProvider
@@ -334,7 +334,7 @@ function WalletScreen() {
 }
 ```
 
-For the full list of available hooks and their parameters, see the [React Native Core API Reference](../tools/react-native-core/api-reference).
+For the full list of available hooks and their parameters, see the [React Native Core API Reference](/tools/react-native-core/api-reference).
 
 ### Step 7: Rebuild and Run
 
@@ -527,14 +527,14 @@ Ready to dive deeper? Check out these resources:
 
 ### Core Concepts
 
-- [**React Native Core Docs**](../tools/react-native-core/) - Full documentation for `@tetherto/wdk-react-native-core`
-- [**API Reference**](../tools/react-native-core/api-reference) - Complete hook and type reference
-- [**Chain Configuration**](../sdk/core-module/configuration#wallet-configuration) - Configure blockchain networks
+- [**React Native Core Docs**](/tools/react-native-core/) - Full documentation for `@tetherto/wdk-react-native-core`
+- [**API Reference**](/tools/react-native-core/api-reference) - Complete hook and type reference
+- [**Chain Configuration**](/sdk/core-module/configuration#wallet-configuration) - Configure blockchain networks
 
 ### Examples & Starters
 
-- [**React Native Starter**](../examples-and-starters/react-native-starter) - Full-featured starter app
-- [**React Native UI Kit**](../ui-kits/react-native-ui-kit/) - Pre-built wallet components
+- [**React Native Starter**](/examples-and-starters/react-native-starter) - Full-featured starter app
+- [**React Native UI Kit**](/ui-kits/react-native-ui-kit/) - Pre-built wallet components
 
 ### **Need Help?**
 

--- a/content/docs/tools/failover-provider/index.mdx
+++ b/content/docs/tools/failover-provider/index.mdx
@@ -3,7 +3,7 @@ title: Failover Provider
 description: Generic provider failover wrapper for retrying sync and async calls across provider candidates
 ---
 
-Failover Provider wraps multiple provider-like objects behind one proxy so your integration can retry failed calls against the next candidate without rewriting each call site. Use this page to review the [Configuration](./configuration) and [API Reference](./api-reference) for the released `@tetherto/wdk-failover-provider` surface.
+Failover Provider wraps multiple provider-like objects behind one proxy so your integration can retry failed calls against the next candidate without rewriting each call site. Use this page to review the [Configuration](/tools/failover-provider/configuration) and [API Reference](/tools/failover-provider/api-reference) for the released `@tetherto/wdk-failover-provider` surface.
 
 Powered by [`@tetherto/wdk-failover-provider`](https://github.com/tetherto/wdk-failover-provider).
 

--- a/content/docs/tools/indexer-api/api-reference.mdx
+++ b/content/docs/tools/indexer-api/api-reference.mdx
@@ -105,7 +105,7 @@ The API returns standard HTTP error codes:
 ## Next Steps
 
 * [**Get Started**](get-started) - Quick start guide with setup instructions
-* [**React Native Starter**](../../examples-and-starters/react-native-starter) - See it in action
+* [**React Native Starter**](/examples-and-starters/react-native-starter) - See it in action
 
 ***
 

--- a/content/docs/tools/indexer-api/index.mdx
+++ b/content/docs/tools/indexer-api/index.mdx
@@ -11,7 +11,7 @@ The WDK Indexer REST API provides fast, reliable access to balances, token trans
 A blockchain indexer continuously monitors and organizes blockchain transactions, making them instantly searchable through a simple REST API.
 </Callout>
 
-[Get Started](./get-started)
+[Get Started](/tools/indexer-api/get-started)
 
 ## Supported Chains and Tokens
 

--- a/content/docs/tools/pear-wrk-wdk/configuration.mdx
+++ b/content/docs/tools/pear-wrk-wdk/configuration.mdx
@@ -41,7 +41,7 @@ module.exports = (rpc) => {
 
 ## Worklet Config Payload
 
-Both [`initializeWDK()`](./api-reference) and [`resetWdkWallets()`](./api-reference) expect `config` to be a JSON string. The decoded object must contain at least one entry under `networks`.
+Both [`initializeWDK()`](/tools/pear-wrk-wdk/api-reference) and [`resetWdkWallets()`](/tools/pear-wrk-wdk/api-reference) expect `config` to be a JSON string. The decoded object must contain at least one entry under `networks`.
 
 ```javascript title="Minimal Worklet Config JSON"
 const workletConfig = {
@@ -74,7 +74,7 @@ const workletConfig = {
 
 ## Initialize WDK
 
-You can create and register the WDK instance inside the worklet using [`initializeWDK()`](./api-reference):
+You can create and register the WDK instance inside the worklet using [`initializeWDK()`](/tools/pear-wrk-wdk/api-reference):
 
 ```javascript title="Initialize WDK"
 const { HRPC } = require('@tetherto/pear-wrk-wdk')
@@ -96,7 +96,7 @@ await hrpc.initializeWDK({
 
 ## Reset Selected Wallets
 
-You can selectively dispose and re-register wallet modules using [`resetWdkWallets()`](./api-reference):
+You can selectively dispose and re-register wallet modules using [`resetWdkWallets()`](/tools/pear-wrk-wdk/api-reference):
 
 ```javascript title="Reset Selected Wallet Modules"
 await hrpc.resetWdkWallets({
@@ -122,7 +122,7 @@ await hrpc.resetWdkWallets({
 
 ## Call Wallet Methods
 
-You can execute wallet account methods through [`callMethod()`](./api-reference):
+You can execute wallet account methods through [`callMethod()`](/tools/pear-wrk-wdk/api-reference):
 
 ```javascript title="Call a Wallet Method"
 const result = await hrpc.callMethod({

--- a/content/docs/tools/react-native-core/index.mdx
+++ b/content/docs/tools/react-native-core/index.mdx
@@ -63,7 +63,7 @@ function WalletScreen() {
 }
 ```
 
-For a full integration guide, see the [React Native Quickstart](../../start-building/react-native-quickstart).
+For a full integration guide, see the [React Native Quickstart](/start-building/react-native-quickstart).
 
 ## Bundle Configuration
 
@@ -165,10 +165,10 @@ WdkAppProvider
 ---
 
 <Cards>
-<Card title="API Reference" href="./api-reference">
+<Card title="API Reference" href="/tools/react-native-core/api-reference">
 Complete reference for all hooks, components, types, and utilities
 </Card>
-<Card title="React Native Quickstart" href="../../start-building/react-native-quickstart">
+<Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Step-by-step integration guide for new and existing apps
 </Card>
 </Cards>

--- a/content/docs/tools/react-native-secure-storage/index.mdx
+++ b/content/docs/tools/react-native-secure-storage/index.mdx
@@ -22,10 +22,10 @@ Powered by [`@tetherto/wdk-react-native-secure-storage`](https://www.npmjs.com/p
 Use this package for local encrypted storage in React Native wallet apps. It does not generate wallet seeds, encrypt plaintext seed material by itself, or provide cloud backup. Pair it with WDK wallet modules and a backup provider when you need recovery across devices.
 
 <Cards>
-<Card title="Configuration" href="./configuration">
+<Card title="Configuration" href="/tools/react-native-secure-storage/configuration">
 Install dependencies, configure authentication prompts, and create a storage instance.
 </Card>
-<Card title="API Reference" href="./api-reference">
+<Card title="API Reference" href="/tools/react-native-secure-storage/api-reference">
 Review `createSecureStorage`, storage methods, options, constants, and errors.
 </Card>
 </Cards>

--- a/content/docs/tools/wdk-utils/index.mdx
+++ b/content/docs/tools/wdk-utils/index.mdx
@@ -21,10 +21,10 @@ WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, 
 - Reuse the same helpers across Node.js and Bare-based environments without adding a larger wallet module dependency.
 
 <Cards>
-<Card title="WDK Utils Configuration" href="./configuration">
+<Card title="WDK Utils Configuration" href="/tools/wdk-utils/configuration">
 Install the package, import the helpers, and review runtime notes.
 </Card>
-<Card title="WDK Utils API Reference" href="./api-reference">
+<Card title="WDK Utils API Reference" href="/tools/wdk-utils/api-reference">
 Review the exported validators, parsers, and result types.
 </Card>
 </Cards>

--- a/content/docs/tools/worklet-bundler/configuration.mdx
+++ b/content/docs/tools/worklet-bundler/configuration.mdx
@@ -122,7 +122,7 @@ This matters when a generated worklet performs HTTPS-backed fetches. In `beta.2`
 ## Troubleshooting
 
 - If `loadConfig()` cannot find a config file, run `npx wdk-worklet-bundler init` or pass `--config \<path\>`.
-- If `validate` or `generate` reports missing modules, use `generate --install` or inspect the install command from the exported helper APIs in the [API Reference](./api-reference).
+- If `validate` or `generate` reports missing modules, use `generate --install` or inspect the install command from the exported helper APIs in the [API Reference](/tools/worklet-bundler/api-reference).
 - If you need to inspect generated source before bundling, use `generate --source-only` and review the files in `.wdk/`.
 
 ***

--- a/content/docs/ui-kits/react-native-ui-kit/api-reference.mdx
+++ b/content/docs/ui-kits/react-native-ui-kit/api-reference.mdx
@@ -408,7 +408,7 @@ function WalletBackup({ seedWords, editable, onWordChange }) {
 
 - [Get Started](get-started) - Quick start guide and basic usage
 - [Theming Guide](theming) - Deep dive into theming capabilities
-- [React Native Quickstart](../../start-building/react-native-quickstart) - Complete implementation example
+- [React Native Quickstart](/start-building/react-native-quickstart) - Complete implementation example
 
 ***
 

--- a/content/docs/ui-kits/react-native-ui-kit/get-started.mdx
+++ b/content/docs/ui-kits/react-native-ui-kit/get-started.mdx
@@ -171,9 +171,9 @@ export function SendScreen() {
 
 ## Next Steps
 
-* [Components List](./api-reference) - Complete API Reference for all components
-* [Theming Guide](./theming) - Deep dive into theming capabilities
-* [React Native Starter](../../start-building/react-native-quickstart) - See a complete implementation
+* [Components List](/ui-kits/react-native-ui-kit/api-reference) - Complete API Reference for all components
+* [Theming Guide](/ui-kits/react-native-ui-kit/theming) - Deep dive into theming capabilities
+* [React Native Starter](/start-building/react-native-quickstart) - See a complete implementation
 
 ***
 

--- a/content/docs/ui-kits/react-native-ui-kit/theming.mdx
+++ b/content/docs/ui-kits/react-native-ui-kit/theming.mdx
@@ -367,7 +367,7 @@ function Settings() {
 
 * [Get Started](get-started) - Quick start guide for the UI Kit
 * [Components List](api-reference) - Complete API Reference for all components
-* [React Native Quickstart](../../start-building/react-native-quickstart) - See theming in action
+* [React Native Quickstart](/start-building/react-native-quickstart) - See theming in action
 
 ***
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1134,7 +1134,7 @@ server.registerWallet('bitcoin', WalletManagerBtc, )
 server.registerWallet('solana', WalletManagerSolana, )
 ```
 
-Each `registerWallet()` call registers the chain name and makes it available to all wallet tools. For configuration details of each wallet module, see the [Wallet Modules](../../sdk/wallet-modules/) documentation.
+Each `registerWallet()` call registers the chain name and makes it available to all wallet tools. For configuration details of each wallet module, see the [Wallet Modules](/sdk/wallet-modules/) documentation.
 
 ***
 
@@ -1145,7 +1145,7 @@ Enable optional capabilities before registering their tools:
 | Capability | Method | Requirement | Unlocks |
 | --- | --- | --- | --- |
 | **Pricing** | `server.usePricing()` | None | `PRICING_TOOLS` (2 tools) |
-| **Indexer** | `server.useIndexer()` | [WDK API key](../../tools/indexer-api/get-started/#request-api-key) | `INDEXER_TOOLS` (2 tools) |
+| **Indexer** | `server.useIndexer()` | [WDK API key](/tools/indexer-api/get-started/#request-api-key) | `INDEXER_TOOLS` (2 tools) |
 | **Swap** | `server.registerProtocol(chain, label, SwapProtocol)` | Swap module installed | `SWAP_TOOLS` (2 tools) |
 | **Bridge** | `server.registerProtocol(chain, label, BridgeProtocol)` | Bridge module installed | `BRIDGE_TOOLS` (2 tools) |
 | **Lending** | `server.registerProtocol(chain, label, LendingProtocol)` | Lending module installed | `LENDING_TOOLS` (8 tools) |
@@ -1541,7 +1541,7 @@ server.registerTools([
 | Variable | Required | Description |
 | --- | --- | --- |
 | `WDK_SEED` | Yes | BIP-39 seed phrase for wallet derivation |
-| `WDK_INDEXER_API_KEY` | No | Enables `INDEXER_TOOLS` - [get a key](../../tools/indexer-api/get-started/#request-api-key) |
+| `WDK_INDEXER_API_KEY` | No | Enables `INDEXER_TOOLS` - [get a key](/tools/indexer-api/get-started/#request-api-key) |
 | `MOONPAY_API_KEY` | No | Enables `FIAT_TOOLS` - [MoonPay Dashboard](https://dashboard.moonpay.com/) |
 | `MOONPAY_SECRET_KEY` | No | Required with `MOONPAY_API_KEY` |
 
@@ -2049,7 +2049,7 @@ console.log("Bridge tx:", result.hash);
 
 USD₮0 arrives on the destination chain within a few minutes.
 
-You can bridge from any of 25+ supported EVM chains, not just Ethereum. Point your wallet at the source chain's RPC and use the [USD₮ token address](https://tether.to/es/supported-protocols/) on that chain. See the full [bridge module documentation](../sdk/bridge-modules/bridge-usdt0-evm/).
+You can bridge from any of 25+ supported EVM chains, not just Ethereum. Point your wallet at the source chain's RPC and use the [USD₮ token address](https://tether.to/es/supported-protocols/) on that chain. See the full [bridge module documentation](/sdk/bridge-modules/bridge-usdt0-evm/).
 
 ---
 
@@ -2286,7 +2286,7 @@ app.use(
 - [Semantic Facilitator Docs](https://docs.semanticpay.io) - API Reference for the hosted facilitator
 - [Self-Hosted Facilitator Module](https://www.npmjs.com/package/@semanticio/wdk-wallet-evm-x402-facilitator) - Community in-process facilitator
 - [x402-usdt0 Demo](https://github.com/SemanticPay/x402-usdt0-demo) - Full working buyer + seller demo
-- [WDK EVM Wallet Module](../sdk/wallet-modules/wallet-evm/) - WDK EVM wallet documentation
+- [WDK EVM Wallet Module](/sdk/wallet-modules/wallet-evm/) - WDK EVM wallet documentation
 - [USD₮0 Deployments](https://docs.usdt0.to/technical-documentation/deployments) - Contract addresses on all chains
 - [EIP-3009 Specification](https://eips.ethereum.org/EIPS/eip-3009) - The authorization standard enabling gasless USD₮ transfers
 ## React Native Starter (Alpha)
@@ -2296,7 +2296,7 @@ The React Native Starter Alpha is an Expo + React Native app showing how to buil
 
 ***
 
-**Prerequisites:** Node.js 22+, and either Xcode (iOS) or Android SDK API 29+ (Android). See the [React Native Quickstart](../start-building/react-native-quickstart#prerequisites) for details.
+**Prerequisites:** Node.js 22+, and either Xcode (iOS) or Android SDK API 29+ (Android). See the [React Native Quickstart](/start-building/react-native-quickstart#prerequisites) for details.
 
 ### Quickstart
 
@@ -2314,7 +2314,7 @@ git clone https://github.com/tetherto/wdk-starter-react-native.git && cd wdk-sta
 cp .env.example .env
 ```
 
-Get your free WDK Indexer API key [here](../tools/indexer-api/get-started) and add it to your `.env` file:
+Get your free WDK Indexer API key [here](/tools/indexer-api/get-started) and add it to your `.env` file:
 
 ```bash
 EXPO_PUBLIC_WDK_INDEXER_BASE_URL=https://wdk-api.tether.io
@@ -2341,7 +2341,7 @@ npm run android # Android Emulator
 
 ***
 
-**Need detailed instructions?** Check out the complete [React Native Quickstart](../start-building/react-native-quickstart) guide for step-by-step setup, configuration, and troubleshooting.
+**Need detailed instructions?** Check out the complete [React Native Quickstart](/start-building/react-native-quickstart) guide for step-by-step setup, configuration, and troubleshooting.
 
 ### Features
 
@@ -2359,9 +2359,9 @@ npm run android # Android Emulator
 
 **Asset Management**
 
-* **Real-Time Balances**: Live balance updates via [WDK Indexer](../tools/indexer-api/)
-* **Transaction History**: Complete transaction tracking and history via [WDK Indexer](../tools/indexer-api/)
-* **Price Conversion**: Real-time fiat pricing via [Pricing Provider](../tools/price-rates/)
+* **Real-Time Balances**: Live balance updates via [WDK Indexer](/tools/indexer-api/)
+* **Transaction History**: Complete transaction tracking and history via [WDK Indexer](/tools/indexer-api/)
+* **Price Conversion**: Real-time fiat pricing via [Pricing Provider](/tools/price-rates/)
 
 **User Experience**
 
@@ -2437,24 +2437,24 @@ Detailed project structure can be found in the [Github Repository](https://githu
 
 **Customizing the UI**
 
-This starter uses components from the [WDK React Native UI Kit](../ui-kits/react-native-ui-kit/). To customize the look and feel:
+This starter uses components from the [WDK React Native UI Kit](/ui-kits/react-native-ui-kit/). To customize the look and feel:
 
-* [**Theming Guide**](../ui-kits/react-native-ui-kit/theming) - Deep dive into theming capabilities
-* [**Component Reference**](../ui-kits/react-native-ui-kit/api-reference) - Complete component documentation
+* [**Theming Guide**](/ui-kits/react-native-ui-kit/theming) - Deep dive into theming capabilities
+* [**Component Reference**](/ui-kits/react-native-ui-kit/api-reference) - Complete component documentation
 
 **Add new functionality**
 
 This starter provides a solid foundation that you can extend with additional functionality:
 
-* **Add support for other tokens** using wallet modules in the [WDK SDK](../sdk/get-started)
-* **Add DeFi protocols** like swaps, bridges, and lending using [protocol modules](../sdk/get-started)
+* **Add support for other tokens** using wallet modules in the [WDK SDK](/sdk/get-started)
+* **Add DeFi protocols** like swaps, bridges, and lending using [protocol modules](/sdk/get-started)
 
 **Or explore documentation**
 
-* [**WDK SDK Documentation**](../sdk/get-started) - Learn about the underlying SDK
-* [**UI Kit Documentation**](../ui-kits/react-native-ui-kit/get-started) - Customize the interface
-* [**WDK Indexer**](../tools/indexer-api/) - Understand data fetching
-* [**Secret Manager**](../tools/secret-manager/) - Learn about secure key management
+* [**WDK SDK Documentation**](/sdk/get-started) - Learn about the underlying SDK
+* [**UI Kit Documentation**](/ui-kits/react-native-ui-kit/get-started) - Customize the interface
+* [**WDK Indexer**](/tools/indexer-api/) - Understand data fetching
+* [**Secret Manager**](/tools/secret-manager/) - Learn about secure key management
 
 ***
 
@@ -2518,26 +2518,26 @@ WDK natively supports a broad set of blockchains and standards out of the box:
 
 | Blockchain/Module                                               | Support |
 | --------------------------------------------------------------- | ------- |
-| [Bitcoin](../sdk/wallet-modules/wallet-btc/)                    | ✅       |
-| [Ethereum & EVM](../sdk/wallet-modules/wallet-evm/)             | ✅       |
-| [Ethereum ERC-4337](../sdk/wallet-modules/wallet-evm-erc-4337/) | ✅       |
-| [TON](../sdk/wallet-modules/wallet-ton/)                        | ✅       |
-| [TON Gasless](../sdk/wallet-modules/wallet-ton-gasless/)        | ✅       |
-| [TRON](../sdk/wallet-modules/wallet-tron/)                      | ✅       |
-| [TRON Gasfree](../sdk/wallet-modules/wallet-tron-gasfree/)      | ✅       |
-| [Solana](../sdk/wallet-modules/wallet-solana/)                  | ✅       |
-| [Spark/Lightning](../sdk/wallet-modules/wallet-spark/)          | ✅       |
+| [Bitcoin](/sdk/wallet-modules/wallet-btc/)                    | ✅       |
+| [Ethereum & EVM](/sdk/wallet-modules/wallet-evm/)             | ✅       |
+| [Ethereum ERC-4337](/sdk/wallet-modules/wallet-evm-erc-4337/) | ✅       |
+| [TON](/sdk/wallet-modules/wallet-ton/)                        | ✅       |
+| [TON Gasless](/sdk/wallet-modules/wallet-ton-gasless/)        | ✅       |
+| [TRON](/sdk/wallet-modules/wallet-tron/)                      | ✅       |
+| [TRON Gasfree](/sdk/wallet-modules/wallet-tron-gasfree/)      | ✅       |
+| [Solana](/sdk/wallet-modules/wallet-solana/)                  | ✅       |
+| [Spark/Lightning](/sdk/wallet-modules/wallet-spark/)          | ✅       |
 
 | Protocol/Module                                                | Support |
 | -------------------------------------------------------------- | ------- |
-| [velora (EVM)](../sdk/swap-modules/swap-velora-evm/)       | ✅       |
+| [velora (EVM)](/sdk/swap-modules/swap-velora-evm/)       | ✅       |
 | StonFi (TON)                                                   | In progress |
-| [USD₮0 Bridge (EVM)](../sdk/bridge-modules/bridge-usdt0-evm/)  | ✅       |
-| [Aave Lending (EVM)](../sdk/lending-modules/lending-aave-evm/) | ✅       |
+| [USD₮0 Bridge (EVM)](/sdk/bridge-modules/bridge-usdt0-evm/)  | ✅       |
+| [Aave Lending (EVM)](/sdk/lending-modules/lending-aave-evm/) | ✅       |
 
 The modular architecture allows new chains, tokens, or protocols to be added by implementing dedicated modules.
 
-Ready to start building? Explore our [getting started guide](../start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](../sdk/get-started).
+Ready to start building? Explore our [getting started guide](/start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](/sdk/get-started).
 ## Changelog
 URL: https://docs.wdk.tether.io/overview/changelog
 Description: Updates and improvements to the Wallet Development Kit (WDK) modules and tools.
@@ -2585,7 +2585,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 **What's New**
 - **wdk-utils** ([v1.0.0-beta.2](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.2)): Add EIP-681 request parsing utilities for transfer deeplinks, including request detection and structured parse results.
 - **wdk-core** ([v1.0.0-beta.7](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.7)): Added `dispose(blockchains?)`, so you can dispose one or more registered wallets without tearing down every wallet in the WDK instance.
-- **pear-wrk-wdk** ([v1.0.0-beta.8](../tools/pear-wrk-wdk)): Adds `resetWdkWallets()` so custom Bare hosts can selectively dispose and re-register wallet modules from a new `networks` config.
+- **pear-wrk-wdk** ([v1.0.0-beta.8](/tools/pear-wrk-wdk)): Adds `resetWdkWallets()` so custom Bare hosts can selectively dispose and re-register wallet modules from a new `networks` config.
 
 **Changes**
 - **wallet-spark** ([v1.0.0-beta.13](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.13)): Refresh `@buildonspark/bare` and `@buildonspark/spark-sdk` dependencies.
@@ -2604,7 +2604,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### April 3, 2026
 
 **Changes**
-- **wallet-spark** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.12)): [`WalletAccountReadOnlySpark`](../sdk/wallet-modules/wallet-spark/api-reference) gained [`getTransfers()`](../sdk/wallet-modules/wallet-spark/api-reference), [`getUnusedDepositAddresses()`](../sdk/wallet-modules/wallet-spark/api-reference) (paginated return type), [`getStaticDepositAddresses()`](../sdk/wallet-modules/wallet-spark/api-reference), [`getUtxosForDepositAddress()`](../sdk/wallet-modules/wallet-spark/api-reference), and [`getSparkInvoices()`](../sdk/wallet-modules/wallet-spark/api-reference) (new parameter type). Removed `sparkScanApiKey` config option and `SparkTransactionReceipt` type after dropping the `@sparkscan/api-node-sdk-client` dependency. [`getTransactionReceipt()`](../sdk/wallet-modules/wallet-spark/api-reference) now returns `SparkTransfer` instead. Added [`getAccountByPath()`](../sdk/wallet-modules/wallet-spark/api-reference) to [`WalletManagerSpark`](../sdk/wallet-modules/wallet-spark/api-reference). SIGNET network support documented. Dependency upgrades: `@buildonspark/spark-sdk` 0.7.3, `@buildonspark/bare` 0.0.53.
+- **wallet-spark** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.12)): [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference) gained [`getTransfers()`](/sdk/wallet-modules/wallet-spark/api-reference), [`getUnusedDepositAddresses()`](/sdk/wallet-modules/wallet-spark/api-reference) (paginated return type), [`getStaticDepositAddresses()`](/sdk/wallet-modules/wallet-spark/api-reference), [`getUtxosForDepositAddress()`](/sdk/wallet-modules/wallet-spark/api-reference), and [`getSparkInvoices()`](/sdk/wallet-modules/wallet-spark/api-reference) (new parameter type). Removed `sparkScanApiKey` config option and `SparkTransactionReceipt` type after dropping the `@sparkscan/api-node-sdk-client` dependency. [`getTransactionReceipt()`](/sdk/wallet-modules/wallet-spark/api-reference) now returns `SparkTransfer` instead. Added [`getAccountByPath()`](/sdk/wallet-modules/wallet-spark/api-reference) to [`WalletManagerSpark`](/sdk/wallet-modules/wallet-spark/api-reference). SIGNET network support documented. Dependency upgrades: `@buildonspark/spark-sdk` 0.7.3, `@buildonspark/bare` 0.0.53.
 
 ---
 
@@ -2618,14 +2618,14 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### March 24, 2026
 
 **What's New**
-- **[React Native Core](../tools/react-native-core/)**: Added documentation for `@tetherto/wdk-react-native-core` ([v1.0.0-beta.6](https://github.com/tetherto/wdk-core-react-native/releases/tag/v1.0.0-beta.6)), the hooks-based React Native integration layer for WDK. Includes [API Reference](../tools/react-native-core/api-reference) covering `WdkAppProvider`, `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, and more. Updated [React Native Quickstart](../start-building/react-native-quickstart) with step-by-step integration guide.
+- **[React Native Core](/tools/react-native-core/)**: Added documentation for `@tetherto/wdk-react-native-core` ([v1.0.0-beta.6](https://github.com/tetherto/wdk-core-react-native/releases/tag/v1.0.0-beta.6)), the hooks-based React Native integration layer for WDK. Includes [API Reference](/tools/react-native-core/api-reference) covering `WdkAppProvider`, `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, and more. Updated [React Native Quickstart](/start-building/react-native-quickstart) with step-by-step integration guide.
 
 ---
 
 ### March 12, 2026
 
 **Changes**
-- **wallet-btc** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.6)): Added `dispose()` method to [`WalletAccountReadOnlyBtc`](../sdk/wallet-modules/wallet-btc/api-reference) for closing internal Electrum connections. Security dependency updates.
+- **wallet-btc** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.6)): Added `dispose()` method to [`WalletAccountReadOnlyBtc`](/sdk/wallet-modules/wallet-btc/api-reference) for closing internal Electrum connections. Security dependency updates.
 
 ---
 
@@ -2641,7 +2641,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### March 5, 2026
 
 **What's New**
-- **create-wdk-module**: Added documentation for the [`create-wdk-module`](../tools/create-wdk-module) CLI scaffolding tool. Updated [Community Modules](../sdk/community-modules/) and [SDK Get Started](../sdk/get-started) pages with references to the new tool.
+- **create-wdk-module**: Added documentation for the [`create-wdk-module`](/tools/create-wdk-module) CLI scaffolding tool. Updated [Community Modules](/sdk/community-modules/) and [SDK Get Started](/sdk/get-started) pages with references to the new tool.
 
 ---
 
@@ -2655,8 +2655,8 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 25, 2026
 
 **Changes**
-- **wallet-evm** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.8)): Added [`getTokenBalances(tokenAddresses)`](../sdk/wallet-modules/wallet-evm/api-reference) to [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference), also available on [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference) through inheritance.
-- **wallet-evm-erc-4337** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.5)): Added EIP-712 typed data methods [`signTypedData(typedData)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and [`verifyTypedData(typedData, signature)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference), plus multicall token balance method [`getTokenBalances(tokenAddresses)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference).
+- **wallet-evm** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.8)): Added [`getTokenBalances(tokenAddresses)`](/sdk/wallet-modules/wallet-evm/api-reference) to [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference), also available on [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) through inheritance.
+- **wallet-evm-erc-4337** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.5)): Added EIP-712 typed data methods [`signTypedData(typedData)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and [`verifyTypedData(typedData, signature)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference), plus multicall token balance method [`getTokenBalances(tokenAddresses)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference).
 
 ---
 
@@ -2670,22 +2670,22 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 20, 2026
 
 **What's New**
-- **[Showcase](../overview/showcase)**: More visibility for our showcase page, we value contributions! Added 4 featured community projects: [wdk-mcp](https://github.com/dieselftw/wdk-mcp), [wdk-starter-browser-extension](https://github.com/base58-io/wdk-starter-browser-extension), [wdk-wallet-evm-x402-facilitator](https://github.com/SemanticPay/wdk-wallet-evm-x402-facilitator), and [x402-usdt0](https://github.com/baghdadgherras/x402-usdt0).
-- **[Community Modules](../sdk/community-modules)**: Added [`@base58-io/wdk-wallet-cosmos`](https://github.com/base58-io/wdk-wallet-cosmos) — wallet module for Cosmos-compatible blockchains by [Base58](https://base58.io/).
+- **[Showcase](/overview/showcase)**: More visibility for our showcase page, we value contributions! Added 4 featured community projects: [wdk-mcp](https://github.com/dieselftw/wdk-mcp), [wdk-starter-browser-extension](https://github.com/base58-io/wdk-starter-browser-extension), [wdk-wallet-evm-x402-facilitator](https://github.com/SemanticPay/wdk-wallet-evm-x402-facilitator), and [x402-usdt0](https://github.com/baghdadgherras/x402-usdt0).
+- **[Community Modules](/sdk/community-modules)**: Added [`@base58-io/wdk-wallet-cosmos`](https://github.com/base58-io/wdk-wallet-cosmos) — wallet module for Cosmos-compatible blockchains by [Base58](https://base58.io/).
 
 ---
 
 ### February 18, 2026
 
 **What's New**
-- **[x402 Payments](../ai/x402)**: New guide for accepting and making instant USD₮ payments over HTTP using WDK self-custodial wallets. Covers the x402 protocol, buyer integration with `@tetherto/wdk-wallet-evm`, seller setup with hosted and self-hosted facilitators, and bridging USD₮ to Plasma and Stable chains.
+- **[x402 Payments](/ai/x402)**: New guide for accepting and making instant USD₮ payments over HTTP using WDK self-custodial wallets. Covers the x402 protocol, buyer integration with `@tetherto/wdk-wallet-evm`, seller setup with hosted and self-hosted facilitators, and bridging USD₮ to Plasma and Stable chains.
 
 ---
 
 ### February 15, 2026
 
 **Changes**
-- **wallet-spark**: Added [`getIdentityKey()`](../sdk/wallet-modules/wallet-spark/api-reference) method to [`WalletAccountReadOnlySpark`](../sdk/wallet-modules/wallet-spark/api-reference) for retrieving the account's identity public key ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.10))
+- **wallet-spark**: Added [`getIdentityKey()`](/sdk/wallet-modules/wallet-spark/api-reference) method to [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference) for retrieving the account's identity public key ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.10))
 
 ---
 
@@ -2699,26 +2699,25 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 12, 2026
 
 **What's New**
-- **[Agent Skills](../ai/agent-skills)**: New page covering WDK's agent skill capabilities, self-custodial vs hosted comparison, and platform compatibility with OpenClaw, Claude, Cursor, and other agent platforms.
-- **[OpenClaw Integration](../ai/openclaw)**: New page for installing and configuring the WDK skill in OpenClaw via ClawHub, including security precautions for running agents locally.
+- **[Agent Skills](/ai/agent-skills)**: New page covering WDK's agent skill capabilities, self-custodial vs hosted comparison, and platform compatibility with OpenClaw, Claude, Cursor, and other agent platforms.
+- **[OpenClaw Integration](/ai/openclaw)**: New page for installing and configuring the WDK skill in OpenClaw via ClawHub, including security precautions for running agents locally.
 
 **Changes**
 - **wallet-evm** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.7)): Added [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data support:
-  - Added [`signTypedData(typedData)`](../sdk/wallet-modules/wallet-evm/api-reference) method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference) for signing structured data
-  - Added [`verifyTypedData(typedData, signature)`](../sdk/wallet-modules/wallet-evm/api-reference) method to [`WalletAccountEvm`](../sdk/wallet-modules/wallet-evm/api-reference) and [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference) for verifying typed data signatures
+  - Added [`signTypedData(typedData)`](/sdk/wallet-modules/wallet-evm/api-reference) method to [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) for signing structured data
+  - Added [`verifyTypedData(typedData, signature)`](/sdk/wallet-modules/wallet-evm/api-reference) method to [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) and [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference) for verifying typed data signatures
 - **wallet-evm-erc-4337** ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.4)):
-  - Added 2 new gas payment modes: [Sponsorship Policy](../sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags) and [Native Coins](../sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags), alongside the existing Paymaster Token mode
-  - Added per-call [config override](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference) parameter to `sendTransaction`, `transfer`, `quoteSendTransaction`, and `quoteTransfer`
-  - Added [`getUserOperationReceipt(hash)`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference) method for retrieving ERC-4337 UserOperation receipts
-  - Added [`ConfigurationError`](../sdk/wallet-modules/wallet-evm-erc-4337/api-reference) error type for invalid configuration validation
+  - Added 2 new gas payment modes: [Sponsorship Policy](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags) and [Native Coins](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#gas-payment-mode-flags), alongside the existing Paymaster Token mode
+  - Added per-call [config override](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) parameter to `sendTransaction`, `transfer`, `quoteSendTransaction`, and `quoteTransfer`
+  - Added [`getUserOperationReceipt(hash)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) method for retrieving ERC-4337 UserOperation receipts
+  - Added [`ConfigurationError`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) error type for invalid configuration validation
 
 ---
 
 ### February 10, 2026
 
 **What's New**
-- **[MCP Toolkit](../ai/mcp-toolkit)**: New documentation for `@tetherto/wdk-mcp-toolkit` (`v1.0.0-beta.1`). Covers the `WdkMcpServer` class, 35 built-in MCP tools across 7 categories (wallet, pricing, indexer, swap, bridge, lending, fiat), setup wizard, multi-tool configuration, and full API Reference.
-
+- **[MCP Toolkit](/ai/mcp-toolkit)**: New documentation for `@tetherto/wdk-mcp-toolkit` (`v1.0.0-beta.1`). Covers the `WdkMcpServer` class, 35 built-in MCP tools across 7 categories (wallet, pricing, indexer, swap, bridge, lending, fiat), setup wizard, multi-tool configuration, and full API Reference.
 ---
 
 ### February 08, 2026
@@ -2731,8 +2730,8 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### February 02, 2026
 
 **Changes**
-- **wallet-ton-gasless**: Added `verify` method to [`WalletAccountReadOnlyTonGasless`](../sdk/wallet-modules/wallet-ton-gasless/api-reference#walletaccountreadonlytongasless) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.4))
-- **wallet-tron-gasfree**: Added `verify` method to [`WalletAccountReadOnlyTronGasfree`](../sdk/wallet-modules/wallet-tron-gasfree/api-reference#walletaccountreadonlytrongasfree) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron-gasfree/releases/tag/v1.0.0-beta.4))
+- **wallet-ton-gasless**: Added `verify` method to [`WalletAccountReadOnlyTonGasless`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#walletaccountreadonlytongasless) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.4))
+- **wallet-tron-gasfree**: Added `verify` method to [`WalletAccountReadOnlyTronGasfree`](/sdk/wallet-modules/wallet-tron-gasfree/api-reference#walletaccountreadonlytrongasfree) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron-gasfree/releases/tag/v1.0.0-beta.4))
 
 ### January 29, 2026
 
@@ -2750,27 +2749,27 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 **Changes**
 - **wallet-btc** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-btc/releases/tag/v1.0.0-beta.5)):
-  - Added `verify` method to [`WalletAccountReadOnlyBtc`](../sdk/wallet-modules/wallet-btc/api-reference)
-  - Added Pluggable Transport classes: [`ElectrumTcp`](../sdk/wallet-modules/wallet-btc/api-reference), [`ElectrumTls`](../sdk/wallet-modules/wallet-btc/api-reference), [`ElectrumSsl`](../sdk/wallet-modules/wallet-btc/api-reference), [`ElectrumWs`](../sdk/wallet-modules/wallet-btc/api-reference)
-- **wallet-evm**: Added `verify` method to [`WalletAccountReadOnlyEvm`](../sdk/wallet-modules/wallet-evm/api-reference) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.5))
-- **wallet-solana**: Added `verify` method to [`WalletAccountReadOnlySolana`](../sdk/wallet-modules/wallet-solana/api-reference) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.5))
-- **wallet-ton**: Added `verify` method to [`WalletAccountReadOnlyTon`](../sdk/wallet-modules/wallet-ton/api-reference) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-ton/releases/tag/v1.0.0-beta.7))
-- **wallet-tron**: Added `verify` method to [`WalletAccountReadOnlyTron`](../sdk/wallet-modules/wallet-tron/api-reference) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.4))
-- **wallet-spark**: Added `verify` method to [`WalletAccountReadOnlySpark`](../sdk/wallet-modules/wallet-spark/api-reference) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.7))
+  - Added `verify` method to [`WalletAccountReadOnlyBtc`](/sdk/wallet-modules/wallet-btc/api-reference)
+  - Added Pluggable Transport classes: [`ElectrumTcp`](/sdk/wallet-modules/wallet-btc/api-reference), [`ElectrumTls`](/sdk/wallet-modules/wallet-btc/api-reference), [`ElectrumSsl`](/sdk/wallet-modules/wallet-btc/api-reference), [`ElectrumWs`](/sdk/wallet-modules/wallet-btc/api-reference)
+- **wallet-evm**: Added `verify` method to [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.5))
+- **wallet-solana**: Added `verify` method to [`WalletAccountReadOnlySolana`](/sdk/wallet-modules/wallet-solana/api-reference) ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.5))
+- **wallet-ton**: Added `verify` method to [`WalletAccountReadOnlyTon`](/sdk/wallet-modules/wallet-ton/api-reference) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-ton/releases/tag/v1.0.0-beta.7))
+- **wallet-tron**: Added `verify` method to [`WalletAccountReadOnlyTron`](/sdk/wallet-modules/wallet-tron/api-reference) ([v1.0.0-beta.4](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.4))
+- **wallet-spark**: Added `verify` method to [`WalletAccountReadOnlySpark`](/sdk/wallet-modules/wallet-spark/api-reference) ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.7))
 
 ---
 
 ### January 23, 2026
 
 **What's New**
-- **wdk-core docs**: Added comprehensive [Core Module Guides](../sdk/core-module/guides/getting-started) covering:
-  - [Getting Started](../sdk/core-module/guides/getting-started) - Installation and instantiation
-  - [Wallet Registration](../sdk/core-module/guides/wallet-registration) - Registering wallet modules for different blockchains
-  - [Account Management](../sdk/core-module/guides/account-management) - Working with accounts and addresses
-  - [Transactions](../sdk/core-module/guides/transactions) - Sending native tokens
-  - [Protocol Integration](../sdk/core-module/guides/protocol-integration) - Using swaps, bridges, and lending protocols
-  - [Middleware](../sdk/core-module/guides/middleware) - Configuring logging and failover protection
-  - [Error Handling](../sdk/core-module/guides/error-handling) - Best practices and memory management
+- **wdk-core docs**: Added comprehensive [Core Module Guides](/sdk/core-module/guides/getting-started) covering:
+  - [Getting Started](/sdk/core-module/guides/getting-started) - Installation and instantiation
+  - [Wallet Registration](/sdk/core-module/guides/wallet-registration) - Registering wallet modules for different blockchains
+  - [Account Management](/sdk/core-module/guides/account-management) - Working with accounts and addresses
+  - [Transactions](/sdk/core-module/guides/transactions) - Sending native tokens
+  - [Protocol Integration](/sdk/core-module/guides/protocol-integration) - Using swaps, bridges, and lending protocols
+  - [Middleware](/sdk/core-module/guides/middleware) - Configuring logging and failover protection
+  - [Error Handling](/sdk/core-module/guides/error-handling) - Best practices and memory management
 - **wdk-core**: Added support for 24-word seed phrases via `WDK.getRandomSeedPhrase(24)`
 - **indexer-api**: 
   - Added new `/api/v1/chains` endpoint to list supported blockchains and tokens
@@ -2800,13 +2799,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### December 23, 2025
 
 **What's New**
-- Added [MoonPay Fiat Module](../sdk/fiat-modules/fiat-moonpay/) for on-ramp and off-ramp functionality
-- Added [Community Modules](../sdk/community-modules/) section to highlight community-built modules
+- Added [MoonPay Fiat Module](/sdk/fiat-modules/fiat-moonpay/) for on-ramp and off-ramp functionality
+- Added [Community Modules](/sdk/community-modules/) section to highlight community-built modules
 
 **Changes**
 - Added this changelog page in the docs!
 - **wallet-spark**: Updated Spark SDK to latest version ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.6))
-- Introduced [All Modules](../sdk/all-modules) page in docs for comprehensive module listings
+- Introduced [All Modules](/sdk/all-modules) page in docs for comprehensive module listings
 - Reorganized documentation structure for better navigation
 
 ---
@@ -2866,7 +2865,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 **What's New**
 - **wallet-ton-gasless**: Added unit tests ([v1.0.0-beta.3](https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.3))
-- **pear-wrk-wdk**: Added seed buffer support in `workletStart` ([v1.0.0-beta.5](../tools/pear-wrk-wdk))
+- **pear-wrk-wdk**: Added seed buffer support in `workletStart` ([v1.0.0-beta.5](/tools/pear-wrk-wdk))
 
 **Changes**
 - **wallet-tron-gasfree**: Fixed bug interacting with Gasfree API ([v1.0.0-beta.3](https://github.com/tetherto/wdk-wallet-tron-gasfree/releases/tag/v1.0.0-beta.3))
@@ -3001,7 +3000,7 @@ Showcase projects are developed and maintained independently by third-party cont
 
 Tether and the WDK Team do not endorse or assume responsibility for their code, security, or maintenance. Use your own judgment and proceed at your own risk.
 
-Looking for community-built WDK modules you can install and use in your project? Check out the [Community Modules](../sdk/community-modules/) page instead.
+Looking for community-built WDK modules you can install and use in your project? Check out the [Community Modules](/sdk/community-modules/) page instead.
 
 ## Featured Projects
 
@@ -3116,7 +3115,7 @@ Join us in building this future. The tools are open-source, the vision is clear,
 
 ***
 
-Ready to start building? Explore our [getting started guide](../start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](../sdk/get-started).
+Ready to start building? Explore our [getting started guide](/start-building/nodejs-bare-quickstart) or dive into our [SDK documentation](/sdk/get-started).
 ## Concepts & Definitions
 URL: https://docs.wdk.tether.io/resources/concepts
 Description: Key concepts and definitions used throughout the Wallet Development Kit
@@ -3302,15 +3301,15 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 
 | Module | Blockchain | Description | Documentation |
 |--------|------------|-------------|---------------|
-| [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | Bitcoin SegWit wallet with BIP-39/BIP-44 support | [Docs](./wallet-modules/wallet-btc/) |
-| [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | Ethereum and EVM-compatible chains wallet | [Docs](./wallet-modules/wallet-evm/) |
-| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](./wallet-modules/wallet-evm-erc-4337/) |
-| [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | TON blockchain wallet | [Docs](./wallet-modules/wallet-ton/) |
-| [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | Gasless transactions on TON | [Docs](./wallet-modules/wallet-ton-gasless/) |
-| [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | TRON blockchain wallet | [Docs](./wallet-modules/wallet-tron/) |
-| [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | Gas-free transactions on TRON | [Docs](./wallet-modules/wallet-tron-gasfree/) |
-| [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | Solana blockchain wallet | [Docs](./wallet-modules/wallet-solana/) |
-| [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | Spark/Lightning Bitcoin L2 wallet | [Docs](./wallet-modules/wallet-spark/) |
+| [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | Bitcoin SegWit wallet with BIP-39/BIP-44 support | [Docs](/sdk/wallet-modules/wallet-btc/) |
+| [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | Ethereum and EVM-compatible chains wallet | [Docs](/sdk/wallet-modules/wallet-evm/) |
+| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-erc-4337/) |
+| [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | TON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-ton/) |
+| [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | Gasless transactions on TON | [Docs](/sdk/wallet-modules/wallet-ton-gasless/) |
+| [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | TRON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-tron/) |
+| [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | Gas-free transactions on TRON | [Docs](/sdk/wallet-modules/wallet-tron-gasfree/) |
+| [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | Solana blockchain wallet | [Docs](/sdk/wallet-modules/wallet-solana/) |
+| [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | Spark/Lightning Bitcoin L2 wallet | [Docs](/sdk/wallet-modules/wallet-spark/) |
 
 ## Swap Modules
 
@@ -3326,7 +3325,7 @@ Cross-chain bridge functionality for token transfers between blockchains.
 
 | Module | Route | Description | Documentation |
 |--------|-------|-------------|---------------|
-| [`@tetherto/wdk-protocol-bridge-usdt0-evm`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm) | EVM → EVM + Non-EVM | USD₮0 bridging from EVM source chains to EVM and non-EVM destinations | [Docs](./bridge-modules/bridge-usdt0-evm/) |
+| [`@tetherto/wdk-protocol-bridge-usdt0-evm`](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm) | EVM → EVM + Non-EVM | USD₮0 bridging from EVM source chains to EVM and non-EVM destinations | [Docs](/sdk/bridge-modules/bridge-usdt0-evm/) |
 
 ## Lending Modules
 
@@ -3368,13 +3367,13 @@ Cross-chain bridge functionality for token transfers between blockchains:
 
 To get started with WDK modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the modules that best fit your needs from the tables above 
 3. Check specific documentation for modules you wish to use
 
 You can also:
 
-- Learn about key concepts like [Account Abstraction](../../resources/concepts#account-abstraction) and other important definitions
+- Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready
 ## Bridge USD₮0 EVM Overview
 URL: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm
@@ -3979,7 +3978,7 @@ This guide covers [prerequisites](#prerequisites), how to [run a standard EVM-to
 
 ## Prerequisites
 
-Complete [Get Started](./get-started): an account from [`new WalletAccountEvm(seed, path, config?)`](../../../wallet-modules/wallet-evm/api-reference) and a bridge from [`new Usdt0ProtocolEvm(account, config?)`](../api-reference). The source chain RPC must match the account network.
+Complete [Get Started](/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started): an account from [`new WalletAccountEvm(seed, path, config?)`](/sdk/wallet-modules/wallet-evm/api-reference) and a bridge from [`new Usdt0ProtocolEvm(account, config?)`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference). The source chain RPC must match the account network.
 
 ## Run a standard EVM-to-EVM bridge
 
@@ -4057,7 +4056,7 @@ This guide covers [prerequisites](#prerequisites), how to [create an ERC-4337 ac
 
 ## Create a WalletAccountEvmErc4337 account
 
-You can construct an ERC-4337 signing account using [`new WalletAccountEvmErc4337(seed, path, config)`](../../../wallet-modules/wallet-evm-erc-4337/api-reference) with chain, provider, bundler, entry point, and paymaster settings:
+You can construct an ERC-4337 signing account using [`new WalletAccountEvmErc4337(seed, path, config)`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) with chain, provider, bundler, entry point, and paymaster settings:
 
 ```javascript title="ERC-4337 account on Arbitrum"
 import  from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -4129,7 +4128,7 @@ npm install @tetherto/wdk-protocol-bridge-usdt0-evm
 
 ## Create an EVM account
 
-You can construct a signing account using [`new WalletAccountEvm(seed, path, config?)`](../../../wallet-modules/wallet-evm/api-reference) from `@tetherto/wdk-wallet-evm` with an RPC `provider`:
+You can construct a signing account using [`new WalletAccountEvm(seed, path, config?)`](/sdk/wallet-modules/wallet-evm/api-reference) from `@tetherto/wdk-wallet-evm` with an RPC `provider`:
 
 ```javascript title="Create WalletAccountEvm"
 import  from '@tetherto/wdk-wallet-evm'
@@ -4234,7 +4233,7 @@ Prefer [`quoteBridge()`](../api-reference) before [`bridge()`](../api-reference)
 
 ## Best practices
 
-You can clear private key material from memory when a session ends by calling [`account.dispose()`](../../../wallet-modules/wallet-evm/api-reference) on [`WalletAccountEvm`](../../../wallet-modules/wallet-evm/api-reference), or [`account.dispose()`](../../../wallet-modules/wallet-evm-erc-4337/api-reference) on [`WalletAccountEvmErc4337`](../../../wallet-modules/wallet-evm-erc-4337/api-reference):
+You can clear private key material from memory when a session ends by calling [`account.dispose()`](/sdk/wallet-modules/wallet-evm/api-reference) on [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference), or [`account.dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) on [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Dispose EVM account after use"
 account.dispose()
@@ -4297,7 +4296,7 @@ Want to extend WDK with your own custom module? Use the `create-wdk-module` CLI 
 npx @tetherto/create-wdk-module@latest
 ```
 
-The CLI generates source files, tests, TypeScript type definitions, and CI workflows for all five module types (wallet, swap, bridge, lending, fiat). See the [Create WDK Module documentation](../../tools/create-wdk-module) for the full guide, CLI options, and generated project structure.
+The CLI generates source files, tests, TypeScript type definitions, and CI workflows for all five module types (wallet, swap, bridge, lending, fiat). See the [Create WDK Module documentation](/tools/create-wdk-module) for the full guide, CLI options, and generated project structure.
 
 You can also:
 
@@ -5129,7 +5128,7 @@ const wdk = new WDK(existingSeed)
 
 ## Next Steps
 
-With your WDK instance ready, you can now [register wallet modules](./wallet-registration) to interact with specific blockchains like [Ethereum](../../wallet-modules/wallet-evm/), [TON](../../wallet-modules/wallet-ton/), or [Bitcoin](../../wallet-modules/wallet-btc/).
+With your WDK instance ready, you can now [register wallet modules](/sdk/core-module/guides/wallet-registration) to interact with specific blockchains like [Ethereum](/sdk/wallet-modules/wallet-evm/), [TON](/sdk/wallet-modules/wallet-ton/), or [Bitcoin](/sdk/wallet-modules/wallet-btc/).
 ## Configure Middleware
 URL: https://docs.wdk.tether.io/sdk/core-module/guides/middleware
 Description: Learn how to intercept and enhance wallet operations with middleware.
@@ -5271,7 +5270,7 @@ URL: https://docs.wdk.tether.io/sdk/core-module/guides/transactions
 Description: Learn how to send native tokens on different blockchains.
 You can send native tokens (like ETH, TON, or BTC) from any of your wallet accounts to another address.
 
-**Get Testnet Funds:** To test these transactions without spending real money, ensure you are on a testnet and have obtained funds. See [Testnet Funds & Faucets](../../../resources/concepts#testnet-funds--faucets) for a list of available faucets.
+**Get Testnet Funds:** To test these transactions without spending real money, ensure you are on a testnet and have obtained funds. See [Testnet Funds & Faucets](/resources/concepts#testnet-funds--faucets) for a list of available faucets.
 
 **BigInt Usage:** Always use `BigInt` (the `n` suffix) for monetary values to avoid precision loss with large numbers.
 
@@ -5360,7 +5359,7 @@ The `registerWallet` method (see [API Reference](../api-reference)) requires thr
 
 ## Installation
 
-Install the [wallet managers](../../wallet-modules/) for the blockchains you want to support:
+Install the [wallet managers](/sdk/wallet-modules/) for the blockchains you want to support:
 
 ```bash
 npm install @tetherto/wdk-wallet-evm @tetherto/wdk-wallet-tron @tetherto/wdk-wallet-btc
@@ -5448,15 +5447,15 @@ Fiat modules provide:
 
 To get started with WDK fiat modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the fiat module that best fits your needs from the table above
 3. Check specific documentation for the module you wish to use
 
 You can also:
 
-- Learn about key concepts in our [Concepts](../../resources/concepts) page
-- Explore [wallet modules](../wallet-modules/) to manage user wallets
-- Check our [examples](../../examples-and-starters/react-native-starter) for production-ready implementations
+- Learn about key concepts in our [Concepts](/resources/concepts) page
+- Explore [wallet modules](/sdk/wallet-modules/) to manage user wallets
+- Check our [examples](/examples-and-starters/react-native-starter) for production-ready implementations
 ## Fiat MoonPay Overview
 URL: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay
 Description: Overview of the @tetherto/wdk-protocol-fiat-moonpay module
@@ -6409,7 +6408,7 @@ const aave = new AaveProtocolEvm(account)
 
 ---
 
-When `AaveProtocolEvm` is initialized with an ERC‑4337 smart account, the optional `config` argument on mutating and quote methods accepts the same gas-payment override families documented in [`@tetherto/wdk-wallet-evm-erc-4337`](../../wallet-modules/wallet-evm-erc-4337/api-reference): paymaster token, sponsorship policy, and native coins.
+When `AaveProtocolEvm` is initialized with an ERC‑4337 smart account, the optional `config` argument on mutating and quote methods accepts the same gas-payment override families documented in [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference): paymaster token, sponsorship policy, and native coins.
 
 ### `supply(options, config?)`
 Add tokens to the pool.
@@ -6616,9 +6615,9 @@ const aave = new AaveProtocolEvm(account)
 
 ## ERC‑4337 (Account Abstraction)
 
-When using ERC‑4337 smart accounts, every mutating method and quote helper accepts an optional `config` override. In `v1.0.0-beta.4`, that override matches the three gas-payment families exposed by [`@tetherto/wdk-wallet-evm-erc-4337`](../../wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins.
+When using ERC‑4337 smart accounts, every mutating method and quote helper accepts an optional `config` override. In `v1.0.0-beta.4`, that override matches the three gas-payment families exposed by [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins.
 
-Use the fields that match the gas-payment mode you want for that call. For the full field-level definitions, see the [`@tetherto/wdk-wallet-evm-erc-4337` configuration docs](../../wallet-modules/wallet-evm-erc-4337/configuration) and [`Config Override`](../../wallet-modules/wallet-evm-erc-4337/api-reference) reference.
+Use the fields that match the gas-payment mode you want for that call. For the full field-level definitions, see the [`@tetherto/wdk-wallet-evm-erc-4337` configuration docs](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) and [`Config Override`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) reference.
 
 ```javascript
 import  from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -6937,13 +6936,13 @@ DeFi swap functionality for token exchanges across different DEXs:
 
 To get started with WDK modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the modules that best fit your needs from the tables above 
 3. Check specific documentation for modules you wish to use
 
 You can also:
 
-- Learn about key concepts like [Account Abstraction](../../resources/concepts#account-abstraction) and other important definitions
+- Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready
 ## Swap velora EVM Overview
 URL: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm
@@ -7265,7 +7264,7 @@ console.log('Tokens bought (base units):', result.tokenOutAmount)
 
 ## Swap with ERC-4337
 
-You can perform a user-operation-backed swap by constructing [`VeloraProtocolEvm`](../api-reference) with [`WalletAccountEvmErc4337`](../../../wallet-modules/wallet-evm-erc-4337/api-reference) and passing paymaster options to [`swap()`](../api-reference):
+You can perform a user-operation-backed swap by constructing [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) with [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and passing paymaster options to [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Swap with smart account and paymaster"
 import  from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -7285,9 +7284,9 @@ Token addresses must match the chain your account uses (for example, mainnet USD
 
 ## Next Steps
 
-- [Get swap quotes](get-swap-quotes) before sending
-- [Handle errors](handle-errors)
-- [Get started](get-started) if you still need setup
+- [Get swap quotes](/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes) before sending
+- [Handle errors](/sdk/swap-modules/swap-velora-evm/guides/handle-errors)
+- [Get started](/sdk/swap-modules/swap-velora-evm/guides/get-started) if you still need setup
 ## Get Started
 URL: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/get-started
 Description: Install the package, create VeloraProtocolEvm, and learn supported networks.
@@ -7316,25 +7315,25 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", )
 const swapProtocol = new VeloraProtocolEvm(account, )
 ```
 
-Optional `swapMaxFee` caps the total gas fee in wei for swaps. See [configuration](../configuration) for environment-specific settings.
+Optional `swapMaxFee` caps the total gas fee in wei for swaps. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for environment-specific settings.
 
 ## Supported networks
 
-Velora routing works on EVM networks the aggregator supports, including **Ethereum**, **Polygon**, **Arbitrum**, and other chains where Velora exposes liquidity. Use an RPC endpoint for the network your [`WalletAccountEvm`](../../../wallet-modules/wallet-evm/api-reference) is configured for so [`swap()`](../api-reference) and [`quoteSwap()`](../api-reference) target the correct chain.
+Velora routing works on EVM networks the aggregator supports, including **Ethereum**, **Polygon**, **Arbitrum**, and other chains where Velora exposes liquidity. Use an RPC endpoint for the network your [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) is configured for so [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) and [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) target the correct chain.
 
 ## Next Steps
 
-- [Execute swaps](execute-swaps)
-- [Get swap quotes](get-swap-quotes)
-- [Handle errors](handle-errors)
+- [Execute swaps](/sdk/swap-modules/swap-velora-evm/guides/execute-swaps)
+- [Get swap quotes](/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes)
+- [Handle errors](/sdk/swap-modules/swap-velora-evm/guides/handle-errors)
 ## Get Swap Quotes
 URL: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes
 Description: Estimate fees and amounts with quoteSwap before executing a swap.
-This guide shows how to [quote before swapping](#quote-before-swapping) and use quotes for [fee estimation](#fee-estimation). Quotes use [`quoteSwap()`](../api-reference), which works with read-only accounts as well as signing accounts.
+This guide shows how to [quote before swapping](#quote-before-swapping) and use quotes for [fee estimation](#fee-estimation). Quotes use [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference), which works with read-only accounts as well as signing accounts.
 
 ## Quote before swapping
 
-You can preview fee and token amounts for the same parameters you would pass to [`swap()`](../api-reference) using [`quoteSwap()`](../api-reference):
+You can preview fee and token amounts for the same parameters you would pass to [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) using [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Quote exact input swap"
 const quote = await swapProtocol.quoteSwap()
@@ -7344,7 +7343,7 @@ console.log('Tokens in (base units):', quote.tokenInAmount)
 console.log('Tokens out (base units):', quote.tokenOutAmount)
 ```
 
-You can quote an exact-output style trade the same way by passing `tokenOutAmount` instead of `tokenInAmount` to [`quoteSwap()`](../api-reference):
+You can quote an exact-output style trade the same way by passing `tokenOutAmount` instead of `tokenInAmount` to [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Quote exact output swap"
 const quote = await swapProtocol.quoteSwap()
@@ -7355,7 +7354,7 @@ console.log('Required token in (base units):', quote.tokenInAmount)
 
 ## Fee estimation
 
-You can read `quote.fee` from [`quoteSwap()`](../api-reference) as the estimated total swap fee in wei before calling [`swap()`](../api-reference):
+You can read `quote.fee` from [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) as the estimated total swap fee in wei before calling [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
 
 ```javascript title="Quote fee before deciding"
 const quote = await swapProtocol.quoteSwap()
@@ -7371,13 +7370,13 @@ const maxFee = 200000000000000n
 const quote = await swapProtocol.quoteSwap()
 
 if (quote.fee 
-On-chain conditions can change between quote and execution. The executed [`swap()`](../api-reference) may still differ slightly from the last [`quoteSwap()`](../api-reference) result.
+On-chain conditions can change between quote and execution. The executed [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) may still differ slightly from the last [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) result.
 
 ## Next Steps
 
-- [Execute swaps](execute-swaps)
-- [Handle errors](handle-errors)
-- [Get started](get-started)
+- [Execute swaps](/sdk/swap-modules/swap-velora-evm/guides/execute-swaps)
+- [Handle errors](/sdk/swap-modules/swap-velora-evm/guides/handle-errors)
+- [Get started](/sdk/swap-modules/swap-velora-evm/guides/get-started)
 ## Handle Errors
 URL: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/handle-errors
 Description: Catch swap failures, interpret common messages, and clean up sensitive state.
@@ -7404,7 +7403,7 @@ Match string fragments only as a convenience; production apps should prefer stab
 
 ## Quote errors
 
-You can handle failures from [`quoteSwap()`](../api-reference) the same way, including provider or routing errors:
+You can handle failures from [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) the same way, including provider or routing errors:
 
 ```javascript title="Handle quote failures"
 try {
@@ -7417,7 +7416,7 @@ Common causes are listed under [Errors](../api-reference) in the API reference (
 
 ## Best Practices
 
-You can clear signing material when a session ends by calling [`dispose()`](../../../wallet-modules/wallet-evm/api-reference) on each [`WalletAccountEvm`](../../../wallet-modules/wallet-evm/api-reference), or [`dispose()`](../../../wallet-modules/wallet-evm/api-reference) on [`WalletManagerEvm`](../../../wallet-modules/wallet-evm/api-reference) if you use a manager:
+You can clear signing material when a session ends by calling [`dispose()`](/sdk/wallet-modules/wallet-evm/api-reference) on each [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference), or [`dispose()`](/sdk/wallet-modules/wallet-evm/api-reference) on [`WalletManagerEvm`](/sdk/wallet-modules/wallet-evm/api-reference) if you use a manager:
 
 ```javascript title="Dispose wallet accounts"
 try {
@@ -7425,13 +7424,13 @@ try {
 } finally 
 ```
 
-If you use an ERC-4337 account, call [`dispose()`](../../../wallet-modules/wallet-evm-erc-4337/api-reference) on that account type per its API reference. Drop references to your [`VeloraProtocolEvm`](../api-reference) instance when you no longer need it.
+If you use an ERC-4337 account, call [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) on that account type per its API reference. Drop references to your [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) instance when you no longer need it.
 
 ## Next Steps
 
-- [Get swap quotes](get-swap-quotes)
-- [Execute swaps](execute-swaps)
-- [API reference](../api-reference)
+- [Get swap quotes](/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes)
+- [Execute swaps](/sdk/swap-modules/swap-velora-evm/guides/execute-swaps)
+- [API reference](/sdk/swap-modules/swap-velora-evm/api-reference)
 ## Swap velora EVM Guides
 URL: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/usage
 Description: How to install and use @tetherto/wdk-protocol-swap-velora-evm for swapping tokens on EVM
@@ -7489,7 +7488,7 @@ Standard wallet implementations that use native blockchain tokens for transactio
 
 ## Account Abstraction Wallet Modules
 
-Wallet implementations that support [Account Abstraction](../../resources/concepts#account-abstraction) for gasless transactions using paymaster tokens like USD₮:
+Wallet implementations that support [Account Abstraction](/resources/concepts#account-abstraction) for gasless transactions using paymaster tokens like USD₮:
 
 | Module | Blockchain | Status | Documentation |
 |--------|------------|--------|---------------|
@@ -7512,13 +7511,13 @@ Community modules are developed and maintained independently. Use your own judgm
 
 To get started with WDK modules, follow these steps:
 
-1. Get up and running quickly with our [Quickstart Guide](../../start-building/nodejs-bare-quickstart)
+1. Get up and running quickly with our [Quickstart Guide](/start-building/nodejs-bare-quickstart)
 2. Choose the modules that best fit your needs from the tables above 
 3. Check specific documentation for modules you wish to use
 
 You can also:
 
-- Learn about key concepts like [Account Abstraction](../../resources/concepts#account-abstraction) and other important definitions
+- Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready
 ## Wallet BTC Overview
 URL: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc
@@ -8317,9 +8316,9 @@ The `network` option specifies which Bitcoin network to use.
 **Type:** `string`
 
 **Values:**
-- `"bitcoin"` - Bitcoin [mainnet](../../../resources/concepts#mainnet) (production)
-- `"testnet"` - Bitcoin [testnet](../../../resources/concepts#testnet) (development)
-- `"regtest"` - Bitcoin [regtest](../../../resources/concepts#regtest) (local testing)
+- `"bitcoin"` - Bitcoin [mainnet](/resources/concepts#mainnet) (production)
+- `"testnet"` - Bitcoin [testnet](/resources/concepts#testnet) (development)
+- `"regtest"` - Bitcoin [regtest](/resources/concepts#regtest) (local testing)
 
 **Default:** `"bitcoin"`
 
@@ -8335,8 +8334,8 @@ The `bip` option specifies the address type derivation standard to use.
 **Type:** `number`
 
 **Values:**
-- `84` - [BIP-84](../../../resources/concepts#bip-84-native-segwit) (P2WPKH / Native SegWit) - addresses start with `bc1` (mainnet) or `tb1` (testnet)
-- `44` - [BIP-44](../../../resources/concepts#bip-44-multi-account-hierarchy) (P2PKH / Legacy) - addresses start with `1` (mainnet) or `m`/`n` (testnet)
+- `84` - [BIP-84](/resources/concepts#bip-84-native-segwit) (P2WPKH / Native SegWit) - addresses start with `bc1` (mainnet) or `tb1` (testnet)
+- `44` - [BIP-44](/resources/concepts#bip-44-multi-account-hierarchy) (P2PKH / Legacy) - addresses start with `1` (mainnet) or `m`/`n` (testnet)
 
 **Default:** `84`
 
@@ -14338,7 +14337,7 @@ const regtestConfig =
 
 ## BIP-44 Derivation Path
 
-Spark uses the [BIP-44](../../../resources/concepts#bip-44-multi-account-hierarchy) coin type 998, resulting in derivation paths like:
+Spark uses the [BIP-44](/resources/concepts#bip-44-multi-account-hierarchy) coin type 998, resulting in derivation paths like:
 - `m/44'/998'/0'/0/0` for MAINNET account index 0
 - `m/44'/998'/0'/0/1` for MAINNET account index 1
 - `m/44'/998'/2'/0/0` for SIGNET account index 0
@@ -14349,7 +14348,7 @@ The path follows the pattern `m/44'/998'/'/0/` where:
 - `networkNumber` is 0 for MAINNET, 2 for SIGNET, or 3 for REGTEST
 - `index` is the account index
 
-This ensures compatibility with standard [BIP-44](../../../resources/concepts#bip-44-multi-account-hierarchy) wallets while using Spark's unique coin type identifier.
+This ensures compatibility with standard [BIP-44](/resources/concepts#bip-44-multi-account-hierarchy) wallets while using Spark's unique coin type identifier.
 
 ## Complete Configuration Example
 
@@ -18996,7 +18995,7 @@ You can try all features without real funds required. You can use the Pimlico or
 [Get mock/test USD₮ on Pimlico](https://dashboard.pimlico.io/test-erc20-faucet)
 [Get mock/test USD₮ on Candide](https://dashboard.candide.dev/faucet)
 
-See the [configuration](../sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
+See the [configuration](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
 
 ***
 
@@ -19016,10 +19015,10 @@ npm install @tetherto/wdk @tetherto/wdk-wallet-evm @tetherto/wdk-wallet-tron @te
 
 Learn more about WDK modules:
 
-* [**@tetherto/wdk**](../sdk/core-module/) - The main SDK module
-* [**@tetherto/wdk-wallet-evm**](../sdk/wallet-modules/wallet-evm/) - Ethereum and EVM-compatible chains support
-* [**@tetherto/wdk-wallet-tron**](../sdk/wallet-modules/wallet-tron/) - TRON blockchain support
-* [**@tetherto/wdk-wallet-btc**](../sdk/wallet-modules/wallet-btc/) - Bitcoin blockchain support
+* [**@tetherto/wdk**](/sdk/core-module/) - The main SDK module
+* [**@tetherto/wdk-wallet-evm**](/sdk/wallet-modules/wallet-evm/) - Ethereum and EVM-compatible chains support
+* [**@tetherto/wdk-wallet-tron**](/sdk/wallet-modules/wallet-tron/) - TRON blockchain support
+* [**@tetherto/wdk-wallet-btc**](/sdk/wallet-modules/wallet-btc/) - Bitcoin blockchain support
 
 ***
 
@@ -19059,9 +19058,9 @@ console.log('Wallets registered for Ethereum, TRON, and Bitcoin')
 ```
 
 To learn more about configuring the wallet modules:
-* [Configuring @tetherto/wdk-wallet-evm](../sdk/wallet-modules/wallet-evm/configuration)
-* [Configuring @tetherto/wdk-wallet-tron](../sdk/wallet-modules/wallet-tron/configuration)
-* [Configuring @tetherto/wdk-wallet-btc](../sdk/wallet-modules/wallet-btc/configuration)
+* [Configuring @tetherto/wdk-wallet-evm](/sdk/wallet-modules/wallet-evm/configuration)
+* [Configuring @tetherto/wdk-wallet-tron](/sdk/wallet-modules/wallet-tron/configuration)
+* [Configuring @tetherto/wdk-wallet-btc](/sdk/wallet-modules/wallet-btc/configuration)
 
 ***
 
@@ -19280,7 +19279,7 @@ You can try all features without real funds required. You can use the Pimlico or
 - [Get mock/test USD₮ on Pimlico](https://dashboard.pimlico.io/test-erc20-faucet)
 - [Get mock/test USD₮ on Candide](https://dashboard.candide.dev/faucet)
 
-See the [ERC-4337 configuration](../sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
+See the [ERC-4337 configuration](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) for quick setup and Sepolia testnet configuration.
 
 ## Prerequisites
 
@@ -19345,7 +19344,7 @@ EXPO_PUBLIC_TRON_API_KEY=your_tron_api_key
 EXPO_PUBLIC_TRON_API_SECRET=your_tron_api_secret
 ```
 
-**Where do I get an Indexer API key?** The WDK Indexer is required for transaction history and balance indexing. Get your free API key from the [Indexer API setup guide](../tools/indexer-api/get-started).
+**Where do I get an Indexer API key?** The WDK Indexer is required for transaction history and balance indexing. Get your free API key from the [Indexer API setup guide](/tools/indexer-api/get-started).
 
 ### Step 4: Run Your App
 
@@ -19478,7 +19477,7 @@ export const wdkConfigs: WdkConfigs = {
 }
 ```
 
-This example uses **Sepolia testnet** with a free public RPC so you can start immediately without API keys. For production or mainnet configuration, see the [Chain Configuration Guide](../sdk/core-module/configuration).
+This example uses **Sepolia testnet** with a free public RPC so you can start immediately without API keys. For production or mainnet configuration, see the [Chain Configuration Guide](/sdk/core-module/configuration).
 
 ### Step 5: Add WdkAppProvider
 
@@ -19533,7 +19532,7 @@ function WalletScreen() {
 }
 ```
 
-For the full list of available hooks and their parameters, see the [React Native Core API Reference](../tools/react-native-core/api-reference).
+For the full list of available hooks and their parameters, see the [React Native Core API Reference](/tools/react-native-core/api-reference).
 
 ### Step 7: Rebuild and Run
 
@@ -19702,14 +19701,14 @@ Ready to dive deeper? Check out these resources:
 
 ### Core Concepts
 
-- [**React Native Core Docs**](../tools/react-native-core/) - Full documentation for `@tetherto/wdk-react-native-core`
-- [**API Reference**](../tools/react-native-core/api-reference) - Complete hook and type reference
-- [**Chain Configuration**](../sdk/core-module/configuration#wallet-configuration) - Configure blockchain networks
+- [**React Native Core Docs**](/tools/react-native-core/) - Full documentation for `@tetherto/wdk-react-native-core`
+- [**API Reference**](/tools/react-native-core/api-reference) - Complete hook and type reference
+- [**Chain Configuration**](/sdk/core-module/configuration#wallet-configuration) - Configure blockchain networks
 
 ### Examples & Starters
 
-- [**React Native Starter**](../examples-and-starters/react-native-starter) - Full-featured starter app
-- [**React Native UI Kit**](../ui-kits/react-native-ui-kit/) - Pre-built wallet components
+- [**React Native Starter**](/examples-and-starters/react-native-starter) - Full-featured starter app
+- [**React Native UI Kit**](/ui-kits/react-native-ui-kit/) - Pre-built wallet components
 
 ### **Need Help?**
 ## Create WDK Module
@@ -20273,7 +20272,7 @@ The API returns standard HTTP error codes:
 ## Next Steps
 
 * [**Get Started**](get-started) - Quick start guide with setup instructions
-* [**React Native Starter**](../../examples-and-starters/react-native-starter) - See it in action
+* [**React Native Starter**](/examples-and-starters/react-native-starter) - See it in action
 
 ***
 
@@ -20909,7 +20908,7 @@ function WalletScreen() {
 }
 ```
 
-For a full integration guide, see the [React Native Quickstart](../../start-building/react-native-quickstart).
+For a full integration guide, see the [React Native Quickstart](/start-building/react-native-quickstart).
 
 ## Bundle Configuration
 
@@ -22827,7 +22826,7 @@ function WalletBackup()
 
 - [Get Started](get-started) - Quick start guide and basic usage
 - [Theming Guide](theming) - Deep dive into theming capabilities
-- [React Native Quickstart](../../start-building/react-native-quickstart) - Complete implementation example
+- [React Native Quickstart](/start-building/react-native-quickstart) - Complete implementation example
 
 ***
 
@@ -22955,7 +22954,7 @@ export function SendScreen() {
 
 * [Components List](./api-reference) - Complete API Reference for all components
 * [Theming Guide](./theming) - Deep dive into theming capabilities
-* [React Native Starter](../../start-building/react-native-quickstart) - See a complete implementation
+* [React Native Starter](/start-building/react-native-quickstart) - See a complete implementation
 
 ***
 
@@ -23244,7 +23243,7 @@ function Settings() {
 
 * [Get Started](get-started) - Quick start guide for the UI Kit
 * [Components List](api-reference) - Complete API Reference for all components
-* [React Native Quickstart](../../start-building/react-native-quickstart) - See theming in action
+* [React Native Quickstart](/start-building/react-native-quickstart) - See theming in action
 
 ***
 


### PR DESCRIPTION
Noticed while browsing the docs that most pages use relative links, often causing navigation issues

e.g. "Indexer API setup guide" on [React Native Quickstart ](https://docs.wdk.tether.io/start-building/react-native-quickstart/) links to [../tools/indexer-api/get-started](https://docs.wdk.tether.io/start-building/tools/indexer-api/get-started) instead of [/tools/indexer-api/get-started](https://docs.wdk.tether.io/tools/indexer-api/get-started)

Absolute links are also better for SEO/agent discoverability