### PR TITLE
Add Morpho to Community Modules

### DIFF
--- a/content/docs/sdk/community-modules/index.mdx
+++ b/content/docs/sdk/community-modules/index.mdx
@@ -19,6 +19,7 @@ Tether and the WDK Team do not endorse or assume responsibility for their code, 
 |--------|------|-------------|--------|
 | [@utexo/wdk-wallet-rgb](https://github.com/UTEXO-Protocol/wdk-wallet-rgb) | Wallet Module | Wallet module for RGB, Bitcoin-based smart contracts | [UTEXO](https://github.com/UTEXO-Protocol) |
 | [@base58-io/wdk-wallet-cosmos](https://github.com/base58-io/wdk-wallet-cosmos) | Wallet Module | Wallet module for Cosmos-compatible blockchains | [Base58](https://base58.io/) |
+| [@morpho-org/wdk-protocol-lending-morpho-evm](https://www.npmjs.com/package/@morpho-org/wdk-protocol-lending-morpho-evm) ([GitHub](https://github.com/morpho-org/sdks/tree/main/packages/wdk-protocol-lending-morpho-evm)) | Lending Module | Morpho EVM lending module for vault deposits, collateral supply, borrowing, repayment, and position reads | [Morpho Association](https://morpho.org/) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `@morpho-org/wdk-protocol-lending-morpho-evm` to the Community Modules table.
- Links to both the published npm package and the Morpho SDK source package.
- Keeps the module under the existing third-party community module disclaimer instead of adding a first-party lending docs home.

## Validation
- `git diff --check`
- `npm run check:meta`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `SKIP_OG_BUILD=1 NEXT_PUBLIC_DOCS_ORIGIN=https://docs.wdk.tether.io npm run build`

## Notes
- Build passed with existing docs-seo warnings for unrelated pages missing `docType` frontmatter.
