### PR TITLE
Add redirects and restore Build with AI page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -7,30 +7,30 @@
 /examples-and-starters/tools/indexer-api/*     /tools/indexer-api/:splat 301
 
 # Old flat module aliases.
-# Trailing-slash rules cover module landing pages; splats cover nested pages.
-/sdk/wallet-evm/                               /sdk/wallet-modules/wallet-evm                         301
+# Exact rules cover module landing pages; splats cover trailing-slash and nested paths.
+/sdk/wallet-evm                                /sdk/wallet-modules/wallet-evm                         301
 /sdk/wallet-evm/*                              /sdk/wallet-modules/wallet-evm/:splat                  301
-/sdk/wallet-evm-erc-4337/                      /sdk/wallet-modules/wallet-evm-erc-4337                301
+/sdk/wallet-evm-erc-4337                       /sdk/wallet-modules/wallet-evm-erc-4337                301
 /sdk/wallet-evm-erc-4337/*                     /sdk/wallet-modules/wallet-evm-erc-4337/:splat         301
-/sdk/wallet-btc/                               /sdk/wallet-modules/wallet-btc                         301
+/sdk/wallet-btc                                /sdk/wallet-modules/wallet-btc                         301
 /sdk/wallet-btc/*                              /sdk/wallet-modules/wallet-btc/:splat                  301
-/sdk/wallet-solana/                            /sdk/wallet-modules/wallet-solana                      301
+/sdk/wallet-solana                             /sdk/wallet-modules/wallet-solana                      301
 /sdk/wallet-solana/*                           /sdk/wallet-modules/wallet-solana/:splat               301
-/sdk/wallet-ton/                               /sdk/wallet-modules/wallet-ton                         301
+/sdk/wallet-ton                                /sdk/wallet-modules/wallet-ton                         301
 /sdk/wallet-ton/*                              /sdk/wallet-modules/wallet-ton/:splat                  301
-/sdk/wallet-ton-gasless/                       /sdk/wallet-modules/wallet-ton-gasless                 301
+/sdk/wallet-ton-gasless                        /sdk/wallet-modules/wallet-ton-gasless                 301
 /sdk/wallet-ton-gasless/*                      /sdk/wallet-modules/wallet-ton-gasless/:splat          301
-/sdk/wallet-tron/                              /sdk/wallet-modules/wallet-tron                        301
+/sdk/wallet-tron                               /sdk/wallet-modules/wallet-tron                        301
 /sdk/wallet-tron/*                             /sdk/wallet-modules/wallet-tron/:splat                 301
-/sdk/wallet-tron-gasfree/                      /sdk/wallet-modules/wallet-tron-gasfree                301
+/sdk/wallet-tron-gasfree                       /sdk/wallet-modules/wallet-tron-gasfree                301
 /sdk/wallet-tron-gasfree/*                     /sdk/wallet-modules/wallet-tron-gasfree/:splat         301
-/sdk/wallet-spark/                             /sdk/wallet-modules/wallet-spark                       301
+/sdk/wallet-spark                              /sdk/wallet-modules/wallet-spark                       301
 /sdk/wallet-spark/*                            /sdk/wallet-modules/wallet-spark/:splat                301
-/sdk/swap-velora-evm/                          /sdk/swap-modules/swap-velora-evm                      301
+/sdk/swap-velora-evm                           /sdk/swap-modules/swap-velora-evm                      301
 /sdk/swap-velora-evm/*                         /sdk/swap-modules/swap-velora-evm/:splat               301
-/sdk/bridge-usdt0-evm/                         /sdk/bridge-modules/bridge-usdt0-evm                   301
+/sdk/bridge-usdt0-evm                          /sdk/bridge-modules/bridge-usdt0-evm                   301
 /sdk/bridge-usdt0-evm/*                        /sdk/bridge-modules/bridge-usdt0-evm/:splat            301
-/sdk/lending-aave-evm/                         /sdk/lending-modules/lending-aave-evm                  301
+/sdk/lending-aave-evm                          /sdk/lending-modules/lending-aave-evm                  301
 /sdk/lending-aave-evm/*                        /sdk/lending-modules/lending-aave-evm/:splat           301
-/sdk/fiat-moonpay/                             /sdk/fiat-modules/fiat-moonpay                         301
+/sdk/fiat-moonpay                              /sdk/fiat-modules/fiat-moonpay                         301
 /sdk/fiat-moonpay/*                            /sdk/fiat-modules/fiat-moonpay/:splat                  301

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,36 @@
+# Sevalla redirects for old docs URLs.
+# Keep exact rules above splat rules because Sevalla applies the first match.
+
+# Broken relative URL generated before internal docs links were made root-absolute.
+/examples-and-starters/tools/indexer-api       /tools/indexer-api       301
+/examples-and-starters/tools/indexer-api/      /tools/indexer-api       301
+/examples-and-starters/tools/indexer-api/*     /tools/indexer-api/:splat 301
+
+# Old flat module aliases.
+# Trailing-slash rules cover module landing pages; splats cover nested pages.
+/sdk/wallet-evm/                               /sdk/wallet-modules/wallet-evm                         301
+/sdk/wallet-evm/*                              /sdk/wallet-modules/wallet-evm/:splat                  301
+/sdk/wallet-evm-erc-4337/                      /sdk/wallet-modules/wallet-evm-erc-4337                301
+/sdk/wallet-evm-erc-4337/*                     /sdk/wallet-modules/wallet-evm-erc-4337/:splat         301
+/sdk/wallet-btc/                               /sdk/wallet-modules/wallet-btc                         301
+/sdk/wallet-btc/*                              /sdk/wallet-modules/wallet-btc/:splat                  301
+/sdk/wallet-solana/                            /sdk/wallet-modules/wallet-solana                      301
+/sdk/wallet-solana/*                           /sdk/wallet-modules/wallet-solana/:splat               301
+/sdk/wallet-ton/                               /sdk/wallet-modules/wallet-ton                         301
+/sdk/wallet-ton/*                              /sdk/wallet-modules/wallet-ton/:splat                  301
+/sdk/wallet-ton-gasless/                       /sdk/wallet-modules/wallet-ton-gasless                 301
+/sdk/wallet-ton-gasless/*                      /sdk/wallet-modules/wallet-ton-gasless/:splat          301
+/sdk/wallet-tron/                              /sdk/wallet-modules/wallet-tron                        301
+/sdk/wallet-tron/*                             /sdk/wallet-modules/wallet-tron/:splat                 301
+/sdk/wallet-tron-gasfree/                      /sdk/wallet-modules/wallet-tron-gasfree                301
+/sdk/wallet-tron-gasfree/*                     /sdk/wallet-modules/wallet-tron-gasfree/:splat         301
+/sdk/wallet-spark/                             /sdk/wallet-modules/wallet-spark                       301
+/sdk/wallet-spark/*                            /sdk/wallet-modules/wallet-spark/:splat                301
+/sdk/swap-velora-evm/                          /sdk/swap-modules/swap-velora-evm                      301
+/sdk/swap-velora-evm/*                         /sdk/swap-modules/swap-velora-evm/:splat               301
+/sdk/bridge-usdt0-evm/                         /sdk/bridge-modules/bridge-usdt0-evm                   301
+/sdk/bridge-usdt0-evm/*                        /sdk/bridge-modules/bridge-usdt0-evm/:splat            301
+/sdk/lending-aave-evm/                         /sdk/lending-modules/lending-aave-evm                  301
+/sdk/lending-aave-evm/*                        /sdk/lending-modules/lending-aave-evm/:splat           301
+/sdk/fiat-moonpay/                             /sdk/fiat-modules/fiat-moonpay                         301
+/sdk/fiat-moonpay/*                            /sdk/fiat-modules/fiat-moonpay/:splat                  301

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -41,8 +41,8 @@ Get started with WDK in a Node.js environment
 <Card title="React Native Quickstart" href="/start-building/react-native-quickstart">
 Build mobile wallets with React Native Expo
 </Card>
-<Card title="Bare Runtime Quickstart" href="/start-building/nodejs-bare-quickstart">
-Deploy WDK in lightweight environments
+<Card title="Build with AI" href="/start-building/build-with-ai">
+Connect AI assistants to WDK docs and tools
 </Card>
 <Card title="UI Kit" href="/ui-kits/react-native-ui-kit/">
 Explore our React Native UI Kit with pre-built components

--- a/content/docs/start-building/build-with-ai.mdx
+++ b/content/docs/start-building/build-with-ai.mdx
@@ -1,0 +1,136 @@
+---
+title: Build with AI
+description: Connect AI assistants to WDK docs, project rules, and wallet tools for faster app development.
+docType: how-to
+schemaType: TechArticle
+icon: Bot
+---
+
+WDK documentation is optimized for AI coding assistants. Give your AI tool context about WDK to get accurate code generation, architecture guidance, and debugging help.
+
+Use this page as the starting point for building WDK apps with AI assistance.
+
+<Cards>
+<Card title="MCP Toolkit" href="/ai/mcp-toolkit">
+Give AI agents access to WDK wallet tools through MCP
+</Card>
+<Card title="Agent Skills" href="/ai/agent-skills">
+Use WDK instructions with agentic coding tools
+</Card>
+<Card title="OpenClaw" href="/ai/openclaw">
+Install the community WDK skill in OpenClaw
+</Card>
+<Card title="x402" href="/ai/x402">
+Build AI payment flows with WDK wallets
+</Card>
+</Cards>
+
+There are two practical ways to provide WDK context to your AI:
+
+1. **[Connect via Markdown](#connect-wdk-docs-via-markdown)** - Works with any AI tool. Feed documentation directly into the context window.
+2. **[Add WDK project rules](#add-wdk-project-rules-optional)** - Give your AI assistant persistent context about package names, architecture, and coding patterns.
+
+<Callout type="info">
+**Want to give AI agents wallet access?** The [MCP Toolkit](/ai/mcp-toolkit) creates an MCP server that exposes WDK wallets as tools, letting AI agents check balances, send transactions, swap tokens, bridge assets, and more.
+</Callout>
+
+---
+
+## Connect WDK Docs via Markdown
+
+If your AI tool does not support a docs-specific connector, you can feed WDK documentation directly into the context window using these endpoints:
+
+| Endpoint | URL | Description |
+|---|---|---|
+| Page index | [docs.wdk.tether.io/llms.txt](/llms.txt) | Index of all page URLs and titles |
+| Full docs | [docs.wdk.tether.io/llms-full.txt](/llms-full.txt) | Complete documentation in one file |
+
+You can also append `.md` to any documentation page URL to get raw Markdown, ready to paste into a chat context window.
+
+---
+
+## Add WDK Project Rules (Optional)
+
+Project rules give your AI assistant persistent context about WDK conventions, package naming, and common patterns. This is optional, but recommended for teams working extensively with WDK.
+
+Copy the rules content below and save it at the file path for your tool.
+
+### Rules Content
+
+````markdown
+# WDK Development Rules
+
+## Package Structure
+- All WDK packages are published under the `@tetherto` scope on npm.
+- Core module: `@tetherto/wdk`.
+- Wallet modules follow the pattern: `@tetherto/wdk-wallet-<chain>`.
+  - Examples: `@tetherto/wdk-wallet-evm`, `@tetherto/wdk-wallet-btc`, `@tetherto/wdk-wallet-solana`, `@tetherto/wdk-wallet-ton`, `@tetherto/wdk-wallet-tron`, `@tetherto/wdk-wallet-spark`.
+- Specialized wallet modules: `@tetherto/wdk-wallet-evm-erc4337`, `@tetherto/wdk-wallet-ton-gasless`, `@tetherto/wdk-wallet-tron-gasfree`.
+- Protocol modules follow the pattern: `@tetherto/wdk-protocol-<type>-<name>-<chain>`.
+  - Examples: `@tetherto/wdk-protocol-swap-velora-evm`, `@tetherto/wdk-protocol-bridge-usdt0-evm`, `@tetherto/wdk-protocol-lending-aave-evm`.
+
+## Platform Notes
+- For Node.js or Bare runtime: use `@tetherto/wdk` as the orchestrator, then register individual wallet modules.
+- For React Native: use the React Native provider package for convenience, or use WDK packages directly in the Hermes runtime.
+
+## Architecture
+- WDK is modular: each blockchain and protocol is a separate npm package.
+- Wallet modules expose `WalletManager`, `WalletAccount`, and `WalletAccountReadOnly` classes.
+- `WalletAccount` extends `WalletAccountReadOnly`, so it has all read-only methods plus write methods such as sign and send.
+- All modules follow a consistent pattern: configuration, initialization, usage.
+
+## Documentation
+- Official docs: [docs.wdk.tether.io](/)
+- For any WDK question, consult the official documentation before making assumptions.
+- API references, configuration guides, and usage examples are available for every module.
+````
+
+### Where to Save
+
+| AI Coding Assistant | File Path | Notes |
+|---|---|---|
+| Cursor | `.cursor/rules/wdk.mdc` | Project-level, auto-attached |
+| Claude Code | `CLAUDE.md` | Place in project root |
+| Windsurf | `.windsurf/rules/wdk.md` | Project-level rules |
+| GitHub Copilot | `.github/copilot-instructions.md` | Project-level instructions |
+| Cline | `.clinerules` | Place in project root |
+| Continue | `.continuerules` | Place in project root |
+
+---
+
+## Agent Guidelines in WDK Repos
+
+Each WDK package repository can include an `AGENTS.md` file in its root. This file gives AI agents context about project structure, coding conventions, testing patterns, and linting rules.
+
+If your AI tool has access to WDK source repositories through a local clone, it can use `AGENTS.md` for additional context beyond the documentation.
+
+---
+
+## Example Prompt
+
+Use a prompt like this to generate a multi-chain wallet with WDK. Include `/llms-full.txt` or the relevant quickstart pages in context for best results:
+
+```txt
+Create a Node.js app using WDK (@tetherto/wdk) that:
+1. Creates a multi-chain wallet supporting Bitcoin and Polygon.
+2. Uses @tetherto/wdk-wallet-btc for Bitcoin and @tetherto/wdk-wallet-evm for Polygon.
+3. Generates wallet addresses for both chains.
+4. Retrieves the balance for each address.
+5. Uses a mnemonic from environment variables.
+
+Check the WDK documentation for the correct configuration and initialization pattern.
+```
+
+---
+
+## Tips for Effective AI-Assisted Development
+
+- **Be specific about the chain.** Tell the AI which blockchain you are targeting, such as "I am building on Ethereum using `@tetherto/wdk-wallet-evm`."
+- **Reference the exact package name.** Mention the full `@tetherto/wdk-*` package name in your prompt for more accurate code generation.
+- **Ask the AI to check docs first.** Prompt with "Check the WDK documentation before answering" to make it use the docs context instead of older training data.
+- **Start with a quickstart.** Point the AI at the [Node.js & Bare Quickstart](/start-building/nodejs-bare-quickstart) or [React Native Quickstart](/start-building/react-native-quickstart) as a working reference before building custom features.
+- **Iterate in steps.** Use the AI to scaffold your WDK integration first, then refine module configuration and error handling in follow-up prompts.
+
+## Need Help?
+
+<SupportCards />

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "check-links": "node scripts/check-links.js",
     "check:links": "node scripts/check-links.mjs",
     "check:meta": "node scripts/check-meta.mjs",
-    "quality": "npm run check:meta && npm run check:links && npm run build"
+    "check:redirects": "node scripts/check-redirects.mjs",
+    "quality": "npm run check:meta && npm run check:redirects && npm run check:links && npm run build"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.29",

--- a/scripts/check-redirects.mjs
+++ b/scripts/check-redirects.mjs
@@ -31,8 +31,13 @@ const expectedRedirects = [
     status: '301',
   },
   {
-    source: '/sdk/lending-aave-evm/',
+    source: '/sdk/lending-aave-evm',
     target: '/sdk/lending-modules/lending-aave-evm',
+    status: '301',
+  },
+  {
+    source: '/sdk/lending-aave-evm/',
+    target: '/sdk/lending-modules/lending-aave-evm/',
     status: '301',
   },
   {
@@ -168,18 +173,18 @@ function validateModuleRedirectShape(redirects, failures) {
 
   for (const { source, target } of moduleRedirects) {
     const bareRule = bySource.get(source);
-    if (bareRule) {
+    if (!bareRule || bareRule.target !== target || bareRule.status !== '301') {
       failures.push({
-        line: bareRule.line,
-        reason: `Module alias "${source}" should use only the trailing-slash and splat rules.`,
+        line: bareRule?.line ?? 0,
+        reason: `Missing module landing redirect: ${source} -> ${target} 301`,
       });
     }
 
     const indexRule = bySource.get(`${source}/`);
-    if (!indexRule || indexRule.target !== target || indexRule.status !== '301') {
+    if (indexRule) {
       failures.push({
-        line: indexRule?.line ?? 0,
-        reason: `Missing module landing redirect: ${source}/ -> ${target} 301`,
+        line: indexRule.line,
+        reason: `Module alias "${source}/" should be covered by the splat rule.`,
       });
     }
 

--- a/scripts/check-redirects.mjs
+++ b/scripts/check-redirects.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const redirectsPath = path.join(repoRoot, '_redirects');
+const docsRoot = path.join(repoRoot, 'content', 'docs');
+const publicRoot = path.join(repoRoot, 'public');
+
+const moduleRedirects = [
+  ['/sdk/wallet-evm', '/sdk/wallet-modules/wallet-evm'],
+  ['/sdk/wallet-evm-erc-4337', '/sdk/wallet-modules/wallet-evm-erc-4337'],
+  ['/sdk/wallet-btc', '/sdk/wallet-modules/wallet-btc'],
+  ['/sdk/wallet-solana', '/sdk/wallet-modules/wallet-solana'],
+  ['/sdk/wallet-ton', '/sdk/wallet-modules/wallet-ton'],
+  ['/sdk/wallet-ton-gasless', '/sdk/wallet-modules/wallet-ton-gasless'],
+  ['/sdk/wallet-tron', '/sdk/wallet-modules/wallet-tron'],
+  ['/sdk/wallet-tron-gasfree', '/sdk/wallet-modules/wallet-tron-gasfree'],
+  ['/sdk/wallet-spark', '/sdk/wallet-modules/wallet-spark'],
+  ['/sdk/swap-velora-evm', '/sdk/swap-modules/swap-velora-evm'],
+  ['/sdk/bridge-usdt0-evm', '/sdk/bridge-modules/bridge-usdt0-evm'],
+  ['/sdk/lending-aave-evm', '/sdk/lending-modules/lending-aave-evm'],
+  ['/sdk/fiat-moonpay', '/sdk/fiat-modules/fiat-moonpay'],
+].map(([source, target]) => ({ source, target }));
+
+const expectedRedirects = [
+  {
+    source: '/examples-and-starters/tools/indexer-api/get-started',
+    target: '/tools/indexer-api/get-started',
+    status: '301',
+  },
+  {
+    source: '/sdk/lending-aave-evm/',
+    target: '/sdk/lending-modules/lending-aave-evm',
+    status: '301',
+  },
+  {
+    source: '/sdk/lending-aave-evm/api-reference',
+    target: '/sdk/lending-modules/lending-aave-evm/api-reference',
+    status: '301',
+  },
+  {
+    source: '/sdk/bridge-usdt0-evm/guides/get-started',
+    target: '/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started',
+    status: '301',
+  },
+  {
+    source: '/sdk/wallet-evm/guides/getting-started',
+    target: '/sdk/wallet-modules/wallet-evm/guides/getting-started',
+    status: '301',
+  },
+];
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+async function listFiles(rootDir, predicate) {
+  if (!fs.existsSync(rootDir)) return [];
+
+  const results = [];
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = await fs.promises.readdir(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (entry.isFile() && predicate(full)) {
+        results.push(full);
+      }
+    }
+  }
+
+  return results.sort((a, b) => a.localeCompare(b));
+}
+
+function routeFromDocFile(filePath) {
+  let relativePath = toPosix(path.relative(docsRoot, filePath)).replace(/\.mdx$/, '');
+  if (relativePath === 'index') return '/';
+  if (relativePath.endsWith('/index')) {
+    relativePath = relativePath.slice(0, -'/index'.length);
+  }
+  return `/${relativePath}`;
+}
+
+function normalizeRoute(route) {
+  if (route === '/') return route;
+  return route.replace(/\/+$/, '');
+}
+
+function stripTargetDecorations(target) {
+  return target.split(/[?#]/, 1)[0];
+}
+
+function targetRouteForValidation(target) {
+  const cleanTarget = stripTargetDecorations(target);
+  if (cleanTarget.includes(':splat')) {
+    return normalizeRoute(cleanTarget.replace(/\/:splat.*$/, ''));
+  }
+  return normalizeRoute(cleanTarget);
+}
+
+async function buildValidTargets() {
+  const docFiles = await listFiles(docsRoot, (filePath) => filePath.endsWith('.mdx'));
+  const publicFiles = await listFiles(publicRoot, () => true);
+
+  const targets = new Set(docFiles.map(routeFromDocFile));
+
+  for (const filePath of publicFiles) {
+    targets.add(`/${toPosix(path.relative(publicRoot, filePath))}`);
+  }
+
+  return targets;
+}
+
+function parseRedirects(raw) {
+  const redirects = [];
+
+  raw.split(/\r?\n/).forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return;
+
+    const parts = trimmed.split(/\s+/);
+    redirects.push({
+      line: index + 1,
+      source: parts[0],
+      target: parts[1],
+      status: parts.find((part) => /^\d{3}!?$/.test(part)),
+      options: parts.slice(2),
+    });
+  });
+
+  return redirects;
+}
+
+function resolveRedirect(redirects, sourcePath) {
+  for (const redirect of redirects) {
+    if (redirect.source.endsWith('/*')) {
+      const prefix = redirect.source.slice(0, -1);
+      if (!sourcePath.startsWith(prefix)) continue;
+
+      return {
+        ...redirect,
+        resolvedTarget: redirect.target.replace(':splat', sourcePath.slice(prefix.length)),
+      };
+    }
+
+    if (redirect.source === sourcePath) {
+      return {
+        ...redirect,
+        resolvedTarget: redirect.target,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function validateModuleRedirectShape(redirects, failures) {
+  const bySource = new Map(redirects.map((redirect) => [redirect.source, redirect]));
+
+  for (const { source, target } of moduleRedirects) {
+    const bareRule = bySource.get(source);
+    if (bareRule) {
+      failures.push({
+        line: bareRule.line,
+        reason: `Module alias "${source}" should use only the trailing-slash and splat rules.`,
+      });
+    }
+
+    const indexRule = bySource.get(`${source}/`);
+    if (!indexRule || indexRule.target !== target || indexRule.status !== '301') {
+      failures.push({
+        line: indexRule?.line ?? 0,
+        reason: `Missing module landing redirect: ${source}/ -> ${target} 301`,
+      });
+    }
+
+    const splatRule = bySource.get(`${source}/*`);
+    if (!splatRule || splatRule.target !== `${target}/:splat` || splatRule.status !== '301') {
+      failures.push({
+        line: splatRule?.line ?? 0,
+        reason: `Missing module nested redirect: ${source}/* -> ${target}/:splat 301`,
+      });
+    }
+  }
+}
+
+async function run() {
+  if (!fs.existsSync(redirectsPath)) {
+    console.log('✅ check-redirects: no _redirects file found.');
+    return;
+  }
+
+  const validTargets = await buildValidTargets();
+  const redirects = parseRedirects(await fs.promises.readFile(redirectsPath, 'utf8'));
+  const seenSources = new Map();
+  const failures = [];
+
+  for (const redirect of redirects) {
+    if (!redirect.source || !redirect.target) {
+      failures.push({ line: redirect.line, reason: 'Redirect rule must include source and target.' });
+      continue;
+    }
+
+    if (seenSources.has(redirect.source)) {
+      failures.push({
+        line: redirect.line,
+        reason: `Duplicate source path "${redirect.source}" also appears on line ${seenSources.get(redirect.source)}.`,
+      });
+    } else {
+      seenSources.set(redirect.source, redirect.line);
+    }
+
+    if (!redirect.source.startsWith('/')) {
+      failures.push({ line: redirect.line, reason: `Source path must start with "/": ${redirect.source}` });
+    }
+
+    if (/^https?:\/\//.test(redirect.target)) continue;
+
+    if (!redirect.target.startsWith('/')) {
+      failures.push({ line: redirect.line, reason: `Internal target must start with "/": ${redirect.target}` });
+      continue;
+    }
+
+    const targetRoute = targetRouteForValidation(redirect.target);
+    if (!validTargets.has(targetRoute)) {
+      failures.push({
+        line: redirect.line,
+        reason: `Target route does not exist in content/docs or public: ${redirect.target}`,
+      });
+    }
+  }
+
+  validateModuleRedirectShape(redirects, failures);
+
+  for (const expected of expectedRedirects) {
+    const redirect = resolveRedirect(redirects, expected.source);
+    if (!redirect) {
+      failures.push({
+        line: 0,
+        reason: `Expected redirect did not match any rule: ${expected.source}`,
+      });
+      continue;
+    }
+
+    if (redirect.resolvedTarget !== expected.target || redirect.status !== expected.status) {
+      failures.push({
+        line: redirect.line,
+        reason:
+          `Expected ${expected.source} -> ${expected.target} ${expected.status}, ` +
+          `got ${redirect.resolvedTarget} ${redirect.status ?? ''}`.trim(),
+      });
+    }
+  }
+
+  if (failures.length === 0) {
+    console.log(
+      `✅ check-redirects: validated ${redirects.length} redirect rule(s) ` +
+      `and ${expectedRedirects.length} expected match(es).`,
+    );
+    return;
+  }
+
+  console.error(`❌ check-redirects: found ${failures.length} redirect issue(s):\n`);
+  for (const failure of failures) {
+    console.error(failure.line > 0 ? `- _redirects:${failure.line}` : '- _redirects');
+    console.error(`  reason: ${failure.reason}`);
+  }
+  process.exitCode = 1;
+}
+
+run().catch((error) => {
+  console.error(`❌ check-redirects failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -19,6 +19,7 @@ export const customTree: Node[] = [
   },
   { name: 'Node.js & Bare Quickstart', url: '/start-building/nodejs-bare-quickstart', type: 'page', icon: resolveIcon('Terminal') },
   { name: 'React Native Quickstart', url: '/start-building/react-native-quickstart', type: 'page', icon: resolveIcon('Smartphone') },
+  { name: 'Build with AI', url: '/start-building/build-with-ai', type: 'page', icon: resolveIcon('Bot') },
   {
     type: 'separator',
     name: 'AI',


### PR DESCRIPTION
## Summary
- Add repo-root Sevalla `_redirects` with permanent redirects for the bad Indexer API URL pattern reported in #146.
- Keep Eugene’s compact two-rule module alias shape: `/sdk/wallet-evm` for module landing pages and `/sdk/wallet-evm/*` -> `/sdk/wallet-modules/wallet-evm/:splat` for trailing-slash and nested paths.
- Restore the marketing-friendly `Build with AI` page at `/start-building/build-with-ai`, add it back to Start Building navigation, and link it from the homepage Start Building cards.
- Add `npm run check:redirects` to `npm run quality` so duplicate sources, missing redirect targets, expected behavior, and module redirect shape are caught.

Fixes #146

## Validation
- `npm ci`
- `git diff --check`
- `npm run check:redirects` (29 rules, 6 expected matches)
- `npm run quality` (passes; 0 broken links, existing external-link and SEO warnings only)
- Static export redirect test over `dist`: 29 redirect rules, 39 module alias probes, 3 Indexer probes, and exact redirect targets followed to 200.
- Static export `Build with AI` link sweep: 45 rendered internal hrefs checked, important card/footer/LLM links present, 0 failures.
- Browser click-through on the static export: homepage card, four AI cards, and generated previous/next footer links all reached the expected pages/H1s.
- OG image checked for `/start-building/build-with-ai`: generated `1200x630` WebP at `/og/docs/start-building/build-with-ai/image.webp`, page meta points to it, and the card text renders without truncation.

## Redirect testing note
Local `next dev` does not process Sevalla `_redirects`, so final platform behavior should still be canaried on a Sevalla preview or production deploy. The redirect behavior claimed by this PR is locally covered by `npm run check:redirects` and the static-export redirect emulator against `dist`.
