### PR TITLE
Align community module package links

### DIFF
--- a/content/docs/sdk/community-modules/index.mdx
+++ b/content/docs/sdk/community-modules/index.mdx
@@ -17,8 +17,8 @@ Tether and the WDK Team do not endorse or assume responsibility for their code, 
 
 | Module | Type | Description | Author |
 |--------|------|-------------|--------|
-| [@utexo/wdk-wallet-rgb](https://github.com/UTEXO-Protocol/wdk-wallet-rgb) | Wallet Module | Wallet module for RGB, Bitcoin-based smart contracts | [UTEXO](https://github.com/UTEXO-Protocol) |
-| [@base58-io/wdk-wallet-cosmos](https://github.com/base58-io/wdk-wallet-cosmos) | Wallet Module | Wallet module for Cosmos-compatible blockchains | [Base58](https://base58.io/) |
+| [@utexo/wdk-wallet-rgb](https://www.npmjs.com/package/@utexo/wdk-wallet-rgb) ([GitHub](https://github.com/UTEXO-Protocol/wdk-wallet-rgb)) | Wallet Module | Wallet module for RGB, Bitcoin-based smart contracts | [UTEXO](https://github.com/UTEXO-Protocol) |
+| [@base58-io/wdk-wallet-cosmos](https://www.npmjs.com/package/@base58-io/wdk-wallet-cosmos) ([GitHub](https://github.com/base58-io/wdk-wallet-cosmos)) | Wallet Module | Wallet module for Cosmos-compatible blockchains | [Base58](https://base58.io/) |
 | [@morpho-org/wdk-protocol-lending-morpho-evm](https://www.npmjs.com/package/@morpho-org/wdk-protocol-lending-morpho-evm) ([GitHub](https://github.com/morpho-org/sdks/tree/main/packages/wdk-protocol-lending-morpho-evm)) | Lending Module | Morpho EVM lending module for vault deposits, collateral supply, borrowing, repayment, and position reads | [Morpho Association](https://morpho.org/) |
 
 ---


### PR DESCRIPTION
## Summary
- Link the RGB community module package name to npm and add a separate GitHub repo link.
- Link the Cosmos community module package name to npm and add a separate GitHub repo link.

## Validation
- npm view @utexo/wdk-wallet-rgb name version repository.url --json
- npm view @base58-io/wdk-wallet-cosmos name version repository.url --json
- npm run check:meta
- npm run check:links (0 broken links; existing npm 403 warnings remain warnings)
- npm run build (passed; existing docType SEO warnings remain)
