### PR TITLE
docs: simplify quickstart examples and make them bare-friendly

### DIFF
--- a/content/docs/sdk/core-module/guides/account-management.mdx
+++ b/content/docs/sdk/core-module/guides/account-management.mdx
@@ -56,12 +56,8 @@ console.log('Ethereum address:', ethAddress)
 You can check the native token balance of any account (e.g., ETH on Ethereum, TON on TON) by using the `getBalance()` function.
 
 ```typescript title="Get Balance"
-try {
-  const balance = await ethAccount.getBalance()
-  console.log('Balance:', balance)
-} catch (error) {
-  console.error('Failed to fetch balance:', error)
-}
+const balance = await ethAccount.getBalance()
+console.log('Balance:', balance)
 ```
 
 ### Multi-Chain Balance Check
@@ -78,13 +74,9 @@ The following example:
 const chains = ['ethereum', 'ton', 'bitcoin']
 
 for (const chain of chains) {
-  try {
-    const account = await wdk.getAccount(chain, 0)
-    const balance = await account.getBalance()
-    console.log(`${chain} balance:`, balance)
-  } catch (error) {
-    console.log(`${chain}: Wallet not registered or unavailable`)
-  }
+  const account = await wdk.getAccount(chain, 0)
+  const balance = await account.getBalance()
+  console.log(`${chain} balance:`, balance)
 }
 ```
 

--- a/content/docs/start-building/nodejs-bare-quickstart.mdx
+++ b/content/docs/start-building/nodejs-bare-quickstart.mdx
@@ -95,24 +95,14 @@ import WalletManagerBtc from '@tetherto/wdk-wallet-btc'
 
 console.log('Starting WDK App...')
 
-try {
-  // Your code will go here
-} catch (error) {
-  console.error('Application error:', error.message)
-  process.exit(1)
-}
+// Your code will go here
 ```
 
 Now, add the following code to generate a seed phrase:
 
 ```typescript title="app.js"
-try {
-  const seedPhrase = WDK.getRandomSeedPhrase()
-  console.log('Generated seed phrase:', seedPhrase)
-} catch (error) {
-  console.error('Application error:', error.message)
-  process.exit(1)
-}
+const seedPhrase = WDK.getRandomSeedPhrase()
+console.log('Generated seed phrase:', seedPhrase)
 ```
 
 Now, let's register wallets for different blockchains:
@@ -190,53 +180,50 @@ import WalletManagerBtc from '@tetherto/wdk-wallet-btc'
 
 console.log('Starting WDK App...')
 
-try {
-  const seedPhrase = WDK.getRandomSeedPhrase()
-  console.log('Generated seed phrase:', seedPhrase)
+const seedPhrase = WDK.getRandomSeedPhrase()
+console.log('Generated seed phrase:', seedPhrase)
 
-  console.log('Registering wallets...')
+console.log('Registering wallets...')
 
-  const wdkWithWallets = new WDK(seedPhrase)
-    .registerWallet('ethereum', WalletManagerEvm, {
-      provider: 'https://eth.drpc.org'
-    })
-    .registerWallet('tron', WalletManagerTron, {
-      provider: 'https://api.trongrid.io'
-    })
-    .registerWallet('bitcoin', WalletManagerBtc, {
-      network: 'mainnet',
-      host: 'electrum.blockstream.info',
-      port: 50001
-    })
+const wdkWithWallets = new WDK(seedPhrase)
+  .registerWallet('ethereum', WalletManagerEvm, {
+    provider: 'https://eth.drpc.org'
+  })
+  .registerWallet('tron', WalletManagerTron, {
+    provider: 'https://api.trongrid.io'
+  })
+  .registerWallet('bitcoin', WalletManagerBtc, {
+    network: 'mainnet',
+    host: 'electrum.blockstream.info',
+    port: 50001
+  })
 
-  console.log('Wallets registered for Ethereum, TRON, and Bitcoin')
+console.log('Wallets registered for Ethereum, TRON, and Bitcoin')
 
-  const accounts = {
-    ethereum: await wdkWithWallets.getAccount('ethereum', 0),
-    tron: await wdkWithWallets.getAccount('tron', 0),
-    bitcoin: await wdkWithWallets.getAccount('bitcoin', 0)
-  }
-
-  console.log('Resolving addresses:')
-
-  for (const [chain, account] of Object.entries(accounts)) {
-    const address = await account.getAddress()
-    console.log(`   ${chain.toUpperCase()}: ${address}`)
-  }
-
-  console.log('Checking balances...')
-
-  for (const [chain, account] of Object.entries(accounts)) {
-    const balance = await account.getBalance()
-    console.log(`   ${chain.toUpperCase()}: ${balance.toString()} units`)
-  }
-
-  console.log('Application completed successfully!')
-  process.exit(0)
-} catch (error) {
-  console.error('Application error:', error.message)
-  process.exit(1)
+const accounts = {
+  ethereum: await wdkWithWallets.getAccount('ethereum', 0),
+  tron: await wdkWithWallets.getAccount('tron', 0),
+  bitcoin: await wdkWithWallets.getAccount('bitcoin', 0)
 }
+
+console.log('Resolving addresses:')
+
+for (const [chain, account] of Object.entries(accounts)) {
+  const address = await account.getAddress()
+  console.log(`   ${chain.toUpperCase()}: ${address}`)
+}
+
+console.log('Checking balances...')
+
+for (const [chain, account] of Object.entries(accounts)) {
+  const balance = await account.getBalance()
+  console.log(`   ${chain.toUpperCase()}: ${balance.toString()} units`)
+}
+
+console.log('Application completed successfully!')
+
+// Close all wallet connections so the program can exit
+wdkWithWallets.dispose()
 ```
 
 ***
@@ -319,15 +306,11 @@ wdk.registerWallet('solana', WalletManagerSolana, {
 
 ```typescript
 for (const [chain, account] of Object.entries(accounts)) {
-  try {
-    const quote = await account.quoteSendTransaction({
-      to: await account.getAddress(),
-      value: chain === 'bitcoin' ? 100000000n : chain === 'tron' ? 1000000n : 1000000000000000000n
-    })
-    console.log(`   ${chain.toUpperCase()}: ${quote.fee.toString()} units`)
-  } catch (error) {
-    console.log(`   ${chain.toUpperCase()}: Unable to estimate`)
-  }
+  const quote = await account.quoteSendTransaction({
+    to: await account.getAddress(),
+    value: chain === 'bitcoin' ? 100000000n : chain === 'tron' ? 1000000n : 1000000000000000000n
+  })
+  console.log(`   ${chain.toUpperCase()}: ${quote.fee.toString()} units`)
 }
 ```
 


### PR DESCRIPTION
Cleans up the Node/Bare quickstart and account management snippets:

- Drop the try/catch wrappers that were just noise in the example flow (kept them in the dedicated error-handling guides and where they actually demonstrate a guard).
- Use `wdk.dispose()` to close wallet connections instead of `process.exit()`, since `process` isn't available in Bare by default. The complete quickstart now runs and exits cleanly under both `node app.js` and `bare app.js`.