### PR TITLE
docs: update core and utils release docs

### DIFF
--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,14 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 04, 2026
+
+**What's New**
+- **wdk-utils** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.5)): Restore BOLT11 invoice support with exported `validateLightningInvoice()`, `decode()`, `getHashToSign()`, `sign()`, and `encode()` helpers, including fallback address, routing info, feature bits, and `lightning:` prefix handling.
+- **wdk-core** ([v1.0.0-beta.10](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.10)): Add swidge protocol support to global and account-level `registerProtocol()` calls, expose `getSwidgeProtocol()`, preserve account-scoped protocols across repeated account lookups, and reject duplicate `registerWallet()` calls until the existing wallet is disposed.
+
+---
+
 ### June 02, 2026
 
 **What's New**

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -43,7 +43,7 @@ const wdk2 = new WDK(seedBytes)
 
 | Method | Description | Returns | Throws |
 |--------|-------------|---------|--------|
-| `registerWallet(blockchain, wallet, config)` | Registers a new wallet manager for a blockchain | `WDK` | - |
+| `registerWallet(blockchain, wallet, config)` | Registers a new wallet manager for a blockchain | `WDK` | If a wallet is already registered for that blockchain |
 | `registerProtocol(blockchain, label, protocol, config)` | Registers a protocol globally for a blockchain | `WDK` | - |
 | `registerMiddleware(blockchain, middleware)` | Registers middleware for account decoration | `WDK` | - |
 | `getAccount(blockchain, index?)` | Returns a wallet account for a blockchain and index | `Promise<IWalletAccountWithProtocols>` | If wallet not registered |
@@ -63,6 +63,8 @@ Registers a new wallet manager for a specific blockchain.
 - `config` (`ConstructorParameters<W>[1]`): The configuration object for the wallet
 
 **Returns:** `WDK` - The wdk manager instance (supports method chaining)
+
+**Throws:** Error if a wallet is already registered for the same blockchain. Call `dispose([blockchain])` before registering a replacement wallet for that blockchain.
 
 **Example:**
 ```javascript title="Register Wallets"
@@ -92,8 +94,10 @@ const wdk2 = new WDK(seedPhrase)
 ##### `registerProtocol(blockchain, label, protocol, config)`
 Registers a protocol globally for all accounts of a specific blockchain.
 
+For swidge integrations, pass a concrete provider class that extends `SwidgeProtocol` from `@tetherto/wdk-wallet/protocols`.
+
 **Type Parameters:**
-- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocol`'s classes
+- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol | typeof FiatProtocol | typeof SwidgeProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocols` classes
 
 **Parameters:**
 - `blockchain` (string): The name of the blockchain
@@ -115,6 +119,9 @@ wdk.registerProtocol('ethereum', 'velora', veloraProtocolEvm, {
 
 // Register bridge protocol for Ethereum
 wdk.registerProtocol('ethereum', 'usdt0', Usdt0ProtocolEvm)
+
+// Register a concrete swidge provider for Ethereum
+wdk.registerProtocol('ethereum', 'swidge', MySwidgeProtocol, swidgeProtocolConfig)
 
 // Method chaining
 const wdk2 = new WDK(seedPhrase)
@@ -326,12 +333,14 @@ Extended wallet account interface that supports protocol registration and access
 | `getSwapProtocol(label)` | Returns the swap protocol with the given label | `ISwapProtocol` | If protocol not found |
 | `getBridgeProtocol(label)` | Returns the bridge protocol with the given label | `IBridgeProtocol` | If protocol not found |
 | `getLendingProtocol(label)` | Returns the lending protocol with the given label | `ILendingProtocol` | If protocol not found |
+| `getFiatProtocol(label)` | Returns the fiat protocol with the given label | `IFiatProtocol` | If protocol not found |
+| `getSwidgeProtocol(label)` | Returns the swidge protocol with the given label | `ISwidgeProtocol` | If protocol not found |
 
 ##### `registerProtocol(label, protocol, config)`
 Registers a new protocol for this specific account.
 
 **Type Parameters:**
-- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocol`'s classes
+- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol | typeof FiatProtocol | typeof SwidgeProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocols` classes
 
 **Parameters:**
 - `label` (string): Unique label for the protocol (must be unique per account and protocol type)
@@ -451,6 +460,61 @@ const aave = account.getLendingProtocol('aave')
 const supplyResult = await aave.supply({
   token: '0x...',
   amount: 1000000n
+})
+```
+
+##### `getFiatProtocol(label)`
+Returns the fiat protocol with the given label.
+
+**Parameters:**
+- `label` (string): The protocol label
+
+**Returns:** `IFiatProtocol` - The fiat protocol instance
+
+**Throws:** Error if no fiat protocol with the given label has been registered
+
+**Example:**
+```javascript title="Get Fiat Protocol"
+import MoonPayProtocol from '@tetherto/wdk-protocol-fiat-moonpay'
+
+// Register fiat protocol
+account.registerProtocol('moonpay', MoonPayProtocol, moonpayProtocolConfig)
+
+// Get fiat protocol
+const moonpay = account.getFiatProtocol('moonpay')
+
+const buyUrl = await moonpay.buy({
+  cryptoAsset: 'usdt',
+  fiatCurrency: 'usd',
+  fiatAmount: 10000n
+})
+```
+
+##### `getSwidgeProtocol(label)`
+Returns the swidge protocol with the given label.
+
+The examples below use `MySwidgeProtocol` as the concrete provider class supplied by your swidge provider module.
+
+**Parameters:**
+- `label` (string): The protocol label
+
+**Returns:** `ISwidgeProtocol` - The swidge protocol instance
+
+**Throws:** Error if no swidge protocol with the given label has been registered
+
+**Example:**
+```javascript title="Get Swidge Protocol"
+// Register a concrete provider class that extends SwidgeProtocol
+account.registerProtocol('swidge', MySwidgeProtocol, swidgeProtocolConfig)
+
+// Get swidge protocol
+const swidge = account.getSwidgeProtocol('swidge')
+
+const quote = await swidge.quoteSwidge({
+  fromToken: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  toToken: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+  toChain: 'arbitrum',
+  fromTokenAmount: 1000000n
 })
 ```
 

--- a/content/docs/sdk/core-module/guides/protocol-integration.mdx
+++ b/content/docs/sdk/core-module/guides/protocol-integration.mdx
@@ -54,13 +54,16 @@ const wdk = new WDK(seedPhrase)
 
 ## Use Protocols
 
-Once [registered](#register-protocols), you can access the protocol instance using the specific getter methods, such as `getSwapProtocol`, `getBridgeProtocol`, `getLendingProtocol`, or `getFiatProtocol`.
+Once [registered](#register-protocols), you can access the protocol instance using the specific getter methods, such as [`getSwidgeProtocol()`](/sdk/core-module/api-reference#getswidgeprotocollabel), `getSwapProtocol`, `getBridgeProtocol`, `getLendingProtocol`, or `getFiatProtocol`.
 
 ### Swidge Routes
 
-Use a swidge provider module for new swap, bridge, or combined route integrations. The shared swidge interface discovers supported chains and tokens with `getSupportedChains()` and `getSupportedTokens()`, quotes with `quoteSwidge()`, executes with `swidge()`, and tracks asynchronous settlement with `getSwidgeStatus()`. The provider can decide whether the route is fulfilled as a same-chain swap, same-token bridge, combined route, intent, solver route, or aggregator route. The example below assumes `swidge` is an instance of a concrete provider module that implements the shared interface.
+Use a swidge provider module for new swap, bridge, or combined route integrations. Retrieve a registered provider with [`getSwidgeProtocol()`](/sdk/core-module/api-reference#getswidgeprotocollabel). The shared swidge interface discovers supported chains and tokens with `getSupportedChains()` and `getSupportedTokens()`, quotes with `quoteSwidge()`, executes with `swidge()`, and tracks asynchronous settlement with `getSwidgeStatus()`. The provider can decide whether the route is fulfilled as a same-chain swap, same-token bridge, combined route, intent, solver route, or aggregator route.
 
 ```typescript title="Swidge route flow"
+const account = await wdk.getAccount('ethereum', 0)
+const swidge = account.getSwidgeProtocol('swidge')
+
 const chains = await swidge.getSupportedChains()
 const tokens = await swidge.getSupportedTokens({
   fromChain: 'ethereum',

--- a/content/docs/tools/wdk-utils/api-reference.mdx
+++ b/content/docs/tools/wdk-utils/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils API Reference
-description: API for @tetherto/wdk-utils
+description: Validation, BOLT11, and EIP-681 APIs for @tetherto/wdk-utils
 docType: reference
 schemaType: APIReference
 ---
@@ -18,6 +18,10 @@ schemaType: APIReference
 | `validateEVMAddress(address)` | Validate an EVM address, including EIP-55 checksum rules for mixed-case inputs. | `EvmAddressValidationResult` |
 | `stripLightningPrefix(input)` | Remove a leading `lightning:` prefix before other Lightning validation steps. | `string` |
 | `validateLightningInvoice(address)` | Validate a Lightning invoice string. | `LightningInvoiceValidationResult` |
+| `decode(invoice)` | Decode a BOLT11 Lightning invoice into structured invoice data. | `LightningInvoiceDecodingResult` |
+| `getHashToSign(invoiceData)` | Return the SHA-256 hash that must be signed for a BOLT11 invoice. | `LightningInvoiceHashingResult` |
+| `sign(invoiceData, privateKey)` | Sign BOLT11 invoice data with a hex string or `Uint8Array` private key. | `LightningInvoiceSigningResult` |
+| `encode(invoiceData)` | Encode BOLT11 invoice data into an invoice string. | `LightningInvoiceEncodingResult` |
 | `validateLnurl(address)` | Validate an LNURL string. | `LnurlValidationResult` |
 | `decodeLnurl(address)` | Decode an LNURL string into its original URL. | `LnurlDecodingResult` |
 | `validateLightningAddress(address)` | Validate a Lightning Address in `user@domain.tld` form. | `LightningAddressValidationResult` |
@@ -115,6 +119,72 @@ const result = validateLightningInvoice(
 `LightningInvoiceValidationResult` is one of these shapes:
 
 - `{ success: true, type: 'invoice' }`
+- `{ success: false, reason: string }`
+
+#### `decode(invoice)`
+
+Decode a BOLT11 Lightning invoice into structured invoice data. The exported function name is `decode`, so alias it at import sites when your code also decodes other payloads.
+
+Payment descriptions are user-defined. Sanitize `description` tag values before rendering them in HTML or storing them.
+
+```javascript title="Decode A BOLT11 Invoice"
+import { decode as decodeBolt11 } from '@tetherto/wdk-utils'
+
+const result = decodeBolt11(
+  'lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w'
+)
+```
+
+`LightningInvoiceDecodingResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice', data: DecodedLightningInvoice }`
+- `{ success: false, reason: string }`
+
+`DecodedLightningInvoice` includes the invoice `network` (`bitcoin`, `testnet`, `regtest`, or `signet`), optional `millisatoshis`, optional `timestamp`, optional `timeExpireDate`, optional `payeeNodeKey`, optional `signature`, optional `recoveryFlag`, required `tags`, and optional `paymentRequest`.
+
+#### `getHashToSign(invoiceData)`
+
+Return the SHA-256 hash that must be signed for a BOLT11 invoice.
+
+```javascript title="Get The Invoice Signing Hash"
+import { getHashToSign } from '@tetherto/wdk-utils'
+
+const hash = getHashToSign(invoiceData)
+```
+
+`LightningInvoiceHashingResult` is one of these shapes:
+
+- `{ success: true, type: 'hash', data: Uint8Array }`
+- `{ success: false, reason: string }`
+
+#### `sign(invoiceData, privateKey)`
+
+Sign BOLT11 invoice data. The private key can be a hex string or `Uint8Array`.
+
+```javascript title="Sign A BOLT11 Invoice"
+import { sign as signBolt11 } from '@tetherto/wdk-utils'
+
+const signed = signBolt11(invoiceData, privateKey)
+```
+
+`LightningInvoiceSigningResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice', data: DecodedLightningInvoice }`
+- `{ success: false, reason: string }`
+
+#### `encode(invoiceData)`
+
+Encode BOLT11 invoice data into an invoice string.
+
+```javascript title="Encode A BOLT11 Invoice"
+import { encode as encodeBolt11 } from '@tetherto/wdk-utils'
+
+const encoded = encodeBolt11(signed.data)
+```
+
+`LightningInvoiceEncodingResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice', data: string }`
 - `{ success: false, reason: string }`
 
 #### `validateLnurl(address)`

--- a/content/docs/tools/wdk-utils/configuration.mdx
+++ b/content/docs/tools/wdk-utils/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils Configuration
-description: Install and import validation helpers and EIP-681 parsers from @tetherto/wdk-utils
+description: Install and import validation, BOLT11, and EIP-681 helpers from @tetherto/wdk-utils
 ---
 
 This package does not have constructor options or runtime configuration. This page shows how to install `@tetherto/wdk-utils`, import the helpers you need, and understand the published runtime surface.
@@ -43,10 +43,26 @@ import {
 } from '@tetherto/wdk-utils'
 ```
 
+## Import BOLT11 helpers
+
+You can validate, decode, sign, and encode BOLT11 Lightning invoices from the package entrypoint:
+
+```javascript title="Import BOLT11 Helpers"
+import {
+  decode as decodeBolt11,
+  encode as encodeBolt11,
+  getHashToSign,
+  sign as signBolt11,
+  validateLightningInvoice
+} from '@tetherto/wdk-utils'
+```
+
 ## Runtime notes
 
 - `@tetherto/wdk-utils` exports plain functions. There is no client object to initialize.
 - The package publishes a default module entrypoint through `index.js` and a bare runtime entrypoint through `bare.js`.
+- BOLT11 helpers support invoices for `bitcoin`, `testnet`, `regtest`, and `signet` networks.
+- `decode()` returns user-provided invoice descriptions when they are present. Sanitize descriptions before rendering them in HTML or storing them.
 - `decodeLnurl()` returns the decoded URL string when parsing succeeds.
 - `parseEip681Request()` currently supports transfer requests for the schemes implemented in the published runtime: `ethereum`, `pol`, `matic`, `polygon`, `arbitrum`, and `plasma`.
 - `parseEip681Request()` accepts both `uint256` and `value` query parameters for the amount field and normalizes the parsed amount into `amountSmallest`.
@@ -67,6 +83,16 @@ const btc = validateBitcoinAddress('bc1qu9yqnhc6wjj6s62s9x0shnl5l2r7gq5cudm94r7m
 const lightning = validateLightningAddress('sprycomfort92@waletofsatoshi.com')
 const tron = validateTronAddress('TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH')
 const uma = validateUmaAddress('$you@uma.money')
+```
+
+You can decode BOLT11 invoice details before presenting a payment request:
+
+```javascript title="Decode A BOLT11 Invoice"
+import { decode as decodeBolt11 } from '@tetherto/wdk-utils'
+
+const invoice = decodeBolt11(
+  'lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w'
+)
 ```
 
 You can parse a request-shaped EIP-681 transfer string into structured data:

--- a/content/docs/tools/wdk-utils/index.mdx
+++ b/content/docs/tools/wdk-utils/index.mdx
@@ -1,14 +1,15 @@
 ---
 title: WDK Utils
-description: Address validation helpers and EIP-681 request parsers for @tetherto/wdk-utils
+description: Address validation, BOLT11 invoice, and EIP-681 request helpers for @tetherto/wdk-utils
 ---
 
-WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, plus EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, BOLT11 invoice helpers, and EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
 
 ## Features
 
 - **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Spark, Tron, and UMA inputs before you hand them to a wallet flow.
-- **LNURL decoding**: Decode LNURL strings before you display or route payment details.
+- **Lightning payment parsing**: Decode LNURL strings and BOLT11 invoices before you display or route payment details.
+- **BOLT11 invoice helpers**: Validate, decode, hash, sign, and encode BOLT11 invoices for Bitcoin, testnet, regtest, and signet flows.
 - **EIP-681 request parsing**: Detect request-shaped EIP-681 strings and parse transfer payloads into `recipient`, `tokenAddress`, `chainId`, and `amountSmallest`.
 - **No runtime setup**: Import the functions you need. The package has no constructor or runtime configuration.
 - **TypeScript support**: The published package ships typed exports for every validator and parser.
@@ -17,6 +18,7 @@ WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, 
 ## Why this matters
 
 - Validate user input early and return machine-readable failure reasons before you attempt a transaction or resolution flow.
+- Inspect BOLT11 invoice metadata, fallback addresses, routing information, and feature bits before presenting payment details.
 - Normalize EIP-681 payment links into structured transfer data that wallet UIs can inspect before execution.
 - Reuse the same helpers across Node.js and Bare-based environments without adding a larger wallet module dependency.
 


### PR DESCRIPTION
## Summary
- Adds the June 4 changelog entries for `wdk-core v1.0.0-beta.10` and `wdk-utils v1.0.0-beta.5`.
- Documents Swidge protocol support, `getSwidgeProtocol()`, duplicate wallet registration behavior, and restored BOLT11 helpers.
- Updates the related core-module and `wdk-utils` reference/configuration pages.

## Validation
- `git diff --check -- content/docs/overview/changelog.mdx content/docs/sdk/core-module/api-reference.mdx content/docs/sdk/core-module/guides/protocol-integration.mdx content/docs/tools/wdk-utils/api-reference.mdx content/docs/tools/wdk-utils/configuration.mdx content/docs/tools/wdk-utils/index.mdx`
- `npm run check:meta`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
