### PR TITLE
docs: update June release docs

### DIFF
--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,23 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 10, 2026
+
+**Fixes**
+- **wallet-evm-erc-4337** ([v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.9)): Validate cached quote nonces at send time before reusing a quoted UserOperation, re-quoting when the on-chain nonce has moved, and propagate UserOperation gas overrides through `transfer()`, `quoteTransfer()`, and `approve()`.
+
+---
+
+### June 09, 2026
+
+**What's New**
+- **pricing-bitfinex-http** ([v1.0.0-beta.3](https://github.com/tetherto/wdk-pricing-bitfinex-http/releases/tag/v1.0.0-beta.3)): Add batch FX conversion through Bitfinex's `/calc/fx/batch` endpoint, including USD-pivot fallback for fiat pairs Bitfinex does not quote directly, plus `getMultiCurrentPrices()` and `getMultiPriceData()` coverage.
+
+**Changes**
+- **pricing-provider** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-pricing-provider/releases/tag/v1.0.0-beta.5)): Mark unresolved current-price and batch-price results as nullable in the `PricingClient` base type so custom clients can return `null` for unsupported pairs without losing type information.
+
+---
+
 ### June 02, 2026
 
 **What's New**

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -12,6 +12,10 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ### June 10, 2026
 
+**What's New**
+- **wdk-wallet** ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.10)): Add `transactionMaxFee` to the base `WalletConfig` type so wallet modules can expose separate fee caps for `sendTransaction()` / `signTransaction()` flows and token `transfer()` flows.
+- **wallet-tron** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.6)): Add ordered Tron provider failover through `provider` arrays and `retries`, expose `keyPair` as a read-only view of the account keys, and return more precise TRX/TRC20 fee quotes including TRX activation fee details.
+
 **Fixes**
 - **wallet-evm-erc-4337** ([v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.9)): Validate cached quote nonces at send time before reusing a quoted UserOperation, re-quoting when the on-chain nonce has moved, and propagate UserOperation gas overrides through `transfer()`, `quoteTransfer()`, and `approve()`.
 

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -7,6 +7,15 @@ schemaType: TechArticle
 
 The Wallet Development Kit (WDK) provides a set of modules that support multiple blockchain networks. All modules share a common interface, ensuring consistent behavior across different blockchain implementations.
 
+## Shared Fee Limits
+
+Wallet modules can expose fee caps through their configuration objects. Use the chain-specific docs for exact units and supported operations.
+
+| Option | Applies to | Description |
+|--------|------------|-------------|
+| `transferMaxFee` | `transfer()` | Caps token transfer fees in the module's base fee unit. |
+| `transactionMaxFee` | `sendTransaction()` and `signTransaction()` | Caps native transaction send/sign flows separately from token transfers when the module supports that base wallet option. |
+
 ## Supported Networks
 
 This package works with multiple blockchain networks through wallet registration.

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
@@ -265,9 +265,9 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
 | `sendTransaction(tx, config?)` | Sends a transaction via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max |
 | `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | - |
-| `transfer(options, config?)` | Transfers ERC20 tokens via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max |
-| `quoteTransfer(options, config?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | - |
-| `approve(options)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | - |
+| `transfer(options, config?, txOverrides?)` | Transfers ERC20 tokens via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max |
+| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | - |
+| `approve(options, txOverrides?)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | - |
 | `getBalance()` | Returns the native token balance (in wei) | `Promise\<bigint\>` | - |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific ERC20 token | `Promise\<bigint\>` | - |
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
@@ -374,6 +374,8 @@ const fastResult = await account.sendTransaction({
 ##### `quoteSendTransaction(tx, config?)`
 Estimates the fee for a UserOperation without sending it.
 
+Quoted UserOperations are cached internally for up to 2 minutes. When a later `sendTransaction()` matches the quoted transaction, the account performs a lightweight on-chain nonce check before reuse and re-quotes if the nonce has moved.
+
 **Parameters:**
 - `tx` (EvmErc4337Transaction | EvmErc4337Transaction[]): Transaction object or array (same as sendTransaction)
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
@@ -389,7 +391,7 @@ const quote = await account.quoteSendTransaction({
 console.log('Estimated fee:', quote.fee)
 ```
 
-##### `transfer(options, config?)`
+##### `transfer(options, config?, txOverrides?)`
 Transfers ERC20 tokens via UserOperation.
 
 **Parameters:**
@@ -398,6 +400,7 @@ Transfers ERC20 tokens via UserOperation.
   - `recipient` (string): Recipient address
   - `amount` (number | bigint): Amount in token base units
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{hash: string, fee: bigint}\>` - UserOperation hash and fee
 
@@ -413,17 +416,21 @@ const result = await account.transfer({
   amount: 1000000 // 1 USD₮ (6 decimals)
 }, {
   transferMaxFee: 50000 // Override max fee for this call
+}, {
+  maxFeePerGas: 30000000000n,
+  maxPriorityFeePerGas: 2000000000n
 })
 console.log('Transfer hash:', result.hash)
 console.log('Transfer fee:', result.fee)
 ```
 
-##### `quoteTransfer(options, config?)`
+##### `quoteTransfer(options, config?, txOverrides?)`
 Estimates the fee for an ERC20 token transfer.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options (same as transfer)
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
@@ -478,7 +485,7 @@ if (paymasterBalance < 10000n) {
 }
 ```
 
-##### `approve(options)`
+##### `approve(options, txOverrides?)`
 Approves a spender to spend ERC20 tokens on behalf of the Safe account.
 
 **Parameters:**
@@ -486,6 +493,7 @@ Approves a spender to spend ERC20 tokens on behalf of the Safe account.
   - `token` (string): ERC20 token contract address
   - `spender` (string): The address allowed to spend the tokens
   - `amount` (number | bigint): Amount to approve in token base units
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{hash: string, fee: bigint}\>` - Transaction result
 
@@ -495,6 +503,9 @@ const result = await account.approve({
   token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
   spender: '0xSpenderContract...',
   amount: 1000000n // 1 USD₮
+}, {
+  callGasLimit: 90000n,
+  verificationGasLimit: 120000n
 })
 console.log('Approval hash:', result.hash)
 ```
@@ -742,7 +753,7 @@ const sameAddress = WalletAccountEvmErc4337.predictSafeAddress(
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
 | `getAllowance(token, spender)` | Returns current token allowance for a spender | `Promise\<bigint\>` | - |
 | `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | If simulation fails |
-| `quoteTransfer(options, config?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails |
+| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails |
 | `getTransactionReceipt(hash)` | Returns a transaction receipt | `Promise\<EvmTransactionReceipt \| null\>` | - |
 | `getUserOperationReceipt(hash)` | Returns a UserOperation receipt | `Promise\<UserOperationReceipt \| null\>` | - |
 | `signTypedData(typedData)` | Signs EIP-712 typed structured data | `Promise\<string\>` | - |
@@ -855,12 +866,13 @@ try {
 }
 ```
 
-##### `quoteTransfer(options, config?)`
+##### `quoteTransfer(options, config?, txOverrides?)`
 Estimates the fee for an ERC20 token transfer.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
@@ -1063,6 +1075,20 @@ interface EvmErc4337Transaction {
 ```
 
 The gas-override fields are optional. When omitted, the gas limits fall back to AbstractionKit's estimation and the fee pair (`maxFeePerGas` / `maxPriorityFeePerGas`) falls back to the bundler-fetched gas price. Setting either fee field disables the bundler-fetched fee fallback for both, so set them together. In a batched call (`tx` passed as an array), only the gas overrides on the first transaction are honored — a UserOperation carries a single set of gas fields regardless of how many calls it batches.
+
+### EvmErc4337GasOverrides
+
+The helper methods `transfer()`, `quoteTransfer()`, and `approve()` accept these same UserOperation gas and fee override fields as a separate `txOverrides` argument.
+
+```typescript
+interface EvmErc4337GasOverrides {
+  callGasLimit?: number | bigint;
+  verificationGasLimit?: number | bigint;
+  preVerificationGas?: number | bigint;
+  maxFeePerGas?: number | bigint;
+  maxPriorityFeePerGas?: number | bigint;
+}
+```
 
 ### TransferOptions
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
@@ -3,7 +3,7 @@ title: Send Transactions
 description: Send gasless transactions and estimate fees.
 ---
 
-This guide explains how to [send a gasless transaction](#send-a-gasless-transaction), [estimate fees](#estimate-fees), and [use a custom paymaster token](#send-with-custom-paymaster-token).
+This guide explains how to [send a gasless transaction](#send-a-gasless-transaction), [estimate fees](#estimate-fees), [reuse a recent quote](#reuse-a-recent-quote), and [use a custom paymaster token](#send-with-custom-paymaster-token).
 
 ## Send a Gasless Transaction
 
@@ -32,6 +32,23 @@ const quote = await account.quoteSendTransaction({
   value: 1000000000000000n
 })
 console.log('Estimated fee:', quote.fee)
+```
+
+## Reuse a Recent Quote
+
+Quotes are cached for up to 2 minutes. If you call `sendTransaction()` with the same transaction during that window, the account checks the current on-chain nonce before reusing the cached UserOperation. If the nonce has moved, it builds a fresh quote before sending.
+
+```javascript title="Quote Then Send"
+const tx = {
+  to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  value: 1000000000000000n
+}
+
+const quote = await account.quoteSendTransaction(tx)
+console.log('Estimated fee:', quote.fee)
+
+const result = await account.sendTransaction(tx)
+console.log('Transaction hash:', result.hash)
 ```
 
 ## Send with Custom Paymaster Token

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
@@ -3,7 +3,7 @@ title: Transfer Tokens
 description: Transfer ERC-20 tokens with gasless transactions.
 ---
 
-This guide explains how to [transfer ERC-20 tokens](#transfer-erc-20-tokens), [estimate transfer fees](#estimate-transfer-fees), and [set a maximum fee limit](#transfer-with-maximum-fee-limit).
+This guide explains how to [transfer ERC-20 tokens](#transfer-erc-20-tokens), [estimate transfer fees](#estimate-transfer-fees), [set a maximum fee limit](#transfer-with-maximum-fee-limit), and [apply UserOperation gas overrides](#transfer-with-useroperation-gas-overrides).
 
 ## Transfer ERC-20 Tokens
 
@@ -49,6 +49,31 @@ const result = await account.transfer({
 <Callout type="warn">
 If the estimated fee exceeds `transferMaxFee`, the transfer is cancelled with an "Exceeded maximum fee" error.
 </Callout>
+
+## Transfer with UserOperation Gas Overrides
+
+Use the third argument to pass UserOperation gas or EIP-1559 fee overrides through `transfer()` or `quoteTransfer()`. Set `maxFeePerGas` and `maxPriorityFeePerGas` together.
+
+```javascript title="Transfer with Gas Overrides"
+const txOverrides = {
+  callGasLimit: 90000n,
+  verificationGasLimit: 120000n,
+  maxFeePerGas: 30000000000n,
+  maxPriorityFeePerGas: 2000000000n
+}
+
+const quote = await account.quoteTransfer({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  amount: 1000000
+}, undefined, txOverrides)
+
+const result = await account.transfer({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  amount: 1000000
+}, undefined, txOverrides)
+```
 
 ## Next Steps
 

--- a/content/docs/sdk/wallet-modules/wallet-tron/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/api-reference.mdx
@@ -21,8 +21,8 @@ The main class for managing Tron wallets. Extends `WalletManager` from `@tethert
 ### Fee Rate Constants
 
 ```javascript
-const FEE_RATE_NORMAL_MULTIPLIER = 1.1
-const FEE_RATE_FAST_MULTIPLIER = 2.0
+const FEE_RATE_NORMAL_MULTIPLIER = 110n
+const FEE_RATE_FAST_MULTIPLIER = 200n
 ```
 
 ### Constructor
@@ -34,21 +34,31 @@ new WalletManagerTron(seed, config?)
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (TronWalletConfig, optional): Configuration object
-  - `provider` (string | TronWeb, optional): Tron RPC endpoint URL or TronWeb instance
-  - `transferMaxFee` (number, optional): Maximum fee amount for transfer operations (in sun)
+  - `provider` (`string | TronWeb | Array<string | TronWeb>`, optional): Tron RPC endpoint URL, TronWeb instance, or ordered failover list
+  - `retries` (number, optional): Additional failover attempts when `provider` is an array (default: 3)
+  - `transferMaxFee` (`number | bigint`, optional): Maximum fee amount for TRC20 transfer operations (in sun)
 
 **Example:**
 ```javascript
 const wallet = new WalletManagerTron(seedPhrase, {
   provider: 'https://api.trongrid.io', // Tron RPC endpoint
-  transferMaxFee: 10000000 // 10 TRX in sun
+  transferMaxFee: 10000000n // 10 TRX in sun
 })
 
 // Or with TronWeb instance
 const tronWeb = new TronWeb({ fullHost: 'https://api.trongrid.io' })
 const wallet2 = new WalletManagerTron(seedPhrase, {
   provider: tronWeb,
-  transferMaxFee: 10000000
+  transferMaxFee: 10000000n
+})
+
+// Or with ordered provider failover
+const wallet3 = new WalletManagerTron(seedPhrase, {
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ],
+  retries: 3
 })
 ```
 
@@ -58,7 +68,7 @@ const wallet2 = new WalletManagerTron(seedPhrase, {
 |--------|-------------|---------|--------|
 | `getAccount(index?)` | Returns a wallet account at the specified index | `Promise\<WalletAccountTron\>` | - |
 | `getAccountByPath(path)` | Returns a wallet account at the specified BIP-44 derivation path | `Promise\<WalletAccountTron\>` | - |
-| `getFeeRates()` | Returns current fee rates from Tron network | `Promise\<{normal: number, fast: number}\>` | If no provider |
+| `getFeeRates()` | Returns current fee rates from Tron network | `Promise\<{normal: bigint, fast: bigint}\>` | If no provider |
 | `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` | - |
 
 ##### `getAccount(index?)`
@@ -95,7 +105,7 @@ const account = await wallet.getAccountByPath("0'/0/1")
 ##### `getFeeRates()`
 Returns current fee rates from Tron network chain parameters.
 
-**Returns:** `Promise\<{normal: number, fast: number}\>` - Fee rates in sun
+**Returns:** `Promise\<{normal: bigint, fast: bigint}\>` - Fee rates in sun
 - `normal`: Base fee × 1.1
 - `fast`: Base fee × 2.0
 
@@ -124,7 +134,7 @@ Represents an individual Tron wallet account. Extends `WalletAccountReadOnlyTron
 
 ```javascript
 const BIP_44_TRON_DERIVATION_PATH_PREFIX = "m/44'/195'"
-const BANDWIDTH_PRICE = 1_000
+const BANDWIDTH_PRICE = 1_000n
 ```
 
 ### Constructor
@@ -144,7 +154,7 @@ new WalletAccountTron(seed, path, config?)
 ```javascript
 const account = new WalletAccountTron(seedPhrase, "0'/0/0", {
   provider: 'https://api.trongrid.io',
-  transferMaxFee: 10000000 // 10 TRX in sun
+  transferMaxFee: 10000000n // 10 TRX in sun
 })
 ```
 
@@ -155,10 +165,10 @@ const account = new WalletAccountTron(seedPhrase, "0'/0/0", {
 | `getAddress()` | Returns the account's Tron address | `Promise\<string\>` | - |
 | `sign(message)` | Signs a message using the account's private key | `Promise\<string\>` | - |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
-| `sendTransaction(tx)` | Sends a Tron transaction | `Promise\<{hash: string, fee: number}\>` | If no provider or fee exceeds max |
-| `quoteSendTransaction(tx)` | Estimates the fee for a Tron transaction | `Promise\<{fee: number}\>` | If no provider |
-| `transfer(options)` | Transfers TRC20 tokens to another address | `Promise\<{hash: string, fee: number}\>` | If no provider or fee exceeds max |
-| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: number}\>` | If no provider |
+| `sendTransaction(tx)` | Sends a Tron transaction | `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` | If no provider |
+| `quoteSendTransaction(tx)` | Estimates the fee for a Tron transaction | `Promise\<{fee: bigint, activationFee: bigint}\>` | If no provider |
+| `transfer(options)` | Transfers TRC20 tokens to another address | `Promise\<{hash: string, fee: bigint}\>` | If no provider or fee exceeds `transferMaxFee` |
+| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` | If no provider |
 | `getBalance()` | Returns the native TRX balance (in sun) | `Promise\<bigint\>` | If no provider |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific TRC20 token | `Promise\<bigint\>` | If no provider |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise\<TronTransactionReceipt \| null\>` | If no provider |
@@ -207,18 +217,17 @@ console.log('Signature valid:', isValid)
 ```
 
 ##### `sendTransaction(tx)`
-Sends a TRX transaction and returns the result with hash and fee.
+Sends a TRX transaction and returns the result with hash, fee, and activation fee details.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object
   - `to` (string): Recipient Tron address (e.g., 'T...')
-  - `value` (number): Amount in sun (1 TRX = 1,000,000 sun)
+  - `value` (number | bigint): Amount in sun (1 TRX = 1,000,000 sun)
 
-**Returns:** `Promise\<{hash: string, fee: number}\>` - Transaction hash and fee in sun
+**Returns:** `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` - Transaction hash, total fee in sun, and the portion used for account activation
 
 **Throws:** 
 - Error if no TronWeb provider is configured
-- Error if fee exceeds `transferMaxFee`
 
 **Example:**
 ```javascript
@@ -228,15 +237,16 @@ const result = await account.sendTransaction({
 })
 console.log('Transaction hash:', result.hash)
 console.log('Transaction fee:', result.fee, 'sun')
+console.log('Activation fee:', result.activationFee, 'sun')
 ```
 
 ##### `quoteSendTransaction(tx)`
-Estimates the bandwidth cost for a TRX transaction.
+Estimates the bandwidth and activation fee cost for a TRX transaction.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object (same as sendTransaction)
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun
+**Returns:** `Promise\<{fee: bigint, activationFee: bigint}\>` - Fee estimate in sun and the portion used for account activation
 
 **Throws:** Error if no TronWeb provider is configured
 
@@ -247,6 +257,7 @@ const quote = await account.quoteSendTransaction({
   value: 1000000
 })
 console.log('Estimated fee:', quote.fee, 'sun')
+console.log('Activation fee:', quote.activationFee, 'sun')
 ```
 
 ##### `transfer(options)`
@@ -258,7 +269,7 @@ Transfers TRC20 tokens using smart contract call.
   - `recipient` (string): Recipient Tron address (e.g., 'T...')
   - `amount` (number | bigint): Amount in token's base units
 
-**Returns:** `Promise\<{hash: string, fee: number}\>` - Transaction hash and fee in sun
+**Returns:** `Promise\<{hash: string, fee: bigint}\>` - Transaction hash and fee in sun
 
 **Throws:** 
 - Error if no TronWeb provider is configured
@@ -276,12 +287,12 @@ console.log('Transfer fee:', result.fee, 'sun')
 ```
 
 ##### `quoteTransfer(options)`
-Estimates the energy and bandwidth cost for a TRC20 token transfer.
+Estimates the TRC20 token transfer cost from current chain parameters, account resources, contract energy use, and bandwidth use.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options (same as transfer)
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun (energy + bandwidth costs)
+**Returns:** `Promise\<{fee: bigint}\>` - Fee estimate in sun (energy + bandwidth costs)
 
 **Throws:** Error if no TronWeb provider is configured
 
@@ -367,20 +378,21 @@ account.dispose()
 |----------|------|-------------|
 | `index` | `number` | The derivation path's index of this account |
 | `path` | `string` | The full BIP-44 derivation path of this account |
-| `keyPair` | `{privateKey: Buffer, publicKey: Buffer}` | The account's key pair (⚠️ Contains sensitive data) |
+| `keyPair` | `{privateKey: Uint8Array \| null, publicKey: Uint8Array}` | Read-only view of the account's key pair. `privateKey` is `null` after `dispose()` |
 
 **Example:**
 ```javascript
 console.log('Account index:', account.index) // 0, 1, 2, etc.
 console.log('Account path:', account.path) // m/44'/195'/0'/0/0
 
-// ⚠️ SENSITIVE: Handle with care
 const { privateKey, publicKey } = account.keyPair
 console.log('Public key length:', publicKey.length) // 33 bytes (compressed)
-console.log('Private key length:', privateKey.length) // 32 bytes
+console.log('Private key length:', privateKey?.length) // 32 bytes before dispose()
 ```
 
-⚠️ **Security Note**: The `keyPair` property contains sensitive cryptographic material. Never log, display, or expose the private key.
+<Callout type="warn">
+The `keyPair` byte arrays are bound to the wallet account. Treat them as a read-only view: do not mutate, log, display, or expose the private key.
+</Callout>
 
 ## WalletAccountReadOnlyTron
 
@@ -409,8 +421,8 @@ const readOnlyAccount = new WalletAccountReadOnlyTron('TLyqzVGLV1srkB7dToTAEqgDS
 |--------|-------------|---------|--------|
 | `getBalance()` | Returns the native TRX balance (in sun) | `Promise\<bigint\>` | If no provider |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific TRC20 token | `Promise\<bigint\>` | If no provider |
-| `quoteSendTransaction(tx)` | Estimates the fee for a TRX transaction | `Promise\<{fee: number}\>` | If no provider |
-| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: number}\>` | If no provider |
+| `quoteSendTransaction(tx)` | Estimates the fee for a TRX transaction | `Promise\<{fee: bigint, activationFee: bigint}\>` | If no provider |
+| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` | If no provider |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise\<TronTransactionReceipt \| null\>` | If no provider |
 
@@ -444,22 +456,22 @@ console.log('USDT balance:', tokenBalance)
 ```
 
 ##### `quoteSendTransaction(tx)`
-Estimates the bandwidth cost for a TRX transaction.
+Estimates the bandwidth and activation fee cost for a TRX transaction.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun
+**Returns:** `Promise\<{fee: bigint, activationFee: bigint}\>` - Fee estimate in sun and the portion used for account activation
 
 **Throws:** Error if no TronWeb provider is configured
 
 ##### `quoteTransfer(options)`
-Estimates the energy and bandwidth cost for a TRC20 transfer.
+Estimates the TRC20 token transfer cost from current chain parameters, account resources, contract energy use, and bandwidth use.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun
+**Returns:** `Promise\<{fee: bigint}\>` - Fee estimate in sun
 
 **Throws:** Error if no TronWeb provider is configured
 
@@ -495,8 +507,9 @@ Returns a transaction's receipt if it has been processed.
 
 ```typescript
 interface TronWalletConfig {
-  provider?: string | TronWeb;        // Tron RPC URL or TronWeb instance
-  transferMaxFee?: number;            // Maximum fee in sun
+  provider?: string | TronWeb | Array<string | TronWeb>; // RPC, TronWeb, or failover list
+  retries?: number;                   // Additional failover attempts, default 3
+  transferMaxFee?: number | bigint;   // Maximum TRC20 transfer fee in sun
 }
 ```
 
@@ -505,7 +518,7 @@ interface TronWalletConfig {
 ```typescript
 interface TronTransaction {
   to: string;                         // Recipient Tron address
-  value: number;                      // Amount in sun (1 TRX = 1,000,000 sun)
+  value: number | bigint;             // Amount in sun (1 TRX = 1,000,000 sun)
 }
 ```
 
@@ -524,7 +537,15 @@ interface TransferOptions {
 ```typescript
 interface TransactionResult {
   hash: string;                       // Transaction hash
-  fee: number;                        // Fee paid in sun
+  fee: bigint;                        // Fee paid in sun
+}
+```
+
+### TronActivationFee
+
+```typescript
+interface TronActivationFee {
+  activationFee: bigint;              // Portion of the fee used for account activation
 }
 ```
 
@@ -533,7 +554,7 @@ interface TransactionResult {
 ```typescript
 interface TransferResult {
   hash: string;                       // Transaction hash
-  fee: number;                        // Fee paid in sun
+  fee: bigint;                        // Fee paid in sun
 }
 ```
 
@@ -542,11 +563,11 @@ interface TransferResult {
 ```typescript
 // Tron-specific constants
 const BIP_44_TRON_DERIVATION_PATH_PREFIX: string = "m/44'/195'";
-const BANDWIDTH_PRICE: number = 1_000;
+const BANDWIDTH_PRICE: bigint = 1_000n;
 
 // Fee rate multipliers
-const FEE_RATE_NORMAL_MULTIPLIER: number = 1.1;
-const FEE_RATE_FAST_MULTIPLIER: number = 2.0;
+const FEE_RATE_NORMAL_MULTIPLIER: bigint = 110n;
+const FEE_RATE_FAST_MULTIPLIER: bigint = 200n;
 ```
 
 <Cards>

--- a/content/docs/sdk/wallet-modules/wallet-tron/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/configuration.mdx
@@ -12,8 +12,12 @@ icon: Settings
 import WalletManagerTron from '@tetherto/wdk-wallet-tron'
 
 const config = {
-  provider: 'https://api.trongrid.io', // Tron RPC endpoint
-  transferMaxFee: 10000000 // Maximum fee in sun (optional)
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ], // Tron RPC endpoints; array enables failover
+  retries: 3, // Additional failover attempts when provider is an array
+  transferMaxFee: 10000000n // Maximum transfer fee in sun (optional)
 }
 
 const wallet = new WalletManagerTron(seedPhrase, config)
@@ -26,7 +30,7 @@ import { WalletAccountTron } from '@tetherto/wdk-wallet-tron'
 
 const accountConfig = {
   provider: 'https://api.trongrid.io',
-  transferMaxFee: 10000000 // Maximum fee in sun (optional)
+  transferMaxFee: 10000000n // Maximum transfer fee in sun (optional)
 }
 
 const account = new WalletAccountTron(seedPhrase, "0'/0/0", accountConfig)
@@ -36,28 +40,65 @@ const account = new WalletAccountTron(seedPhrase, "0'/0/0", accountConfig)
 
 ### Provider
 
-The `provider` option specifies the Tron RPC endpoint or TronWeb instance for blockchain interactions.
+The `provider` option specifies how the wallet connects to Tron. It accepts a Tron RPC endpoint URL, a TronWeb instance, or an ordered list of URLs and TronWeb instances for automatic failover.
 
-**Type:** `string | TronWeb`
+**Type:** `string | TronWeb | Array<string | TronWeb>`
+
+**Examples:**
+```javascript
+// Single RPC endpoint
+const config = {
+  provider: 'https://api.trongrid.io'
+}
+
+// TronWeb instance
+const config = {
+  provider: tronWeb
+}
+
+// Ordered failover list
+const config = {
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ],
+  retries: 3
+}
+```
+
+When `provider` is an array, connection errors fail over to the next provider in the list. Empty arrays throw during provider initialization. Use endpoints that serve the same Tron network.
+
+If the array contains TronWeb instances, the first instance becomes the wallet's primary client. Additional instances contribute their `fullNode`, `solidityNode`, and `eventServer` connections to the failover pool.
+
+### Retries
+
+The `retries` option controls how many additional failover attempts can happen after the initial provider call fails. It only applies when `provider` is an array.
+
+**Type:** `number` (optional)
+**Default:** `3`
 
 **Example:**
 ```javascript
 const config = {
-  provider: 'https://api.trongrid.io'
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ],
+  retries: 1
 }
 ```
 
 ### Transfer Max Fee
 
-The `transferMaxFee` option sets the maximum fee amount (in sun) for transfer operations. This helps prevent transactions from being sent with unexpectedly high fees.
+The `transferMaxFee` option sets the maximum fee amount (in sun) for TRC20 `transfer()` operations. This helps prevent transfers from being sent with unexpectedly high fees.
 
-**Type:** `number` (optional)  
+**Type:** `number | bigint` (optional)
 **Unit:** Sun (1 TRX = 1,000,000 Sun)
 
 **Example:**
 ```javascript
 const config = {
-  transferMaxFee: 10000000 // 10 TRX in sun
+  transferMaxFee: 10000000n // 10 TRX in sun
 }
 ```
 

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
@@ -13,17 +13,25 @@ Wrap transactions in `try/catch` blocks to handle common failure scenarios. Use 
 
 ```javascript title="Transaction Error Handling"
 try {
-  const result = await account.sendTransaction({
+  const tx = {
     to: 'TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH',
     value: 1000000 // 1 TRX in sun
-  })
+  }
+
+  const quote = await account.quoteSendTransaction(tx)
+  if (quote.fee > 10000000n) {
+    throw new Error('Transaction fee exceeds configured threshold')
+  }
+
+  const result = await account.sendTransaction(tx)
   console.log('Transaction hash:', result.hash)
   console.log('Fee paid:', result.fee, 'sun')
+  console.log('Activation fee:', result.activationFee, 'sun')
 } catch (error) {
   if (error.message.toLowerCase().includes('insufficient')) {
     console.error('Not enough TRX to complete transaction')
-  } else if (error.message.toLowerCase().includes('max fee')) {
-    console.error('The transfer fee exceeds your configured maximum')
+  } else if (error.message.toLowerCase().includes('configured threshold')) {
+    console.error('The transaction fee exceeds your configured threshold')
   } else {
     console.error('Transaction failed:', error.message)
   }
@@ -57,7 +65,9 @@ try {
 
 ### Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet to prevent transactions from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron/api-reference):
+Set `transferMaxFee` when creating the wallet to prevent TRC20 transfers from exceeding a maximum cost. For native TRX sends, call [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx) and compare `quote.fee` before calling `sendTransaction()`.
+
+You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
@@ -22,11 +22,12 @@ const result = await account.sendTransaction({
 })
 console.log('Transaction hash:', result.hash)
 console.log('Transaction fee:', result.fee, 'sun')
+console.log('Activation fee:', result.activationFee, 'sun')
 ```
 
 ## Estimate Transaction Fees
 
-You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx):
+You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx). The quote includes `activationFee`, which is non-zero when the recipient account must be activated:
 
 ```javascript title="Quote Transaction Fee"
 const quote = await account.quoteSendTransaction({
@@ -34,6 +35,7 @@ const quote = await account.quoteSendTransaction({
   value: 1000000
 })
 console.log('Estimated fee:', quote.fee, 'sun')
+console.log('Activation fee:', quote.activationFee, 'sun')
 ```
 
 ## Use Dynamic Fee Rates

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/transfer-tokens.mdx
@@ -34,6 +34,8 @@ const transferQuote = await account.quoteTransfer({
 console.log('Transfer fee estimate:', transferQuote.fee, 'sun')
 ```
 
+The quote uses current chain parameters, the sender's available resources, and the TRC20 contract simulation result. It charges only the missing energy after available energy is considered, then adds any bandwidth cost.
+
 ## Transfer with Validation
 
 Validate addresses and check balances before transferring to catch errors early:

--- a/content/docs/sdk/wallet-modules/wallet-tron/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/index.mdx
@@ -14,11 +14,11 @@ A simple and secure package to manage BIP-44 wallets for the Tron blockchain. Th
 - **Multi-Account Management**: Create and manage multiple accounts from a single seed phrase
 - **Tron Address Support:** Generate and manage Tron addresses
 - **Message Signing:** Sign and verify messages using Tron cryptography
-- **Transaction Management**: Send transactions and get fee estimates
+- **Transaction Management**: Send transactions and get fee estimates, including activation fee details for native TRX sends
 - **TRC20 Support:** Query native TRX and TRC20 token balances.
 - **TypeScript Support**: Full TypeScript definitions included
 - **Memory Safety**: Secure private key management with automatic memory cleanup
-- **Provider Flexibility:** Support for custom Tron RPC endpoints
+- **Provider Flexibility:** Support for custom Tron RPC endpoints, TronWeb instances, and ordered failover provider lists
 
 ## Supported Networks
 

--- a/content/docs/tools/price-rates/api-reference.mdx
+++ b/content/docs/tools/price-rates/api-reference.mdx
@@ -24,13 +24,39 @@ new BitfinexPricingClient(options?)
 
 | Method | Description | Returns |
 |--------|-------------|---------|
-| `getCurrentPrice(base, quote)` | Fetch latest price for base/quote pair | `Promise\<number\>` |
+| `getCurrentPrice(base, quote)` | Fetch latest price for base/quote pair | `Promise\<number \| null\>` |
+| `getMultiCurrentPrices(pairs)` | Fetch latest prices for multiple pairs in one batch | `Promise\<Array\<number \| null\>\>` |
+| `getMultiPriceData(pairs)` | Fetch last price and 24h change data for multiple directly quoted pairs | `Promise\<Array\<PriceData \| null\>\>` |
 | `getHistoricalPrice(from, to, opts?)` | Fetch historical series (downscaled to ≤ 100 points if needed) | `Promise\<HistoricalPriceResult[]\>` |
 
 ##### `getCurrentPrice(base, quote)`
 
+Uses Bitfinex's `/calc/fx/batch` endpoint. If Bitfinex cannot quote the pair directly, the client tries a two-leg USD pivot. Returns `null` when the pair cannot be resolved.
+
 ```javascript title="Current Price"
 const price = await client.getCurrentPrice('BTC', 'USD')
+const brl = await client.getCurrentPrice('BTC', 'BRL')
+```
+
+##### `getMultiCurrentPrices(pairs)`
+
+Returns current prices in the same order as the input pairs. Each unresolved pair returns `null`.
+
+```javascript title="Batch Current Prices"
+const prices = await client.getMultiCurrentPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
+```
+
+##### `getMultiPriceData(pairs)`
+
+Returns last price plus 24-hour absolute and relative change. This method reads Bitfinex ticker data and does not use the USD-pivot fallback, so unsupported entries return `null`.
+
+```javascript title="Batch Price Data"
+const data = await client.getMultiPriceData([
+  { from: 'BTC', to: 'USD' }
+])
 ```
 
 ##### `getHistoricalPrice(from, to, opts?)`
@@ -69,6 +95,9 @@ new PricingProvider({
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getLastPrice(base, quote)` | Returns cached last price; refreshes when TTL expires | `Promise\<number\>` |
+| `getMultiLastPrices(pairs)` | Returns cached last prices for multiple pairs | `Promise\<number[]\>` |
+| `getLastPriceData(base, quote)` | Returns cached last price plus daily change data | `Promise\<PriceData\>` |
+| `getMultiLastPriceData(pairs)` | Returns cached price data for multiple pairs | `Promise\<PriceData[]\>` |
 | `getHistoricalPrice(from, to, opts?)` | Delegates to client for historical data | `Promise\<HistoricalPriceResult[]\>` |
 
 ##### `getLastPrice(base, quote)`
@@ -76,6 +105,30 @@ new PricingProvider({
 ```javascript title="Last Price with Caching"
 const provider = new PricingProvider({ client })
 const last = await provider.getLastPrice('BTC', 'USD')
+```
+
+##### `getMultiLastPrices(pairs)`
+
+```javascript title="Cached Batch Last Prices"
+const prices = await provider.getMultiLastPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
+```
+
+##### `getLastPriceData(base, quote)`
+
+```javascript title="Cached Price Data"
+const data = await provider.getLastPriceData('BTC', 'USD')
+console.log(data.lastPrice, data.dailyChange, data.dailyChangeRelative)
+```
+
+##### `getMultiLastPriceData(pairs)`
+
+```javascript title="Cached Batch Price Data"
+const data = await provider.getMultiLastPriceData([
+  { from: 'BTC', to: 'USD' }
+])
 ```
 
 ##### `getHistoricalPrice(from, to, opts?)`
@@ -93,12 +146,15 @@ Implement this interface to plug your data source into `PricingProvider`.
 
 | Method | Signature | Notes |
 |--------|-----------|-------|
-| `getCurrentPrice` | `(from: string, to: string) =\> Promise\<number\>` | Should return spot price |
+| `getCurrentPrice` | `(from: string, to: string) =\> Promise\<number \| null\>` | Return spot price or `null` when the pair cannot be resolved |
+| `getMultiCurrentPrices` | `(list: PricePair[]) =\> Promise\<Array\<number \| null\>\>` | Return one result per pair; unresolved entries are `null` |
+| `getMultiPriceData` | `(list: PricePair[]) =\> Promise\<Array\<PriceData \| null\>\>` | Return last price and daily change data; unresolved entries are `null` |
 | `getHistoricalPrice` | `(from: string, to: string, opts?: HistoricalPriceOptions) =\> Promise\<HistoricalPriceResult[]\>` | Return series for charting |
 
 ## Notes
 
-- Uses Bitfinex Public HTTP API (`/v2/ticker` and `/v2/candles`) under the hood for the Bitfinex client
+- Uses Bitfinex Public HTTP API (`/v2/calc/fx/batch`, `/v2/tickers`, and `/v2/candles`) under the hood for the Bitfinex client
+- Current-price lookups can pivot through USD for fiat pairs Bitfinex does not quote directly; historical prices and `getMultiPriceData()` do not use that pivot
 - Provider caches last price per pair using in-memory store and TTL
 
 ***

--- a/content/docs/tools/price-rates/configuration.mdx
+++ b/content/docs/tools/price-rates/configuration.mdx
@@ -17,8 +17,36 @@ const client = new BitfinexPricingClient()
 
 ### Current Price
 
+Current-price lookups use Bitfinex's FX conversion endpoint. If Bitfinex cannot quote the pair directly, the client tries a two-leg `from -> USD -> to` conversion. If the pair still cannot be resolved, the result is `null`.
+
 ```javascript title="Get Current Price"
 const price = await client.getCurrentPrice('BTC', 'USD')
+const brlPrice = await client.getCurrentPrice('BTC', 'BRL') // resolved through USD when available
+
+if (price === null) {
+  // Show an unavailable-price state in your UI
+}
+```
+
+### Batch Current Prices
+
+Batch lookups return results in the same order as the input list. Entries that cannot be resolved are `null`.
+
+```javascript title="Get Batch Current Prices"
+const prices = await client.getMultiCurrentPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
+```
+
+### Batch Price Data
+
+Use `getMultiPriceData()` when you need the last price plus 24-hour absolute and relative change. This method uses Bitfinex ticker data and only supports pairs Bitfinex quotes directly.
+
+```javascript title="Get Batch Price Data"
+const priceData = await client.getMultiPriceData([
+  { from: 'BTC', to: 'USD' }
+])
 ```
 
 ### Historical Series
@@ -47,6 +75,10 @@ const provider = new PricingProvider({
 })
 
 const last = await provider.getLastPrice('BTC', 'USD')
+const prices = await provider.getMultiLastPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
 const hist = await provider.getHistoricalPrice('BTC', 'USD', {
   start: 1709906400000,
   end: 1709913600000

--- a/content/docs/tools/price-rates/index.mdx
+++ b/content/docs/tools/price-rates/index.mdx
@@ -11,7 +11,8 @@ Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/w
 
 ## Features
 
-- **Current Prices**: Fetch latest price for a base/quote pair (e.g., BTC/USD)
+- **Current Prices**: Fetch latest price for one pair or many pairs in a batch (e.g., BTC/USD)
+- **Fiat Fallback**: Resolve fiat pairs Bitfinex does not quote directly by pivoting through USD when current FX data is available
 - **Historical Series**: Retrieve historical price series; long histories optionally downscaled to ≤ 100 points
 - **Provider Compatibility**: Works with `@tetherto/wdk-pricing-provider`
 - **Lightweight HTTP Client**: Minimal dependencies; easy to integrate
@@ -20,6 +21,7 @@ Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/w
 
 - Consistent pricing is required for balance valuations, charts, and quotes
 - A unified client reduces integration time and data handling errors
+- Unsupported pairs return `null` from the pricing client so applications can show a clear unavailable-price state
 
 <Cards>
 <Card title="Price Rates Overview" href="/tools/price-rates/configuration">


### PR DESCRIPTION
## Summary
- Adds June 9/10 changelog entries for `wallet-evm-erc-4337 v1.0.0-beta.9`, `pricing-provider v1.0.0-beta.5`, `pricing-bitfinex-http v1.0.0-beta.3`, `wdk-wallet v1.0.0-beta.10`, and `wallet-tron v1.0.0-beta.6`.
- Documents ERC-4337 cached-quote nonce validation and gas overrides for `transfer()`, `quoteTransfer()`, and `approve()`.
- Updates price-rates docs for nullable unresolved pairs, batch current prices, batch price data, and Bitfinex USD-pivot fallback behavior.
- Adds shared wallet fee-cap guidance for `transferMaxFee` and `transactionMaxFee`.
- Updates Tron docs for provider failover, `retries`, activation fee quotes, bigint fee return types, TRC20 fee quote behavior, and `keyPair` read-only view handling.

## Local baseline
- Ran `node .agent/skills/wdk-release-monitor/bin/wdk-release-monitor.mjs --update-baseline-from-docs` after the changelog contained all five release entries.
- `_audit/release-baseline.yaml` remains local-only and is not included in this PR.

## Validation
- `git diff --check`
- `npm run check:meta`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `npm run build` (passed with existing unrelated `docType` frontmatter warnings)
