### PR TITLE
docs: move swidge out of sidebar

### DIFF
--- a/content/docs/sdk/bridge-modules/index.mdx
+++ b/content/docs/sdk/bridge-modules/index.mdx
@@ -7,10 +7,6 @@ schemaType: TechArticle
 
 The Wallet Development Kit (WDK) provides a set of modules that support bridging between different blockchain networks. All modules share a common interface, ensuring consistent behavior across different blockchain implementations.
 
-<Callout type="info">
-WDK is introducing the [swidge interface](/sdk/swidge-modules) as the preferred interface for new swap, bridge, and combined route providers. Existing bridge modules remain supported, but new protocol integrations should prefer swidge because the standalone bridge interface is expected to be deprecated in a future release once swidge provider coverage is available.
-</Callout>
-
 ## Bridge Protocol Modules
 
 Cross-chain bridge functionality for token transfers between blockchains:
@@ -32,3 +28,7 @@ You can also:
 
 - Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready
+
+## Combined swap and bridge routes
+
+When a route needs both cross-chain movement and a token swap, use the [Swidge protocol interface](/sdk/swidge-modules) instead of wiring separate bridge and swap flows manually. The shared interface covers route discovery, quoting, execution, and status tracking for combined asset routes.

--- a/content/docs/sdk/swap-modules/index.mdx
+++ b/content/docs/sdk/swap-modules/index.mdx
@@ -7,10 +7,6 @@ schemaType: TechArticle
 
 The Swap Development Kit (WDK) provides a set of modules that support swap on top of multiple blockchain networks. All modules share a common interface, ensuring consistent behavior across different blockchain implementations.
 
-<Callout type="info">
-WDK is introducing the [swidge interface](/sdk/swidge-modules) as the preferred interface for new swap, bridge, and combined route providers. Existing swap modules remain supported, but new protocol integrations should prefer swidge because the standalone swap interface is expected to be deprecated in a future release once swidge provider coverage is available.
-</Callout>
-
 ## Swap Protocol Modules
 
 DeFi swap functionality for token exchanges across different DEXs:
@@ -32,3 +28,7 @@ You can also:
 
 - Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready
+
+## Combined swap and bridge routes
+
+When a route needs both a token swap and cross-chain movement, use the [Swidge protocol interface](/sdk/swidge-modules) instead of wiring separate swap and bridge flows manually. The shared interface covers route discovery, quoting, execution, and status tracking for combined asset routes.

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -301,7 +301,6 @@ export const customTree: Node[] = [
       },
     ],
   },
-  { name: 'Swidge Interface', url: '/sdk/swidge-modules', type: 'page', icon: resolveIcon('Route') },
   {
     name: 'Swap Modules',
     type: 'folder',


### PR DESCRIPTION
## Summary

- Removes the Swidge Protocol Interface page from the left navigation.
- Moves Swidge guidance to the end of the Swap Modules and Bridge Modules overview pages for flows that need both swap and bridge behavior.

## Checks

- `git diff --check`
- `npm run check:meta`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `npm run build`