### PR TITLE
docs: release develop to main

### DIFF
--- a/content/docs/overview/about.mdx
+++ b/content/docs/overview/about.mdx
@@ -83,6 +83,7 @@ WDK natively supports a broad set of blockchains and standards out of the box:
 | [Bitcoin](/sdk/wallet-modules/wallet-btc/)                      | ✅       |
 | [Ethereum & EVM](/sdk/wallet-modules/wallet-evm/)               | ✅       |
 | [Ethereum ERC-4337](/sdk/wallet-modules/wallet-evm-erc-4337/)   | ✅       |
+| [Ethereum EIP-7702 Gasless](/sdk/wallet-modules/wallet-evm-7702-gasless/) | ✅       |
 | [TON](/sdk/wallet-modules/wallet-ton/)                          | ✅       |
 | [TON Gasless](/sdk/wallet-modules/wallet-ton-gasless/)          | ✅       |
 | [TRON](/sdk/wallet-modules/wallet-tron/)                        | ✅       |

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,21 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 14, 2026
+
+**What's New**
+- **wdk-utils** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.6)): Add BIP-21 Bitcoin payment URI helpers, including `isBip21Request()`, `parseBip21Request()`, and `encodeBip21Request()` with Bitcoin address validation, optional `amount`, `label`, and `message` fields, and unsupported required-parameter errors.
+- **react-native-core** ([v1.0.0-beta.11](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.11)): Add `useBalancesForWallets()` for fetching balances across multiple account indices, preload addresses for every requested account/network pair, and return per-account token failures without failing the whole query.
+
+---
+
+### June 12, 2026
+
+**What's New**
+- **wdk-core** ([v1.0.0-beta.11](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.11)): Add local transaction policies with `registerPolicy()`, `PolicyViolationError`, `PolicyConfigurationError`, scoped ALLOW/DENY rules for wallet account and protocol write methods, and `account.simulate.*` mirrors for dry-run policy evaluation.
+
+---
+
 ### June 10, 2026
 
 **What's New**

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -12,6 +12,10 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ### June 10, 2026
 
+**What's New**
+- **wdk-wallet** ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.10)): Add `transactionMaxFee` to the base `WalletConfig` type so wallet modules can expose separate fee caps for `sendTransaction()` / `signTransaction()` flows and token `transfer()` flows.
+- **wallet-tron** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.6)): Add ordered Tron provider failover through `provider` arrays and `retries`, expose `keyPair` as a read-only view of the account keys, and return more precise TRX/TRC20 fee quotes including TRX activation fee details.
+
 **Fixes**
 - **wallet-evm-erc-4337** ([v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.9)): Validate cached quote nonces at send time before reusing a quoted UserOperation, re-quoting when the on-chain nonce has moved, and propagate UserOperation gas overrides through `transfer()`, `quoteTransfer()`, and `approve()`.
 

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -22,6 +22,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 **What's New**
 - **wdk-core** ([v1.0.0-beta.11](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.11)): Add local transaction policies with `registerPolicy()`, `PolicyViolationError`, `PolicyConfigurationError`, scoped ALLOW/DENY rules for wallet account and protocol write methods, and `account.simulate.*` mirrors for dry-run policy evaluation.
+- **wdk-asset-registry** ([v1.0.0-beta.1](https://github.com/tetherto/wdk-asset-registry/releases/tag/v1.0.0-beta.1)): Introduce `@tetherto/wdk-asset-registry` with in-memory base and token asset registries, Zod-backed `BaseAsset` and `TokenAsset` schemas, JSON schema exports, Uniswap token-list normalization helpers, and bundled `common-tokens` metadata.
 
 ---
 

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,23 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 10, 2026
+
+**Fixes**
+- **wallet-evm-erc-4337** ([v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.9)): Validate cached quote nonces at send time before reusing a quoted UserOperation, re-quoting when the on-chain nonce has moved, and propagate UserOperation gas overrides through `transfer()`, `quoteTransfer()`, and `approve()`.
+
+---
+
+### June 09, 2026
+
+**What's New**
+- **pricing-bitfinex-http** ([v1.0.0-beta.3](https://github.com/tetherto/wdk-pricing-bitfinex-http/releases/tag/v1.0.0-beta.3)): Add batch FX conversion through Bitfinex's `/calc/fx/batch` endpoint, including USD-pivot fallback for fiat pairs Bitfinex does not quote directly, plus `getMultiCurrentPrices()` and `getMultiPriceData()` coverage.
+
+**Changes**
+- **pricing-provider** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-pricing-provider/releases/tag/v1.0.0-beta.5)): Mark unresolved current-price and batch-price results as nullable in the `PricingClient` base type so custom clients can return `null` for unsupported pairs without losing type information.
+
+---
+
 ### June 04, 2026
 
 **What's New**

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -23,6 +23,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 **What's New**
 - **wdk-core** ([v1.0.0-beta.11](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.11)): Add local transaction policies with `registerPolicy()`, `PolicyViolationError`, `PolicyConfigurationError`, scoped ALLOW/DENY rules for wallet account and protocol write methods, and `account.simulate.*` mirrors for dry-run policy evaluation.
 - **wdk-asset-registry** ([v1.0.0-beta.1](https://github.com/tetherto/wdk-asset-registry/releases/tag/v1.0.0-beta.1)): Introduce `@tetherto/wdk-asset-registry` with in-memory base and token asset registries, Zod-backed `BaseAsset` and `TokenAsset` schemas, JSON schema exports, Uniswap token-list normalization helpers, and bundled `common-tokens` metadata.
+- **wallet-evm-7702-gasless** ([v1.0.0-beta.1](https://github.com/tetherto/wdk-wallet-evm-7702-gasless/releases/tag/v1.0.0-beta.1)): Introduce `@tetherto/wdk-wallet-evm-7702-gasless` for EIP-7702 delegated EVM accounts with ERC-4337 UserOperation submission, sponsored and paymaster-token fee modes, provider failover, quote helpers, and UserOperation receipt lookup.
 
 ---
 

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,14 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 04, 2026
+
+**What's New**
+- **wdk-utils** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.5)): Restore BOLT11 invoice support with exported `validateLightningInvoice()`, `decode()`, `getHashToSign()`, `sign()`, and `encode()` helpers, including fallback address, routing info, feature bits, and `lightning:` prefix handling.
+- **wdk-core** ([v1.0.0-beta.10](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.10)): Add swidge protocol support to global and account-level `registerProtocol()` calls, expose `getSwidgeProtocol()`, preserve account-scoped protocols across repeated account lookups, and reject duplicate `registerWallet()` calls until the existing wallet is disposed.
+
+---
+
 ### June 02, 2026
 
 **What's New**

--- a/content/docs/sdk/all-modules.mdx
+++ b/content/docs/sdk/all-modules.mdx
@@ -24,6 +24,7 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 | [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | Bitcoin SegWit wallet with BIP-39/BIP-44 support | [Docs](/sdk/wallet-modules/wallet-btc/) |
 | [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | Ethereum and EVM-compatible chains wallet | [Docs](/sdk/wallet-modules/wallet-evm/) |
 | [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-erc-4337/) |
+| [`@tetherto/wdk-wallet-evm-7702-gasless`](https://github.com/tetherto/wdk-wallet-evm-7702-gasless) | EVM | EIP-7702 gasless account abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-7702-gasless/) |
 | [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | TON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-ton/) |
 | [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | Gasless transactions on TON | [Docs](/sdk/wallet-modules/wallet-ton-gasless/) |
 | [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | TRON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-tron/) |

--- a/content/docs/sdk/bridge-modules/index.mdx
+++ b/content/docs/sdk/bridge-modules/index.mdx
@@ -7,10 +7,6 @@ schemaType: TechArticle
 
 The Wallet Development Kit (WDK) provides a set of modules that support bridging between different blockchain networks. All modules share a common interface, ensuring consistent behavior across different blockchain implementations.
 
-<Callout type="info">
-WDK is introducing the [swidge interface](/sdk/swidge-modules) as the preferred interface for new swap, bridge, and combined route providers. Existing bridge modules remain supported, but new protocol integrations should prefer swidge because the standalone bridge interface is expected to be deprecated in a future release once swidge provider coverage is available.
-</Callout>
-
 ## Bridge Protocol Modules
 
 Cross-chain bridge functionality for token transfers between blockchains:
@@ -32,3 +28,7 @@ You can also:
 
 - Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready
+
+## Combined swap and bridge routes
+
+When a route needs both cross-chain movement and a token swap, use the [Swidge protocol interface](/sdk/swidge-modules) instead of wiring separate bridge and swap flows manually. The shared interface covers route discovery, quoting, execution, and status tracking for combined asset routes.

--- a/content/docs/sdk/community-modules/index.mdx
+++ b/content/docs/sdk/community-modules/index.mdx
@@ -18,6 +18,7 @@ Tether and the WDK Team do not endorse or assume responsibility for their code, 
 | Module | Type | Description | Documentation | Author |
 |--------|------|-------------|---------------|--------|
 | [@utexo/wdk-wallet-rgb](https://www.npmjs.com/package/@utexo/wdk-wallet-rgb) ([GitHub](https://github.com/UTEXO-Protocol/wdk-wallet-rgb)) | Wallet Module | Wallet module for RGB, Bitcoin-based smart contracts | - | [UTEXO](https://github.com/UTEXO-Protocol) |
+| [@arkade-os/wdk](https://www.npmjs.com/package/@arkade-os/wdk) ([GitHub](https://github.com/arkade-os/arkade-wdk)) | Wallet Module | Bitcoin wallet module built on the Arkade SDK with Arkade addresses, boarding addresses, BIP21/LNURL/Lightning send routing, and optional Boltz swaps | [README](https://github.com/arkade-os/arkade-wdk#readme) | [Arkade](https://github.com/arkade-os) |
 | [@base58-io/wdk-wallet-cosmos](https://www.npmjs.com/package/@base58-io/wdk-wallet-cosmos) ([GitHub](https://github.com/base58-io/wdk-wallet-cosmos)) | Wallet Module | Wallet module for Cosmos-compatible blockchains | - | [Base58](https://base58.io/) |
 | [@morpho-org/wdk-protocol-lending-morpho-evm](https://www.npmjs.com/package/@morpho-org/wdk-protocol-lending-morpho-evm) ([GitHub](https://github.com/morpho-org/sdks/tree/main/packages/wdk-protocol-lending-morpho-evm)) | Lending Module | Morpho EVM lending module for vault deposits, collateral supply, borrowing, repayment, and position reads | [Docs](/sdk/lending-modules/lending-morpho-evm/) | [Morpho Association](https://morpho.org/) |
 

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -10,7 +10,7 @@ icon: Code
 
 | Class | Description | Methods |
 |-------|-------------|---------|
-| [WDK](#wdk) | Main class for managing wallets across multiple blockchains. Orchestrates wallet managers and protocols. | [Constructor](#constructor), [Methods](#methods) |
+| [WDK](#wdk) | Main class for managing wallets across multiple blockchains. Orchestrates wallet managers, protocols, middleware, and local transaction policies. | [Constructor](#constructor), [Methods](#methods) |
 | [IWalletAccount](#iwalletaccount) | Base writable wallet account interface from `@tetherto/wdk-wallet`. | [Methods](#methods-1) |
 | [IWalletAccountWithProtocols](#iwalletaccountwithprotocols) | Extended wallet account interface that supports protocol registration and access. Extends `IWalletAccount`. | [Methods](#methods-2) |
 
@@ -46,9 +46,10 @@ const wdk2 = new WDK(seedBytes)
 | `registerWallet(blockchain, wallet, config)` | Registers a new wallet manager for a blockchain | `WDK` | If a wallet is already registered for that blockchain |
 | `registerProtocol(blockchain, label, protocol, config)` | Registers a protocol globally for a blockchain | `WDK` | - |
 | `registerMiddleware(blockchain, middleware)` | Registers middleware for account decoration | `WDK` | - |
+| `registerPolicy(policies, options?)` | Registers local transaction policies for wallet account and protocol write methods | `WDK` | If policy configuration is invalid |
 | `getAccount(blockchain, index?)` | Returns a wallet account for a blockchain and index | `Promise<IWalletAccountWithProtocols>` | If wallet not registered |
 | `getAccountByPath(blockchain, path)` | Returns a wallet account for a blockchain and derivation path | `Promise<IWalletAccountWithProtocols>` | If wallet not registered |
-| `getFeeRates()` | Returns current fee rates | `Promise<FeeRates>` | - |
+| `getFeeRates(blockchain)` | Returns current fee rates for a registered blockchain | `Promise<FeeRates>` | If wallet not registered |
 | `dispose(blockchains?)` | Disposes all registered wallets, or only the named blockchains, and clears their sensitive data | `void` | - |
 
 ##### `registerWallet(blockchain, wallet, config)`
@@ -62,7 +63,7 @@ Registers a new wallet manager for a specific blockchain.
 - `wallet` (W): The wallet manager class
 - `config` (`ConstructorParameters<W>[1]`): The configuration object for the wallet
 
-**Returns:** `WDK` - The wdk manager instance (supports method chaining)
+**Returns:** `WDK` - The WDK instance (supports method chaining)
 
 **Throws:** Error if a wallet is already registered for the same blockchain. Call `dispose([blockchain])` before registering a replacement wallet for that blockchain.
 
@@ -105,7 +106,7 @@ For swidge integrations, pass a concrete provider class that extends `SwidgeProt
 - `protocol` (P): The protocol class
 - `config` (`ConstructorParameters<P>[1]`): The protocol configuration
 
-**Returns:** `WDK` - The wdk manager instance (supports method chaining)
+**Returns:** `WDK` - The WDK instance (supports method chaining)
 
 **Example:**
 ```javascript title="Register Protocols"
@@ -136,7 +137,7 @@ Registers middleware for account decoration and enhanced functionality.
 - `blockchain` (string): The name of the blockchain
 - `middleware` (`<A extends IWalletAccount>(account: A) => Promise<A | void>`): Middleware function called when deriving accounts
 
-**Returns:** `WDK` - The wdk manager instance (supports method chaining)
+**Returns:** `WDK` - The WDK instance (supports method chaining)
 
 **Example:**
 ```javascript title="Register Middleware"
@@ -163,6 +164,71 @@ const wdk2 = new WDK(seedPhrase)
   })
 ```
 
+##### `registerPolicy(policies, options?)`
+Registers one or more local transaction policies on the WDK instance.
+
+Policies are evaluated before wrapped account and protocol write methods execute. Matching `DENY` rules throw `PolicyViolationError`; matching `ALLOW` rules permit the call. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
+
+**Parameters:**
+- `policies` (`Policy | Policy[]`): A single policy or an array of policies to register.
+- `options` (`RegisterPolicyOptions`, optional): Engine-level settings. `conditionTimeoutMs` defaults to `30000` milliseconds; the most recent value wins.
+
+**Returns:** `WDK` - The WDK instance (supports method chaining)
+
+**Throws:** `PolicyConfigurationError` if a policy or option fails validation, if an account-scoped policy omits its account binding, or if a policy references a wallet identifier that has not been registered.
+
+**Example:**
+```typescript title="Register A Send Policy"
+import WDK, { PolicyViolationError } from '@tetherto/wdk'
+
+const wdk = new WDK(seedPhrase)
+  .registerWallet('ethereum', WalletManagerEvm, ethereumWalletConfig)
+  .registerPolicy({
+    id: 'eth-send-limit',
+    name: 'ETH send limit',
+    scope: 'project',
+    wallet: 'ethereum',
+    rules: [
+      {
+        name: 'block-large-send',
+        operation: 'sendTransaction',
+        action: 'DENY',
+        reason: 'Transaction value exceeds local policy',
+        conditions: [
+          ({ params }) => {
+            const value = (params as { value?: bigint } | null)?.value
+            return typeof value === 'bigint' && value > 1000000000000000000n
+          }
+        ]
+      }
+    ]
+  })
+
+const account = await wdk.getAccount('ethereum', 0)
+
+const simulation = await (account as any).simulate.sendTransaction({
+  to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+  value: 2000000000000000000n
+})
+
+if (simulation.decision === 'DENY') {
+  console.warn(simulation.reason)
+}
+
+try {
+  await account.sendTransaction({
+    to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+    value: 2000000000000000000n
+  })
+} catch (error) {
+  if (error instanceof PolicyViolationError) {
+    console.error(error.reason)
+  }
+}
+```
+
+Supported `PolicyOperation` values are `sendTransaction`, `signTransaction`, `transfer`, `approve`, `sign`, `signTypedData`, `signAuthorization`, `delegate`, `revokeDelegation`, `swap`, `bridge`, `supply`, `withdraw`, `borrow`, `repay`, `buy`, `sell`, `swidge`, and `*`.
+
 ##### `getAccount(blockchain, index?)`
 Returns a wallet account for a specific blockchain and index using BIP-44 derivation.
 
@@ -170,9 +236,9 @@ Returns a wallet account for a specific blockchain and index using BIP-44 deriva
 - `blockchain` (string): The name of the blockchain (e.g., "ethereum")
 - `index` (number, optional): The index of the account to get (default: 0)
 
-**Returns:** `Promise<IWalletAccountWithProtocols>` - The wallet account with protocol support
+**Returns:** `Promise<IWalletAccountWithProtocols>` - The wallet account with protocol support. When a registered policy targets the account, the returned runtime account is policy-enforced and exposes matching `simulate` helpers.
 
-**Throws:** Error if no wallet has been registered for the given blockchain
+**Throws:** Error if no wallet has been registered for the given blockchain. Throws `PolicyConfigurationError` if a registered policy applies but the wallet account does not expose a read-only account view.
 
 **Example:**
 ```javascript title="Get Account"
@@ -200,9 +266,9 @@ Returns a wallet account for a specific blockchain and BIP-44 derivation path.
 - `blockchain` (string): The name of the blockchain (e.g., "ethereum")
 - `path` (string): The derivation path (e.g., "0'/0/0")
 
-**Returns:** `Promise<IWalletAccountWithProtocols>` - The wallet account with protocol support
+**Returns:** `Promise<IWalletAccountWithProtocols>` - The wallet account with protocol support. When a registered policy targets the account, the returned runtime account is policy-enforced and exposes matching `simulate` helpers.
 
-**Throws:** Error if no wallet has been registered for the given blockchain
+**Throws:** Error if no wallet has been registered for the given blockchain. Throws `PolicyConfigurationError` if a registered policy applies but the wallet account does not expose a read-only account view.
 
 **Example:**
 ```javascript title="Get Account by Path"
@@ -213,14 +279,19 @@ const account = await wdk.getAccountByPath('ethereum', "0'/0/1")
 const customAccount = await wdk.getAccountByPath('ton', "1'/2/3")
 ```
 
-##### `getFeeRates()`
-Returns current fee rates for all registered blockchains.
+##### `getFeeRates(blockchain)`
+Returns current fee rates for a registered blockchain.
+
+**Parameters:**
+- `blockchain` (string): The blockchain identifier passed to `registerWallet()`
 
 **Returns:** `Promise<FeeRates>` - The fee rates in base units
 
+**Throws:** Error if no wallet has been registered for the given blockchain.
+
 **Example:**
 ```javascript title="Get Fee Rates"
-const feeRates = await wdk.getFeeRates()
+const feeRates = await wdk.getFeeRates('ethereum')
 console.log('Fee rates:', feeRates)
 ```
 
@@ -244,7 +315,7 @@ wdk.dispose(['ethereum'])
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getRandomSeedPhrase(wordCount?)` | Returns a random BIP-39 seed phrase (12 or 24 words) | `string` |
-| `isValidSeedPhrase(seedPhrase)` | Checks if a seed phrase is valid | `boolean` |
+| `isValidSeed(seed)` | Checks if a seed phrase or seed bytes value is valid | `boolean` |
 
 ##### `getRandomSeedPhrase(wordCount?)`
 Returns a random BIP-39 seed phrase. Supports both 12-word (128-bit entropy) and 24-word (256-bit entropy) seed phrases.
@@ -267,20 +338,20 @@ console.log('Generated 24-word seed:', seedPhrase24)
 // Output: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
 ```
 
-##### `isValidSeedPhrase(seedPhrase)`
-Checks if a seed phrase is valid according to BIP-39 standards.
+##### `isValidSeed(seed)`
+Checks if a seed phrase or seed bytes value is valid.
 
 **Parameters:**
-- `seedPhrase` (string): The seed phrase to validate
+- `seed` (string | Uint8Array): The seed phrase or seed bytes to validate
 
-**Returns:** `boolean` - True if the seed phrase is valid
+**Returns:** `boolean` - True if the seed is valid
 
 **Example:**
-```javascript title="Validate Seed Phrase"
-const isValid = WDK.isValidSeedPhrase('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about')
+```javascript title="Validate Seed"
+const isValid = WDK.isValidSeed('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about')
 console.log('Seed phrase valid:', isValid) // true
 
-const isInvalid = WDK.isValidSeedPhrase('invalid seed phrase')
+const isInvalid = WDK.isValidSeed('invalid seed phrase')
 console.log('Seed phrase valid:', isInvalid) // false
 ```
 
@@ -588,6 +659,70 @@ type MiddlewareFunction = <A extends IWalletAccount>(
   account: A
 ) => Promise<A | void>;
 ```
+
+### Policy Types
+
+```typescript title="Types: Policy Engine"
+type PolicyAction = 'ALLOW' | 'DENY'
+type PolicyScope = 'project' | 'account'
+
+type PolicyOperation =
+  | 'sendTransaction'
+  | 'signTransaction'
+  | 'transfer'
+  | 'approve'
+  | 'sign'
+  | 'signTypedData'
+  | 'signAuthorization'
+  | 'delegate'
+  | 'revokeDelegation'
+  | 'swap'
+  | 'bridge'
+  | 'supply'
+  | 'withdraw'
+  | 'borrow'
+  | 'repay'
+  | 'buy'
+  | 'sell'
+  | 'swidge'
+  | '*'
+
+type PolicyCondition = (context: PolicyContext) => boolean | Promise<boolean>
+
+interface PolicyContext {
+  operation: PolicyOperation
+  wallet: string
+  account: IWalletAccountReadOnly
+  params: unknown
+  args: readonly unknown[]
+}
+
+interface PolicyRule {
+  name: string
+  operation: PolicyOperation | PolicyOperation[]
+  action: PolicyAction
+  conditions: PolicyCondition[]
+  reason?: string
+  override_broader_scope?: boolean
+}
+
+interface Policy {
+  id: string
+  name: string
+  scope: PolicyScope
+  wallet?: string | string[]
+  accounts?: Array<string | number>
+  rules: PolicyRule[]
+}
+
+interface RegisterPolicyOptions {
+  conditionTimeoutMs?: number
+}
+```
+
+`scope: 'project'` can apply across all registered wallets or only the wallets named in `wallet`. `scope: 'account'` requires both `wallet` and `accounts`; account entries can be a derivation path string or an account index number.
+
+Simulation results returned by the runtime `account.simulate.<method>(...)` mirrors include `decision`, `policy_id`, `matched_rule`, `reason`, and a `trace` array that records evaluated rules.
 
 ### Protocol Types
 

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -169,6 +169,8 @@ Registers one or more local transaction policies on the WDK instance.
 
 Policies are evaluated before wrapped account and protocol write methods execute. Matching `DENY` rules throw `PolicyViolationError`; matching `ALLOW` rules permit the call. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
 
+For policy scoping, default-deny behavior, account-level overrides, and protocol simulation examples, see [Transaction Policies](/sdk/core-module/guides/transaction-policies).
+
 **Parameters:**
 - `policies` (`Policy | Policy[]`): A single policy or an array of policies to register.
 - `options` (`RegisterPolicyOptions`, optional): Engine-level settings. `conditionTimeoutMs` defaults to `30000` milliseconds; the most recent value wins.
@@ -189,6 +191,13 @@ const wdk = new WDK(seedPhrase)
     scope: 'project',
     wallet: 'ethereum',
     rules: [
+      {
+        name: 'allow-normal-operations',
+        operation: '*',
+        action: 'ALLOW',
+        reason: 'Default local approval',
+        conditions: [() => true]
+      },
       {
         name: 'block-large-send',
         operation: 'sendTransaction',
@@ -228,6 +237,8 @@ try {
 ```
 
 Supported `PolicyOperation` values are `sendTransaction`, `signTransaction`, `transfer`, `approve`, `sign`, `signTypedData`, `signAuthorization`, `delegate`, `revokeDelegation`, `swap`, `bridge`, `supply`, `withdraw`, `borrow`, `repay`, `buy`, `sell`, `swidge`, and `*`.
+
+Use `sign` for message-style signing in this release. `signMessage` and `signHash` are not valid policy operation names.
 
 ##### `getAccount(blockchain, index?)`
 Returns a wallet account for a specific blockchain and index using BIP-44 derivation.

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -167,7 +167,7 @@ const wdk2 = new WDK(seedPhrase)
 ##### `registerPolicy(policies, options?)`
 Registers one or more local transaction policies on the WDK instance.
 
-Policies are evaluated before wrapped account and protocol write methods execute. Matching `DENY` rules throw `PolicyViolationError`; matching `ALLOW` rules permit the call. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
+Policies are evaluated before wrapped account and protocol write methods execute. Matching `DENY` rules and governed-account default-deny outcomes throw `PolicyViolationError`; matching `ALLOW` rules permit the call only when no higher-priority `DENY` rule applies. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
 
 For policy scoping, default-deny behavior, account-level overrides, and protocol simulation examples, see [Transaction Policies](/sdk/core-module/guides/transaction-policies).
 

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -43,7 +43,7 @@ const wdk2 = new WDK(seedBytes)
 
 | Method | Description | Returns | Throws |
 |--------|-------------|---------|--------|
-| `registerWallet(blockchain, wallet, config)` | Registers a new wallet manager for a blockchain | `WDK` | - |
+| `registerWallet(blockchain, wallet, config)` | Registers a new wallet manager for a blockchain | `WDK` | If a wallet is already registered for that blockchain |
 | `registerProtocol(blockchain, label, protocol, config)` | Registers a protocol globally for a blockchain | `WDK` | - |
 | `registerMiddleware(blockchain, middleware)` | Registers middleware for account decoration | `WDK` | - |
 | `getAccount(blockchain, index?)` | Returns a wallet account for a blockchain and index | `Promise<IWalletAccountWithProtocols>` | If wallet not registered |
@@ -63,6 +63,8 @@ Registers a new wallet manager for a specific blockchain.
 - `config` (`ConstructorParameters<W>[1]`): The configuration object for the wallet
 
 **Returns:** `WDK` - The wdk manager instance (supports method chaining)
+
+**Throws:** Error if a wallet is already registered for the same blockchain. Call `dispose([blockchain])` before registering a replacement wallet for that blockchain.
 
 **Example:**
 ```javascript title="Register Wallets"
@@ -92,8 +94,10 @@ const wdk2 = new WDK(seedPhrase)
 ##### `registerProtocol(blockchain, label, protocol, config)`
 Registers a protocol globally for all accounts of a specific blockchain.
 
+For swidge integrations, pass a concrete provider class that extends `SwidgeProtocol` from `@tetherto/wdk-wallet/protocols`.
+
 **Type Parameters:**
-- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocol`'s classes
+- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol | typeof FiatProtocol | typeof SwidgeProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocols` classes
 
 **Parameters:**
 - `blockchain` (string): The name of the blockchain
@@ -115,6 +119,9 @@ wdk.registerProtocol('ethereum', 'velora', veloraProtocolEvm, {
 
 // Register bridge protocol for Ethereum
 wdk.registerProtocol('ethereum', 'usdt0', Usdt0ProtocolEvm)
+
+// Register a concrete swidge provider for Ethereum
+wdk.registerProtocol('ethereum', 'swidge', MySwidgeProtocol, swidgeProtocolConfig)
 
 // Method chaining
 const wdk2 = new WDK(seedPhrase)
@@ -326,12 +333,14 @@ Extended wallet account interface that supports protocol registration and access
 | `getSwapProtocol(label)` | Returns the swap protocol with the given label | `ISwapProtocol` | If protocol not found |
 | `getBridgeProtocol(label)` | Returns the bridge protocol with the given label | `IBridgeProtocol` | If protocol not found |
 | `getLendingProtocol(label)` | Returns the lending protocol with the given label | `ILendingProtocol` | If protocol not found |
+| `getFiatProtocol(label)` | Returns the fiat protocol with the given label | `IFiatProtocol` | If protocol not found |
+| `getSwidgeProtocol(label)` | Returns the swidge protocol with the given label | `ISwidgeProtocol` | If protocol not found |
 
 ##### `registerProtocol(label, protocol, config)`
 Registers a new protocol for this specific account.
 
 **Type Parameters:**
-- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocol`'s classes
+- `P`: `typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol | typeof FiatProtocol | typeof SwidgeProtocol` - A class that extends one of the `@tetherto/wdk-wallet/protocols` classes
 
 **Parameters:**
 - `label` (string): Unique label for the protocol (must be unique per account and protocol type)
@@ -451,6 +460,61 @@ const aave = account.getLendingProtocol('aave')
 const supplyResult = await aave.supply({
   token: '0x...',
   amount: 1000000n
+})
+```
+
+##### `getFiatProtocol(label)`
+Returns the fiat protocol with the given label.
+
+**Parameters:**
+- `label` (string): The protocol label
+
+**Returns:** `IFiatProtocol` - The fiat protocol instance
+
+**Throws:** Error if no fiat protocol with the given label has been registered
+
+**Example:**
+```javascript title="Get Fiat Protocol"
+import MoonPayProtocol from '@tetherto/wdk-protocol-fiat-moonpay'
+
+// Register fiat protocol
+account.registerProtocol('moonpay', MoonPayProtocol, moonpayProtocolConfig)
+
+// Get fiat protocol
+const moonpay = account.getFiatProtocol('moonpay')
+
+const buyUrl = await moonpay.buy({
+  cryptoAsset: 'usdt',
+  fiatCurrency: 'usd',
+  fiatAmount: 10000n
+})
+```
+
+##### `getSwidgeProtocol(label)`
+Returns the swidge protocol with the given label.
+
+The examples below use `MySwidgeProtocol` as the concrete provider class supplied by your swidge provider module.
+
+**Parameters:**
+- `label` (string): The protocol label
+
+**Returns:** `ISwidgeProtocol` - The swidge protocol instance
+
+**Throws:** Error if no swidge protocol with the given label has been registered
+
+**Example:**
+```javascript title="Get Swidge Protocol"
+// Register a concrete provider class that extends SwidgeProtocol
+account.registerProtocol('swidge', MySwidgeProtocol, swidgeProtocolConfig)
+
+// Get swidge protocol
+const swidge = account.getSwidgeProtocol('swidge')
+
+const quote = await swidge.quoteSwidge({
+  fromToken: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  toToken: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+  toChain: 'arbitrum',
+  fromTokenAmount: 1000000n
 })
 ```
 

--- a/content/docs/sdk/core-module/guides/protocol-integration.mdx
+++ b/content/docs/sdk/core-module/guides/protocol-integration.mdx
@@ -54,13 +54,16 @@ const wdk = new WDK(seedPhrase)
 
 ## Use Protocols
 
-Once [registered](#register-protocols), you can access the protocol instance using the specific getter methods, such as `getSwapProtocol`, `getBridgeProtocol`, `getLendingProtocol`, or `getFiatProtocol`.
+Once [registered](#register-protocols), you can access the protocol instance using the specific getter methods, such as [`getSwidgeProtocol()`](/sdk/core-module/api-reference#getswidgeprotocollabel), `getSwapProtocol`, `getBridgeProtocol`, `getLendingProtocol`, or `getFiatProtocol`.
 
 ### Swidge Routes
 
-Use a swidge provider module for new swap, bridge, or combined route integrations. The shared swidge interface discovers supported chains and tokens with `getSupportedChains()` and `getSupportedTokens()`, quotes with `quoteSwidge()`, executes with `swidge()`, and tracks asynchronous settlement with `getSwidgeStatus()`. The provider can decide whether the route is fulfilled as a same-chain swap, same-token bridge, combined route, intent, solver route, or aggregator route. The example below assumes `swidge` is an instance of a concrete provider module that implements the shared interface.
+Use a swidge provider module for new swap, bridge, or combined route integrations. Retrieve a registered provider with [`getSwidgeProtocol()`](/sdk/core-module/api-reference#getswidgeprotocollabel). The shared swidge interface discovers supported chains and tokens with `getSupportedChains()` and `getSupportedTokens()`, quotes with `quoteSwidge()`, executes with `swidge()`, and tracks asynchronous settlement with `getSwidgeStatus()`. The provider can decide whether the route is fulfilled as a same-chain swap, same-token bridge, combined route, intent, solver route, or aggregator route.
 
 ```typescript title="Swidge route flow"
+const account = await wdk.getAccount('ethereum', 0)
+const swidge = account.getSwidgeProtocol('swidge')
+
 const chains = await swidge.getSupportedChains()
 const tokens = await swidge.getSupportedTokens({
   fromChain: 'ethereum',

--- a/content/docs/sdk/core-module/guides/transaction-policies.mdx
+++ b/content/docs/sdk/core-module/guides/transaction-policies.mdx
@@ -1,0 +1,221 @@
+---
+title: Transaction Policies
+description: Register local ALLOW and DENY rules for WDK account and protocol write methods.
+docType: how-to
+schemaType: TechArticle
+---
+
+Local transaction policies let a WDK app evaluate rules before account or protocol write methods execute. Use them for local approval limits, account-level exceptions, preflight checks, or UI flows that need a dry-run verdict before calling a wallet method.
+
+<Callout type="warn">
+Transaction policies are local pre-execution controls. They do not enforce rules on-chain, replace smart-contract permissions, or validate live token metadata, balances, prices, or contract state.
+</Callout>
+
+## Register Policies
+
+Register wallets before policies. `wdk.registerPolicy()` validates wallet bindings synchronously and throws `PolicyConfigurationError` if a policy references a wallet identifier that has not been registered.
+
+The example below allows normal operations, then denies ETH sends above a local approval limit. The wildcard `ALLOW` rule is intentional: once a policy governs an account, wrapped write operations are default-denied unless a matching `ALLOW` permits them.
+
+```typescript title="Register A Local Send Limit"
+import WDK, { PolicyViolationError } from '@tetherto/wdk'
+
+const wdk = new WDK(seedPhrase)
+  .registerWallet('ethereum', WalletManagerEvm, ethereumWalletConfig)
+  .registerPolicy({
+    id: 'eth-local-send-limit',
+    name: 'ETH local send limit',
+    scope: 'project',
+    wallet: 'ethereum',
+    rules: [
+      {
+        name: 'allow-normal-operations',
+        operation: '*',
+        action: 'ALLOW',
+        reason: 'Default local approval',
+        conditions: [() => true]
+      },
+      {
+        name: 'deny-large-eth-send',
+        operation: 'sendTransaction',
+        action: 'DENY',
+        reason: 'Amount exceeds the local approval limit',
+        conditions: [
+          ({ params }) => {
+            const value = (params as { value?: bigint } | null)?.value
+            return typeof value === 'bigint' && value > 1000000000000000000n
+          }
+        ]
+      }
+    ]
+  })
+
+const account = await wdk.getAccount('ethereum', 0)
+
+try {
+  await account.sendTransaction({
+    to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+    value: 2000000000000000000n
+  })
+} catch (error) {
+  if (error instanceof PolicyViolationError) {
+    console.error(error.reason)
+  }
+}
+```
+
+## Scope Policies
+
+Policies can target a whole project, selected wallets, or selected accounts.
+
+| Scope | Required fields | Applies to |
+| --- | --- | --- |
+| `project` without `wallet` | `scope`, `rules` | All registered wallets |
+| `project` with `wallet` | `scope`, `wallet`, `rules` | One wallet identifier or a list of wallet identifiers |
+| `account` | `scope`, `wallet`, `accounts`, `rules` | Specific account indices or derivation paths for one wallet |
+
+Account entries can be non-negative account indices or derivation-path strings. Index entries match accounts returned by `getAccount(wallet, index)`. Path entries match accounts returned by path-based retrieval.
+
+## Evaluation Rules
+
+- Account-scoped rules are evaluated before project-scoped rules.
+- `DENY` wins when both `ALLOW` and `DENY` rules match.
+- A governed account is default-denied for wrapped write methods that do not match an `ALLOW` rule.
+- `override_broader_scope: true` is only valid on account-scoped `ALLOW` rules, and it lets that account-level allow rule bypass broader project policies when it matches.
+
+```typescript title="Account-Level Exception"
+wdk.registerPolicy([
+  {
+    id: 'project-send-limit',
+    name: 'Project send limit',
+    scope: 'project',
+    wallet: 'ethereum',
+    rules: [
+      {
+        name: 'allow-normal-operations',
+        operation: '*',
+        action: 'ALLOW',
+        conditions: [() => true]
+      },
+      {
+        name: 'deny-large-send',
+        operation: 'sendTransaction',
+        action: 'DENY',
+        reason: 'Project send limit exceeded',
+        conditions: [
+          ({ params }) => {
+            const value = (params as { value?: bigint } | null)?.value
+            return typeof value === 'bigint' && value > 1000000000000000000n
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'treasury-account-override',
+    name: 'Treasury account override',
+    scope: 'account',
+    wallet: 'ethereum',
+    accounts: [0],
+    rules: [
+      {
+        name: 'allow-treasury-sends',
+        operation: 'sendTransaction',
+        action: 'ALLOW',
+        override_broader_scope: true,
+        reason: 'Treasury account has a higher local approval limit',
+        conditions: [
+          ({ params }) => {
+            const value = (params as { value?: bigint } | null)?.value
+            return typeof value === 'bigint' && value <= 10000000000000000000n
+          }
+        ]
+      }
+    ]
+  }
+])
+```
+
+## Supported Operations
+
+Use these operation names in `PolicyRule.operation`:
+
+| Operation | Method family |
+| --- | --- |
+| `sendTransaction` | Native transaction send |
+| `signTransaction` | Transaction signing without broadcast |
+| `transfer` | Token transfer methods |
+| `approve` | Token allowance approvals |
+| `sign` | Message or payload signing |
+| `signTypedData` | EIP-712 style typed-data signing |
+| `signAuthorization` | Authorization signing |
+| `delegate` | Delegation writes |
+| `revokeDelegation` | Delegation revocation |
+| `swap` | Swap protocol execution |
+| `bridge` | Bridge protocol execution |
+| `supply`, `withdraw`, `borrow`, `repay` | Lending protocol writes |
+| `buy`, `sell` | Fiat protocol writes |
+| `swidge` | Combined swap and bridge route execution |
+| `*` | Wildcard rule for all wrapped write operations |
+
+Use `sign` for message-style signing in this release. `signMessage` and `signHash` are not valid `PolicyOperation` values.
+
+## Inspect Policy Context
+
+Conditions receive a frozen `PolicyContext`:
+
+| Field | Description |
+| --- | --- |
+| `operation` | The operation being evaluated |
+| `wallet` | The wallet identifier bound to the account |
+| `account` | Read-only account view exposed by the wallet module |
+| `params` | The first argument passed to the wrapped method |
+| `args` | All arguments passed to the wrapped method |
+
+Conditions can be synchronous or asynchronous. `conditionTimeoutMs` defaults to `30000` milliseconds and can be set through `registerPolicy(policies, options)`. If a `DENY` condition throws or times out, WDK blocks the call. If an `ALLOW` condition throws or times out, WDK treats that allow rule as unmatched.
+
+## Simulate Before Execution
+
+When a policy applies to an account, WDK adds runtime `simulate` mirrors for wrapped account and protocol write methods. Simulation returns the policy verdict and does not call the underlying wallet or protocol method.
+
+```typescript title="Dry-Run A Transaction Policy"
+const account = await wdk.getAccount('ethereum', 0)
+
+const result = await (account as any).simulate.sendTransaction({
+  to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+  value: 2000000000000000000n
+})
+
+console.log(result.decision, result.reason, result.trace)
+```
+
+Simulation results include `decision`, `policy_id`, `matched_rule`, `reason`, and `trace`. Protocol write methods are also mirrored, for example `account.simulate.getSwapProtocol(label).swap(...)`.
+
+<Callout type="info">
+In this beta, `simulate` is added at runtime but is not typed on the account return type. Use a local helper interface or a narrow `as any` cast at the call site.
+</Callout>
+
+## Handle Errors
+
+`PolicyConfigurationError` means WDK rejected the policy setup. Common causes include invalid scopes, actions, operation names, condition functions, timeout options, missing account bindings, or wallet identifiers that have not been registered.
+
+`PolicyViolationError` means an enforced write call matched a blocking policy rule. Catch it around the write call and surface the `reason` to the user or approval workflow.
+
+## Runtime Caveats
+
+- Policies wrap the WDK account/protocol proxy surface. Private fields, underscore methods, protocol internals, or nested calls made inside a module can bypass local policy evaluation.
+- Quote and read methods are not wrapped. Policies apply to write methods such as sends, signs, swaps, bridges, lending writes, fiat writes, and swidge execution.
+- Wallet accounts must expose a read-only account view when a policy applies, otherwise `getAccount()` fails with `PolicyConfigurationError`.
+- Avoid relying on engine-managed durable policy state in this beta. Use explicit application state or closures for local checks that need state.
+
+## Next Steps
+
+- Review [`registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options) in the API reference.
+- Use [Send Transactions](/sdk/core-module/guides/transactions) for base account send flows.
+- Use [Protocol Integration](/sdk/core-module/guides/protocol-integration) for swap, bridge, lending, fiat, and swidge method setup.
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/sdk/core-module/guides/transaction-policies.mdx
+++ b/content/docs/sdk/core-module/guides/transaction-policies.mdx
@@ -199,7 +199,7 @@ In this beta, `simulate` is added at runtime but is not typed on the account ret
 
 `PolicyConfigurationError` means WDK rejected the policy setup. Common causes include invalid scopes, actions, operation names, condition functions, timeout options, missing account bindings, or wallet identifiers that have not been registered.
 
-`PolicyViolationError` means an enforced write call matched a blocking policy rule. Catch it around the write call and surface the `reason` to the user or approval workflow.
+`PolicyViolationError` means an enforced write call was blocked by a matching `DENY` rule or by default-deny when no `ALLOW` rule matched. Catch it around the write call and surface the `reason` to the user or approval workflow.
 
 ## Runtime Caveats
 

--- a/content/docs/sdk/core-module/guides/transactions.mdx
+++ b/content/docs/sdk/core-module/guides/transactions.mdx
@@ -81,6 +81,59 @@ console.log('Signed transaction:', signedTransaction)
 `signTransaction()` only signs. Use `sendTransaction()` when you want WDK to sign, broadcast, and return the transaction hash.
 </Callout>
 
+## Apply Local Transaction Policies
+
+Use [`wdk.registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options) to evaluate local ALLOW and DENY rules before account or protocol write methods run. Policies can target a full wallet identifier or selected account indices and derivation paths.
+
+```typescript title="Deny Large ETH Sends"
+import { PolicyViolationError } from '@tetherto/wdk'
+
+wdk.registerPolicy({
+  id: 'large-eth-send-limit',
+  name: 'Large ETH send limit',
+  scope: 'project',
+  wallet: 'ethereum',
+  rules: [
+    {
+      name: 'deny-large-send',
+      operation: 'sendTransaction',
+      action: 'DENY',
+      reason: 'Amount exceeds the local approval limit',
+      conditions: [
+        ({ params }) => {
+          const value = (params as { value?: bigint } | null)?.value
+          return typeof value === 'bigint' && value > 1000000000000000000n
+        }
+      ]
+    }
+  ]
+})
+
+const ethAccount = await wdk.getAccount('ethereum', 0)
+
+const preview = await (ethAccount as any).simulate.sendTransaction({
+  to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+  value: 2000000000000000000n
+})
+
+if (preview.decision === 'DENY') {
+  console.warn(preview.reason)
+}
+
+try {
+  await ethAccount.sendTransaction({
+    to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+    value: 2000000000000000000n
+  })
+} catch (error) {
+  if (error instanceof PolicyViolationError) {
+    console.error(error.reason)
+  }
+}
+```
+
+`simulate` methods return a structured verdict and do not call the underlying wallet or protocol method. The enforced write call throws `PolicyViolationError` when a matching DENY rule blocks execution.
+
 ## Handling Responses
 
 The `sendTransaction` method returns a [transaction result object](/sdk/core-module/api-reference). The most important field is typically `hash`, which represents the transaction ID on the blockchain. You can use this hash to track the status of your payment on a block explorer.

--- a/content/docs/sdk/core-module/guides/transactions.mdx
+++ b/content/docs/sdk/core-module/guides/transactions.mdx
@@ -85,54 +85,9 @@ console.log('Signed transaction:', signedTransaction)
 
 Use [`wdk.registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options) to evaluate local ALLOW and DENY rules before account or protocol write methods run. Policies can target a full wallet identifier or selected account indices and derivation paths.
 
-```typescript title="Deny Large ETH Sends"
-import { PolicyViolationError } from '@tetherto/wdk'
+When a policy governs an account, wrapped write operations are default-denied unless a matching `ALLOW` permits them. For approval limits, start with an explicit `ALLOW` baseline and add narrower `DENY` rules for blocked cases.
 
-wdk.registerPolicy({
-  id: 'large-eth-send-limit',
-  name: 'Large ETH send limit',
-  scope: 'project',
-  wallet: 'ethereum',
-  rules: [
-    {
-      name: 'deny-large-send',
-      operation: 'sendTransaction',
-      action: 'DENY',
-      reason: 'Amount exceeds the local approval limit',
-      conditions: [
-        ({ params }) => {
-          const value = (params as { value?: bigint } | null)?.value
-          return typeof value === 'bigint' && value > 1000000000000000000n
-        }
-      ]
-    }
-  ]
-})
-
-const ethAccount = await wdk.getAccount('ethereum', 0)
-
-const preview = await (ethAccount as any).simulate.sendTransaction({
-  to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
-  value: 2000000000000000000n
-})
-
-if (preview.decision === 'DENY') {
-  console.warn(preview.reason)
-}
-
-try {
-  await ethAccount.sendTransaction({
-    to: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
-    value: 2000000000000000000n
-  })
-} catch (error) {
-  if (error instanceof PolicyViolationError) {
-    console.error(error.reason)
-  }
-}
-```
-
-`simulate` methods return a structured verdict and do not call the underlying wallet or protocol method. The enforced write call throws `PolicyViolationError` when a matching DENY rule blocks execution.
+See [Transaction Policies](/sdk/core-module/guides/transaction-policies) for policy scope, evaluation order, simulation, and error-handling examples.
 
 ## Handling Responses
 
@@ -168,4 +123,4 @@ async function sendCrossChainPayments(wdk) {
 
 ## Next Steps
 
-For more complex interactions like swapping tokens or bridging assets, learn how to [integrate protocols](/sdk/core-module/guides/protocol-integration).
+For more complex interactions like swapping tokens or bridging assets, learn how to [integrate protocols](/sdk/core-module/guides/protocol-integration). To guard writes before they execute, add [local transaction policies](/sdk/core-module/guides/transaction-policies).

--- a/content/docs/sdk/core-module/index.mdx
+++ b/content/docs/sdk/core-module/index.mdx
@@ -29,6 +29,9 @@ Get started with WDK's API
 <Card title="WDK Core Usage" href="/sdk/core-module/usage">
 Get started with WDK's usage
 </Card>
+<Card title="Transaction Policies" href="/sdk/core-module/guides/transaction-policies">
+Allow, deny, and simulate local write operations before execution
+</Card>
 </Cards>
 
 ***

--- a/content/docs/sdk/core-module/index.mdx
+++ b/content/docs/sdk/core-module/index.mdx
@@ -1,11 +1,18 @@
 ---
 title: WDK Core
-description: Overview of the @tetherto/wdk-core module
+description: Overview of the @tetherto/wdk module
 docType: explanation
 schemaType: TechArticle
 ---
 
- This package serves as the main entry point and **orchestrator for all WDK wallet and protocol modules**, allowing you to register and manage different blockchain wallets through a single, unified interface.
+This package serves as the main entry point and **orchestrator for all WDK wallet and protocol modules**, allowing you to register and manage different blockchain wallets through a single, unified interface.
+
+Use WDK Core to:
+
+- Register wallet managers for the chains your app supports.
+- Attach swap, bridge, lending, fiat, and swidge protocol providers to accounts.
+- Decorate accounts with middleware before they reach the application.
+- Register local transaction policies that allow, deny, or simulate write operations before they execute.
 
 ## Next Steps
 

--- a/content/docs/sdk/core-module/usage.mdx
+++ b/content/docs/sdk/core-module/usage.mdx
@@ -21,6 +21,9 @@ Retrieve accounts and check balances.
 <Card title="Send Transactions" href="/sdk/core-module/guides/transactions">
 Transfer native tokens.
 </Card>
+<Card title="Transaction Policies" href="/sdk/core-module/guides/transaction-policies">
+Allow, deny, and simulate writes before execution.
+</Card>
 <Card title="Integrate Protocols" href="/sdk/core-module/guides/protocol-integration">
 Use Swidge, Swap, Bridge, and Lending protocols.
 </Card>

--- a/content/docs/sdk/swap-modules/index.mdx
+++ b/content/docs/sdk/swap-modules/index.mdx
@@ -7,10 +7,6 @@ schemaType: TechArticle
 
 The Swap Development Kit (WDK) provides a set of modules that support swap on top of multiple blockchain networks. All modules share a common interface, ensuring consistent behavior across different blockchain implementations.
 
-<Callout type="info">
-WDK is introducing the [swidge interface](/sdk/swidge-modules) as the preferred interface for new swap, bridge, and combined route providers. Existing swap modules remain supported, but new protocol integrations should prefer swidge because the standalone swap interface is expected to be deprecated in a future release once swidge provider coverage is available.
-</Callout>
-
 ## Swap Protocol Modules
 
 DeFi swap functionality for token exchanges across different DEXs:
@@ -32,3 +28,7 @@ You can also:
 
 - Learn about key concepts like [Account Abstraction](/resources/concepts#account-abstraction) and other important definitions
 - Use one of our ready-to-use examples to be production ready
+
+## Combined swap and bridge routes
+
+When a route needs both a token swap and cross-chain movement, use the [Swidge protocol interface](/sdk/swidge-modules) instead of wiring separate swap and bridge flows manually. The shared interface covers route discovery, quoting, execution, and status tracking for combined asset routes.

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -62,6 +62,7 @@ Wallet implementations that support [Account Abstraction](/resources/concepts#ac
 | Module | Blockchain | Status | Documentation |
 |--------|------------|--------|---------------|
 | [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-erc-4337) |
+| [`@tetherto/wdk-wallet-evm-7702-gasless`](https://github.com/tetherto/wdk-wallet-evm-7702-gasless) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-7702-gasless) |
 | [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-ton-gasless) |
 | [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-tron-gasfree) |
 | `@tetherto/wdk-wallet-solana-jupiterz` | Solana | In progress | - |

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -7,6 +7,15 @@ schemaType: TechArticle
 
 The Wallet Development Kit (WDK) provides a set of modules that support multiple blockchain networks. All modules share a common interface, ensuring consistent behavior across different blockchain implementations.
 
+## Shared Fee Limits
+
+Wallet modules can expose fee caps through their configuration objects. Use the chain-specific docs for exact units and supported operations.
+
+| Option | Applies to | Description |
+|--------|------------|-------------|
+| `transferMaxFee` | `transfer()` | Caps token transfer fees in the module's base fee unit. |
+| `transactionMaxFee` | `sendTransaction()` and `signTransaction()` | Caps native transaction send/sign flows separately from token transfers when the module supports that base wallet option. |
+
 ## Supported Networks
 
 This package works with multiple blockchain networks through wallet registration.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference.mdx
@@ -73,7 +73,7 @@ new WalletAccountEvm7702Gasless(walletAccountEvm, config)
 | Property | Type | Description |
 |----------|------|-------------|
 | `index` | `number` | Derivation path index from the wrapped EVM account. |
-| `path` | `string` | Derivation path suffix from the wrapped EVM account. |
+| `path` | `string` | Full derivation path from the wrapped EVM account. |
 | `keyPair` | `KeyPair` | Read-only view of the wrapped EVM account key pair. |
 
 Treat the arrays returned through `keyPair` as read-only. Call `dispose()` when the account is no longer needed.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference.mdx
@@ -1,0 +1,216 @@
+---
+title: Wallet EVM 7702 Gasless API Reference
+description: Complete API documentation for @tetherto/wdk-wallet-evm-7702-gasless.
+docType: reference
+schemaType: APIReference
+icon: Code
+---
+
+## Table of Contents
+
+| Export | Description |
+|--------|-------------|
+| [WalletManagerEvm7702Gasless](#walletmanagerevm7702gasless) | Default export. Manages EIP-7702 gasless EVM wallet accounts. |
+| [WalletAccountEvm7702Gasless](#walletaccountevm7702gasless) | Owned EIP-7702 gasless account with signing, approval, transfer, and send methods. |
+| [WalletAccountReadOnlyEvm7702Gasless](#walletaccountreadonlyevm7702gasless) | Read-only account with balances, quotes, receipts, allowances, and verification. |
+| [ConfigurationError](#configurationerror) | Error thrown for invalid wallet configuration. |
+| [Config Types](#config-types) | `Evm7702GaslessWalletConfig` and related fee-mode types. |
+
+## WalletManagerEvm7702Gasless
+
+Default export from `@tetherto/wdk-wallet-evm-7702-gasless`.
+
+```javascript
+import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
+```
+
+### Constructor
+
+```javascript
+new WalletManagerEvm7702Gasless(seed, config)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `seed` | `string \| Uint8Array` | BIP-39 mnemonic seed phrase or seed bytes. |
+| `config` | `Evm7702GaslessWalletConfig` | Wallet configuration with common fields and one fee mode. |
+
+### Methods
+
+| Method | Parameters | Returns | Notes |
+|--------|------------|---------|-------|
+| `getAccount(index?)` | `index?: number` | `Promise\<WalletAccountEvm7702Gasless\>` | Defaults to index `0` and derives `0'/0/{index}`. |
+| `getAccountByPath(path)` | `path: string` | `Promise\<WalletAccountEvm7702Gasless\>` | Returns a cached account for the derivation path suffix. |
+| `getFeeRates()` | - | `Promise\<{ normal: bigint, fast: bigint }\>` | Uses provider fee data. Throws if no provider is connected. |
+| `dispose()` | - | `void` | Inherited from `WalletManager`; disposes managed accounts. |
+
+`getFeeRates()` returns fee rates in wei. The `normal` value applies the EVM wallet normal multiplier, and `fast` applies the EVM wallet fast multiplier to the provider fee.
+
+## WalletAccountEvm7702Gasless
+
+Named export for owned EIP-7702 gasless accounts.
+
+```javascript
+import { WalletAccountEvm7702Gasless } from '@tetherto/wdk-wallet-evm-7702-gasless'
+```
+
+### Constructors
+
+```javascript
+new WalletAccountEvm7702Gasless(seed, path, config)
+new WalletAccountEvm7702Gasless(walletAccountEvm, config)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `seed` | `string \| Uint8Array` | BIP-39 mnemonic seed phrase or seed bytes. |
+| `path` | `string` | EVM derivation path suffix, for example `"0'/0/0"`. |
+| `walletAccountEvm` | `WalletAccountEvm` | Existing EVM account to wrap. |
+| `config` | `Evm7702GaslessWalletConfig` | Wallet configuration. |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `index` | `number` | Derivation path index from the wrapped EVM account. |
+| `path` | `string` | Derivation path suffix from the wrapped EVM account. |
+| `keyPair` | `KeyPair` | Read-only view of the wrapped EVM account key pair. |
+
+Treat the arrays returned through `keyPair` as read-only. Call `dispose()` when the account is no longer needed.
+
+### Methods
+
+| Method | Parameters | Returns | Notes |
+|--------|------------|---------|-------|
+| `getAddress()` | - | `Promise\<string\>` | Inherited read-only method. Returns the EOA address. |
+| `getBalance()` | - | `Promise\<bigint\>` | Native token balance in wei. |
+| `getTokenBalance(tokenAddress)` | `tokenAddress: string` | `Promise\<bigint\>` | ERC-20 balance in base units. |
+| `getTokenBalances(tokenAddresses)` | `tokenAddresses: string[]` | `Promise\<Record\<string, bigint\>\>` | Multiple ERC-20 balances in base units. |
+| `getPaymasterTokenBalance()` | - | `Promise\<bigint\>` | Throws `ConfigurationError` when no `paymasterToken` is configured. |
+| `sign(message)` | `message: string` | `Promise\<string\>` | Signs with the wrapped EVM account. |
+| `signTypedData(typedData)` | `TypedData` | `Promise\<string\>` | Signs EIP-712 typed data. |
+| `verify(message, signature)` | `message: string`, `signature: string` | `Promise\<boolean\>` | Verifies a plain message signature. |
+| `verifyTypedData(typedData, signature)` | `TypedData`, `signature: string` | `Promise\<boolean\>` | Verifies EIP-712 typed data. |
+| `approve(options)` | `ApproveOptions` | `Promise\<TransactionResult\>` | Sends an ERC-20 approval as a UserOperation. |
+| `quoteSendTransaction(tx, config?)` | `EvmTransaction \| EvmTransaction[]`, partial fee-mode config | `Promise\<Omit\<TransactionResult, 'hash'\>\>` | Returns `{ fee }`; owned accounts cache paymaster-token quotes for up to 2 minutes. |
+| `sendTransaction(tx, config?)` | `EvmTransaction \| EvmTransaction[]`, partial fee-mode config | `Promise\<TransactionResult\>` | Returns a UserOperation hash and fee. |
+| `quoteTransfer(options, config?)` | `EvmTransferOptions`, partial fee-mode config | `Promise\<Omit\<TransferResult, 'hash'\>\>` | Quotes an ERC-20 transfer. |
+| `transfer(options, config?)` | `EvmTransferOptions`, partial fee-mode config | `Promise\<TransferResult\>` | Sends an ERC-20 transfer as a UserOperation. |
+| `getAllowance(token, spender)` | `token: string`, `spender: string` | `Promise\<bigint\>` | Reads ERC-20 allowance. |
+| `getUserOperationReceipt(hash)` | `hash: string` | `Promise\<UserOperationReceipt \| null\>` | Reads the raw bundler receipt. |
+| `getTransactionReceipt(hash)` | `hash: string` | `Promise\<EvmTransactionReceipt \| null\>` | Maps a UserOperation hash to an EVM receipt when included. |
+| `toReadOnlyAccount()` | - | `Promise\<WalletAccountReadOnlyEvm7702Gasless\>` | Returns a cached read-only account. |
+| `dispose()` | - | `void` | Clears quote cache and disposes the wrapped EVM account. |
+
+### Quote and Send Behavior
+
+- Sponsored mode returns `fee: 0n` from quote methods.
+- Paymaster-token mode returns fees in the configured paymaster token's base units.
+- Owned account quotes are cached for up to 2 minutes for the same serialized transaction.
+- `sendTransaction()` signs the UserOperation typed data before submitting it to the bundler.
+- If the account is already delegated to `delegationAddress`, the send path does not include a new EIP-7702 authorization.
+
+### Transfer Fee Cap
+
+`transfer()` checks `transferMaxFee` only in paymaster-token mode. It throws when the estimated fee is greater than or equal to the configured cap.
+
+### USDT Approval Rule
+
+On Ethereum mainnet, `approve()` checks the USDT allowance rule. If the current allowance is non-zero and the requested amount is non-zero, the method throws before sending. Send an approval with amount `0` first, then send the new non-zero approval.
+
+## WalletAccountReadOnlyEvm7702Gasless
+
+Named export for read-only accounts.
+
+```javascript
+import { WalletAccountReadOnlyEvm7702Gasless } from '@tetherto/wdk-wallet-evm-7702-gasless'
+```
+
+### Constructor
+
+```javascript
+new WalletAccountReadOnlyEvm7702Gasless(address, config)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `address` | `string` | EOA address. |
+| `config` | `Omit\<Evm7702GaslessWalletConfig, 'transferMaxFee'\>` | Read-only configuration. |
+
+### Methods
+
+| Method | Parameters | Returns | Notes |
+|--------|------------|---------|-------|
+| `getAddress()` | - | `Promise\<string\>` | Returns the configured address. |
+| `getBalance()` | - | `Promise\<bigint\>` | Native token balance in wei. |
+| `getTokenBalance(tokenAddress)` | `tokenAddress: string` | `Promise\<bigint\>` | ERC-20 balance in base units. |
+| `getTokenBalances(tokenAddresses)` | `tokenAddresses: string[]` | `Promise\<Record\<string, bigint\>\>` | Multiple ERC-20 balances. |
+| `getPaymasterTokenBalance()` | - | `Promise\<bigint\>` | Reads the configured paymaster token balance. |
+| `quoteSendTransaction(tx, config?)` | `EvmTransaction \| EvmTransaction[]`, partial fee-mode config | `Promise\<Omit\<TransactionResult, 'hash'\>\>` | Quotes without signing or sending. |
+| `quoteTransfer(options, config?)` | `EvmTransferOptions`, partial fee-mode config | `Promise\<Omit\<TransferResult, 'hash'\>\>` | Quotes an ERC-20 transfer. |
+| `getAllowance(token, spender)` | `token: string`, `spender: string` | `Promise\<bigint\>` | Reads ERC-20 allowance. |
+| `getUserOperationReceipt(hash)` | `hash: string` | `Promise\<UserOperationReceipt \| null\>` | Reads the raw bundler receipt. |
+| `getTransactionReceipt(hash)` | `hash: string` | `Promise\<EvmTransactionReceipt \| null\>` | Returns `null` until the UserOperation maps to an EVM transaction. |
+| `verify(message, signature)` | `message: string`, `signature: string` | `Promise\<boolean\>` | Verifies a plain message signature. |
+| `verifyTypedData(typedData, signature)` | `TypedData`, `signature: string` | `Promise\<boolean\>` | Verifies EIP-712 typed data. |
+
+Read-only accounts cannot sign, approve, send, or transfer.
+
+## ConfigurationError
+
+```javascript
+import { ConfigurationError } from '@tetherto/wdk-wallet-evm-7702-gasless'
+```
+
+`ConfigurationError` extends `Error` and is thrown when wallet configuration is invalid.
+
+Known configuration errors include:
+
+- missing `provider`;
+- missing `bundlerUrl`;
+- missing `delegationAddress`;
+- missing `paymasterToken` when `isSponsored` is absent or `false`;
+- empty provider array;
+- configured `paymasterAddress` does not match the paymaster returned by the RPC.
+
+## Config Types
+
+### Evm7702GaslessWalletCommonConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | `string \| Eip1193Provider \| Array\<string \| Eip1193Provider\>` | Yes | RPC endpoint, EIP-1193 provider, or provider failover list. |
+| `retries` | `number` | No | Additional retry attempts for provider arrays. Defaults to `3`. |
+| `bundlerUrl` | `string` | Yes | ERC-4337 bundler endpoint. |
+| `paymasterUrl` | `string` | No | Paymaster endpoint when different from `bundlerUrl`. |
+| `delegationAddress` | `string` | Yes | Smart-account implementation address used for EIP-7702 delegation. |
+
+### Evm7702GaslessSponsorshipPolicyConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `isSponsored` | `true` | Yes | Enables sponsored fee mode. |
+| `sponsorshipPolicyId` | `string` | No | Paymaster sponsorship policy ID. |
+
+### Evm7702GaslessPaymasterTokenConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `isSponsored` | `false` | No | Omit or set to `false` for paymaster-token mode. |
+| `paymasterAddress` | `string` | No | Expected paymaster contract address. |
+| `paymasterToken.address` | `string` | Yes | ERC-20 token used for fee payment. |
+| `transferMaxFee` | `number \| bigint` | No | Maximum fee for `transfer()` in token base units. |
+
+### Evm7702GaslessWalletConfig
+
+```typescript
+type Evm7702GaslessWalletConfig =
+  Evm7702GaslessWalletCommonConfig &
+  (Evm7702GaslessSponsorshipPolicyConfig | Evm7702GaslessPaymasterTokenConfig)
+```
+
+### Exported Types
+
+The package also re-exports EVM wallet types from `@tetherto/wdk-wallet-evm`, including `FeeRates`, `KeyPair`, `EvmTransaction`, `TransactionResult`, `EvmTransferOptions`, `TransferResult`, `EvmTransactionReceipt`, `ApproveOptions`, `TypedData`, `TypedDataDomain`, and `TypedDataField`.
+
+Module-specific exported types include `UserOperationReceipt`, `Eip7702AuthorizationOverride`, `BuildSponsoredUserOperationOverrides`, and `SponsoredUserOperation`.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
@@ -1,0 +1,157 @@
+---
+title: Configuration
+description: Configuration options for @tetherto/wdk-wallet-evm-7702-gasless.
+docType: reference
+schemaType: TechArticle
+icon: Settings
+---
+
+## Wallet Configuration
+
+`WalletManagerEvm7702Gasless`, `WalletAccountEvm7702Gasless`, and `WalletAccountReadOnlyEvm7702Gasless` use the same base configuration. The account must also choose one fee mode: sponsorship policy or paymaster token.
+
+```javascript title="Sponsored wallet configuration"
+import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
+
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  isSponsored: true,
+  sponsorshipPolicyId: 'sp_my_policy'
+})
+```
+
+```javascript title="Paymaster-token wallet configuration"
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  paymasterAddress: '0x888888888888Ec68A58AB8094Cc1AD20Ba3D2402',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  },
+  transferMaxFee: 100000000000000n
+})
+```
+
+## Required Common Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `provider` | `string \| Eip1193Provider \| Array\<string \| Eip1193Provider\>` | RPC endpoint, EIP-1193 provider, or ordered failover list. |
+| `bundlerUrl` | `string` | ERC-4337 bundler endpoint used to build and submit UserOperations. |
+| `delegationAddress` | `string` | Smart-account implementation address used for EIP-7702 delegation. |
+
+The constructor throws `ConfigurationError` if any required common field is missing.
+
+## Optional Common Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `paymasterUrl` | `string` | `bundlerUrl` | Paymaster endpoint when it differs from the bundler endpoint. |
+| `retries` | `number` | `3` | Additional retry attempts when `provider` is an array. Total attempts are `1 + retries`. |
+
+### Provider Failover
+
+Pass an ordered array when you want read and quote calls to retry against multiple RPC providers:
+
+```javascript title="Provider failover"
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: [
+    'https://rpc.mevblocker.io/fast',
+    'https://eth.llamarpc.com'
+  ],
+  retries: 3,
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  isSponsored: true
+})
+```
+
+<Callout type="warn">
+An empty provider array throws `ConfigurationError`. Include at least one RPC URL or EIP-1193 provider.
+</Callout>
+
+## Fee Mode Configuration
+
+### Sponsorship Policy
+
+Use sponsorship mode when a paymaster sponsors UserOperation fees.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `isSponsored` | `true` | Yes | Enables sponsorship mode. |
+| `sponsorshipPolicyId` | `string` | No | Policy identifier passed to the paymaster context. |
+
+```javascript title="Sponsorship mode"
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  isSponsored: true,
+  sponsorshipPolicyId: 'sp_my_policy'
+})
+```
+
+In sponsorship mode, `quoteSendTransaction()` and `quoteTransfer()` return `{ fee: 0n }`.
+
+### Paymaster Token
+
+Use paymaster-token mode when the account pays UserOperation fees with an ERC-20 token.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `isSponsored` | `false` | No | Omit this field or set it to `false`. |
+| `paymasterToken.address` | `string` | Yes | ERC-20 token address used for fee payment. |
+| `paymasterAddress` | `string` | No | Pins the expected paymaster contract address. |
+| `transferMaxFee` | `number \| bigint` | No | Maximum fee for `transfer()` operations, in paymaster-token base units. |
+
+If `isSponsored` is omitted or `false`, `paymasterToken` is required.
+
+```javascript title="Paymaster token mode"
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  },
+  transferMaxFee: 100000000000000n
+})
+```
+
+When `paymasterAddress` is set, the account checks the paymaster address returned by the RPC response and throws `ConfigurationError` if it does not match.
+
+## Separate Paymaster Endpoint
+
+Some providers use different bundler and paymaster URLs. Set `paymasterUrl` when the paymaster service is not available at `bundlerUrl`.
+
+```javascript title="Separate paymaster endpoint"
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.candide.dev/bundler/v3/1/YOUR_KEY',
+  paymasterUrl: 'https://api.candide.dev/paymaster/v3/1/YOUR_KEY',
+  isSponsored: true,
+  sponsorshipPolicyId: 'your_policy_id'
+})
+```
+
+## Per-call Overrides
+
+`quoteSendTransaction()`, `sendTransaction()`, `quoteTransfer()`, and `transfer()` accept a partial fee-mode config override. Use this to switch sponsorship policy or paymaster token for one operation:
+
+```javascript title="Override the paymaster token"
+const result = await account.sendTransaction({
+  to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+  value: 0n,
+  data: '0x'
+}, {
+  paymasterToken: {
+    address: '0x68749665FF8D2d112Fa859AA293F07A622782F38'
+  }
+})
+```
+
+When an override is provided, the merged config is validated before the operation runs.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
@@ -10,12 +10,16 @@ icon: Settings
 
 `WalletManagerEvm7702Gasless`, `WalletAccountEvm7702Gasless`, and `WalletAccountReadOnlyEvm7702Gasless` use the same base configuration. The account must also choose one fee mode: sponsorship policy or paymaster token.
 
+<Callout type="warn">
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain. The EOA delegates execution to this address.
+</Callout>
+
 ```javascript title="Sponsored wallet configuration"
 import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
 
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true,
   sponsorshipPolicyId: 'sp_my_policy'
@@ -25,13 +29,13 @@ const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
 ```javascript title="Paymaster-token wallet configuration"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   paymasterAddress: '0x888888888888Ec68A58AB8094Cc1AD20Ba3D2402',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  transferMaxFee: 100000000000000n
+  transferMaxFee: 100000n // 0.1 USDT when the token has 6 decimals
 })
 ```
 
@@ -43,7 +47,7 @@ const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
 | `bundlerUrl` | `string` | ERC-4337 bundler endpoint used to build and submit UserOperations. |
 | `delegationAddress` | `string` | Smart-account implementation address used for EIP-7702 delegation. |
 
-The constructor throws `ConfigurationError` if any required common field is missing.
+Account constructors and per-call config overrides throw `ConfigurationError` if any required common field is missing.
 
 ## Optional Common Fields
 
@@ -63,7 +67,7 @@ const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
     'https://eth.llamarpc.com'
   ],
   retries: 3,
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true
 })
@@ -87,7 +91,7 @@ Use sponsorship mode when a paymaster sponsors UserOperation fees.
 ```javascript title="Sponsorship mode"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true,
   sponsorshipPolicyId: 'sp_my_policy'
@@ -105,19 +109,19 @@ Use paymaster-token mode when the account pays UserOperation fees with an ERC-20
 | `isSponsored` | `false` | No | Omit this field or set it to `false`. |
 | `paymasterToken.address` | `string` | Yes | ERC-20 token address used for fee payment. |
 | `paymasterAddress` | `string` | No | Pins the expected paymaster contract address. |
-| `transferMaxFee` | `number \| bigint` | No | Maximum fee for `transfer()` operations, in paymaster-token base units. |
+| `transferMaxFee` | `number \| bigint` | No | Maximum fee for `transfer()` operations, in paymaster-token base units. Choose the value using the token's decimals. |
 
 If `isSponsored` is omitted or `false`, `paymasterToken` is required.
 
 ```javascript title="Paymaster token mode"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  transferMaxFee: 100000000000000n
+  transferMaxFee: 100000n // 0.1 USDT when the token has 6 decimals
 })
 ```
 
@@ -130,7 +134,7 @@ Some providers use different bundler and paymaster URLs. Set `paymasterUrl` when
 ```javascript title="Separate paymaster endpoint"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.candide.dev/bundler/v3/1/YOUR_KEY',
   paymasterUrl: 'https://api.candide.dev/paymaster/v3/1/YOUR_KEY',
   isSponsored: true,
@@ -140,7 +144,7 @@ const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
 
 ## Per-call Overrides
 
-`quoteSendTransaction()`, `sendTransaction()`, `quoteTransfer()`, and `transfer()` accept a partial fee-mode config override. Use this to switch sponsorship policy or paymaster token for one operation:
+`quoteSendTransaction()`, `sendTransaction()`, `quoteTransfer()`, and `transfer()` accept a partial fee-mode config override. Overrides are shallow-merged with the account config. Include `isSponsored: false` when switching a sponsored account to paymaster-token mode for one operation:
 
 ```javascript title="Override the paymaster token"
 const result = await account.sendTransaction({
@@ -148,6 +152,7 @@ const result = await account.sendTransaction({
   value: 0n,
   data: '0x'
 }, {
+  isSponsored: false,
   paymasterToken: {
     address: '0x68749665FF8D2d112Fa859AA293F07A622782F38'
   }

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/check-balances.mdx
@@ -1,0 +1,63 @@
+---
+title: Check Balances
+description: Query native, ERC-20, and paymaster token balances.
+docType: how-to
+---
+
+This guide explains how to read balances from an EIP-7702 gasless account.
+
+## Native Balance
+
+Use `getBalance()` to read the native token balance in wei.
+
+```javascript title="Get native balance"
+const balance = await account.getBalance()
+console.log('Native balance:', balance)
+```
+
+## ERC-20 Balance
+
+Use `getTokenBalance(tokenAddress)` to read one ERC-20 token balance in the token's base units.
+
+```javascript title="Get token balance"
+const usdtBalance = await account.getTokenBalance('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+console.log('USDT balance:', usdtBalance)
+```
+
+## Multiple ERC-20 Balances
+
+Use `getTokenBalances(tokenAddresses)` to read several token balances at once.
+
+```javascript title="Get multiple token balances"
+const balances = await account.getTokenBalances([
+  '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+])
+
+console.log(balances)
+```
+
+The return value maps each token address to a `bigint` balance.
+
+## Paymaster Token Balance
+
+In paymaster-token mode, `getPaymasterTokenBalance()` reads the configured `paymasterToken.address`.
+
+```javascript title="Get paymaster token balance"
+const feeTokenBalance = await account.getPaymasterTokenBalance()
+console.log('Paymaster token balance:', feeTokenBalance)
+```
+
+<Callout type="warn">
+`getPaymasterTokenBalance()` throws `ConfigurationError` when the account is configured for sponsorship mode because no paymaster token is present.
+</Callout>
+
+## Read-only Balance Checks
+
+All balance methods are available on `WalletAccountReadOnlyEvm7702Gasless`.
+
+```javascript title="Read-only balance checks"
+const readOnlyAccount = await account.toReadOnlyAccount()
+const balance = await readOnlyAccount.getBalance()
+const tokenBalance = await readOnlyAccount.getTokenBalance('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+```

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started.mdx
@@ -1,0 +1,65 @@
+---
+title: Get Started
+description: Install @tetherto/wdk-wallet-evm-7702-gasless and create an EIP-7702 gasless account.
+docType: how-to
+---
+
+This guide shows how to install the module, create a sponsored EIP-7702 gasless wallet, and get the account address.
+
+## Install
+
+```bash
+npm install @tetherto/wdk-wallet-evm-7702-gasless
+```
+
+## Create a Sponsored Wallet
+
+```javascript title="Create a sponsored EIP-7702 gasless wallet"
+import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
+
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  isSponsored: true,
+  sponsorshipPolicyId: 'sp_my_policy'
+})
+
+const account = await wallet.getAccount(0)
+const address = await account.getAddress()
+
+console.log('EOA address:', address)
+```
+
+`getAddress()` returns the EOA address. The module signs EIP-7702 authorization only when the account is not already delegated to the configured `delegationAddress`.
+
+## Use Paymaster-token Mode
+
+If the user pays gas with an ERC-20 paymaster token, configure `paymasterToken` instead of `isSponsored: true`.
+
+```javascript title="Create a paymaster-token wallet"
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  },
+  transferMaxFee: 100000000000000n
+})
+```
+
+## Clean Up
+
+Call `dispose()` when the account or wallet manager is no longer needed.
+
+```javascript title="Dispose account state"
+account.dispose()
+wallet.dispose()
+```
+
+## Next Steps
+
+- Review [configuration](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration) for fee modes and provider failover.
+- Learn how to [send transactions](/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions).
+- Learn how to [transfer ERC-20 tokens](/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens).

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started.mdx
@@ -14,12 +14,16 @@ npm install @tetherto/wdk-wallet-evm-7702-gasless
 
 ## Create a Sponsored Wallet
 
+<Callout type="warn">
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain. The EOA delegates execution to this address.
+</Callout>
+
 ```javascript title="Create a sponsored EIP-7702 gasless wallet"
 import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
 
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true,
   sponsorshipPolicyId: 'sp_my_policy'
@@ -40,12 +44,12 @@ If the user pays gas with an ERC-20 paymaster token, configure `paymasterToken` 
 ```javascript title="Create a paymaster-token wallet"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  transferMaxFee: 100000000000000n
+  transferMaxFee: 100000n // 0.1 USDT when the token has 6 decimals
 })
 ```
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors.mdx
@@ -8,7 +8,7 @@ This guide explains the main error cases exposed by `@tetherto/wdk-wallet-evm-77
 
 ## Configuration Errors
 
-Constructors and per-call config overrides can throw `ConfigurationError` when required fields are missing.
+Account creation and per-call config overrides can throw `ConfigurationError` when required fields are missing. The wallet manager stores the config, then account creation validates it before the account is used.
 
 ```javascript title="Handle configuration errors"
 import WalletManagerEvm7702Gasless, { ConfigurationError } from '@tetherto/wdk-wallet-evm-7702-gasless'
@@ -19,6 +19,9 @@ try {
     bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
     isSponsored: true
   })
+
+  const account = await wallet.getAccount(0)
+  console.log(await account.getAddress())
 } catch (error) {
   if (error instanceof ConfigurationError) {
     console.error('Invalid wallet configuration:', error.message)

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors.mdx
@@ -1,0 +1,116 @@
+---
+title: Handle Errors
+description: Handle EIP-7702 gasless wallet configuration, paymaster, fee-limit, and receipt states.
+docType: how-to
+---
+
+This guide explains the main error cases exposed by `@tetherto/wdk-wallet-evm-7702-gasless`.
+
+## Configuration Errors
+
+Constructors and per-call config overrides can throw `ConfigurationError` when required fields are missing.
+
+```javascript title="Handle configuration errors"
+import WalletManagerEvm7702Gasless, { ConfigurationError } from '@tetherto/wdk-wallet-evm-7702-gasless'
+
+try {
+  const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+    provider: 'https://rpc.mevblocker.io/fast',
+    bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+    isSponsored: true
+  })
+} catch (error) {
+  if (error instanceof ConfigurationError) {
+    console.error('Invalid wallet configuration:', error.message)
+  }
+}
+```
+
+Common configuration errors include missing `provider`, `bundlerUrl`, `delegationAddress`, or `paymasterToken` when the account is not sponsored.
+
+## Paymaster Token Errors
+
+Token paymaster sends can fail when the account does not have enough paymaster-token balance to repay the paymaster.
+
+```javascript title="Handle paymaster balance errors"
+try {
+  const result = await account.sendTransaction({
+    to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+    value: 0n,
+    data: '0x'
+  })
+} catch (error) {
+  if (error.message.includes('not enough funds')) {
+    console.error('Insufficient paymaster token balance')
+  } else {
+    console.error('Transaction failed:', error.message)
+  }
+}
+```
+
+If a generic ERC-7677 paymaster does not support the configured token, the operation throws an error that includes `Token <address> is not supported by the paymaster.`
+
+## Paymaster Address Mismatch
+
+When `paymasterAddress` is configured, the module checks it against the paymaster returned by the RPC. A mismatch throws `ConfigurationError`.
+
+```javascript title="Paymaster address mismatch"
+try {
+  await account.quoteSendTransaction({
+    to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+    value: 0n,
+    data: '0x'
+  })
+} catch (error) {
+  if (error instanceof ConfigurationError && error.message.includes('paymasterAddress mismatch')) {
+    console.error('Unexpected paymaster address returned by RPC')
+  }
+}
+```
+
+## Transfer Fee Cap
+
+`transfer()` throws when paymaster-token fee estimation meets or exceeds `transferMaxFee`.
+
+```javascript title="Handle transfer fee cap"
+try {
+  await account.transfer({
+    token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    recipient: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+    amount: 1000000n
+  })
+} catch (error) {
+  if (error.message.includes('Exceeded maximum fee')) {
+    console.error('Transfer cancelled because the estimated fee exceeded transferMaxFee')
+  }
+}
+```
+
+## Receipt Not Included Yet
+
+Receipt methods return `null` before the UserOperation is included.
+
+```javascript title="Poll receipt"
+const txReceipt = await account.getTransactionReceipt(userOperationHash)
+
+if (txReceipt === null) {
+  console.log('UserOperation is not included yet')
+}
+```
+
+## Dispose of Sensitive State
+
+Use `dispose()` when the account is no longer needed.
+
+```javascript title="Dispose state"
+try {
+  const result = await account.transfer({
+    token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    recipient: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+    amount: 1000000n
+  })
+} finally {
+  account.dispose()
+  wallet.dispose()
+}
+```

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts.mdx
@@ -48,12 +48,14 @@ Read-only accounts do not expose `sign()`, `signTypedData()`, `sendTransaction()
 
 ## Create a Read-only Account from an Address
 
+Use the verified EIP-7702 implementation address for the target chain. The placeholder below must be replaced before use.
+
 ```javascript title="Read-only account from address"
 import { WalletAccountReadOnlyEvm7702Gasless } from '@tetherto/wdk-wallet-evm-7702-gasless'
 
 const readOnlyAccount = new WalletAccountReadOnlyEvm7702Gasless('0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F', {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true
 })
@@ -73,7 +75,7 @@ const evmAccount = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 const gaslessAccount = new WalletAccountEvm7702Gasless(evmAccount, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true
 })

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts.mdx
@@ -1,0 +1,89 @@
+---
+title: Manage Accounts
+description: Manage account indices, derivation paths, read-only accounts, and existing EVM accounts.
+docType: how-to
+---
+
+This guide explains how to derive accounts, use custom paths, create read-only accounts, and wrap an existing `WalletAccountEvm`.
+
+## Get an Account by Index
+
+`getAccount(index)` derives accounts with the EVM BIP-44 path suffix `0'/0/{index}`.
+
+```javascript title="Get accounts by index"
+const account0 = await wallet.getAccount()
+const account1 = await wallet.getAccount(1)
+
+console.log(await account0.getAddress())
+console.log(await account1.getAddress())
+```
+
+`getAccount()` defaults to index `0`.
+
+## Get an Account by Path
+
+Use `getAccountByPath(path)` when you need a specific derivation path suffix.
+
+```javascript title="Get account by path"
+const account = await wallet.getAccountByPath("0'/0/5")
+
+console.log(account.path)
+console.log(account.index)
+```
+
+The full derivation path is based on the EVM account path convention, for example `m/44'/60'/0'/0/5`.
+
+## Convert to a Read-only Account
+
+Use `toReadOnlyAccount()` when a flow needs balances, quotes, receipts, allowances, or signature verification without signing access.
+
+```javascript title="Create a read-only account"
+const account = await wallet.getAccount(0)
+const readOnlyAccount = await account.toReadOnlyAccount()
+
+const balance = await readOnlyAccount.getBalance()
+```
+
+Read-only accounts do not expose `sign()`, `signTypedData()`, `sendTransaction()`, `transfer()`, or `approve()`.
+
+## Create a Read-only Account from an Address
+
+```javascript title="Read-only account from address"
+import { WalletAccountReadOnlyEvm7702Gasless } from '@tetherto/wdk-wallet-evm-7702-gasless'
+
+const readOnlyAccount = new WalletAccountReadOnlyEvm7702Gasless('0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F', {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  isSponsored: true
+})
+```
+
+## Wrap an Existing EVM Account
+
+`WalletAccountEvm7702Gasless` can wrap a `WalletAccountEvm` instance. Use this when your application already manages the base EVM account.
+
+```javascript title="Wrap WalletAccountEvm"
+import { WalletAccountEvm } from '@tetherto/wdk-wallet-evm'
+import { WalletAccountEvm7702Gasless } from '@tetherto/wdk-wallet-evm-7702-gasless'
+
+const evmAccount = new WalletAccountEvm(seedPhrase, "0'/0/0", {
+  provider: 'https://rpc.mevblocker.io/fast'
+})
+
+const gaslessAccount = new WalletAccountEvm7702Gasless(evmAccount, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  isSponsored: true
+})
+```
+
+## Clean Up Account State
+
+```javascript title="Dispose accounts"
+gaslessAccount.dispose()
+wallet.dispose()
+```
+
+`dispose()` clears the account quote cache and disposes the wrapped EVM account.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions.mdx
@@ -1,0 +1,87 @@
+---
+title: Send Transactions
+description: Quote and send EVM transactions through EIP-7702 gasless UserOperations.
+docType: how-to
+---
+
+This guide explains how to quote and send EVM transactions through ERC-4337 UserOperations.
+
+## Send a Transaction
+
+Use `sendTransaction(tx)` with a single transaction object or an array of transaction objects.
+
+```javascript title="Send a transaction"
+const result = await account.sendTransaction({
+  to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+  value: 1000000000000000n,
+  data: '0x'
+})
+
+console.log('UserOperation hash:', result.hash)
+console.log('Fee:', result.fee)
+```
+
+The returned `hash` is a UserOperation hash. Use `getUserOperationReceipt(hash)` or `getTransactionReceipt(hash)` to check inclusion.
+
+## Send a Batch
+
+```javascript title="Send a batch"
+const result = await account.sendTransaction([
+  {
+    to: '0x1111111111111111111111111111111111111111',
+    value: 0n,
+    data: '0x'
+  },
+  {
+    to: '0x2222222222222222222222222222222222222222',
+    value: 0n,
+    data: '0x'
+  }
+])
+```
+
+## Quote Before Sending
+
+Use `quoteSendTransaction(tx)` to estimate the fee without submitting the UserOperation.
+
+```javascript title="Quote then send"
+const tx = {
+  to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+  value: 0n,
+  data: '0x'
+}
+
+const quote = await account.quoteSendTransaction(tx)
+console.log('Estimated fee:', quote.fee)
+
+const result = await account.sendTransaction(tx)
+console.log('UserOperation hash:', result.hash)
+```
+
+For paymaster-token mode, the fee is returned in the paymaster token's base units. For sponsorship mode, the quote returns `fee: 0n`.
+
+## Quote Reuse
+
+Owned accounts cache a recently quoted transaction for up to 2 minutes. If `sendTransaction()` receives the same transaction during that window, the account can reuse the built UserOperation. If the account must include a fresh EIP-7702 authorization, it rebuilds the UserOperation before sending.
+
+## Override Fee Mode for One Send
+
+```javascript title="Per-call fee config"
+const result = await account.sendTransaction({
+  to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+  value: 0n,
+  data: '0x'
+}, {
+  isSponsored: true,
+  sponsorshipPolicyId: 'sp_special_case'
+})
+```
+
+## Read Receipts
+
+```javascript title="Read receipts"
+const userOpReceipt = await account.getUserOperationReceipt(result.hash)
+const txReceipt = await account.getTransactionReceipt(result.hash)
+```
+
+`getTransactionReceipt()` returns `null` until the bundler receipt includes an EVM transaction hash.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/sign-verify-messages.mdx
@@ -1,0 +1,73 @@
+---
+title: Sign and Verify Messages
+description: Sign and verify EVM messages and EIP-712 typed data.
+docType: how-to
+---
+
+This guide explains how to sign and verify messages with `WalletAccountEvm7702Gasless`.
+
+## Sign a Message
+
+```javascript title="Sign a message"
+const signature = await account.sign('Hello, EIP-7702')
+console.log(signature)
+```
+
+`sign(message)` delegates to the wrapped EVM account.
+
+## Verify a Message
+
+```javascript title="Verify a message"
+const isValid = await account.verify('Hello, EIP-7702', signature)
+console.log('Valid:', isValid)
+```
+
+`verify(message, signature)` is available on both owned and read-only accounts.
+
+## Sign EIP-712 Typed Data
+
+```javascript title="Sign typed data"
+const signature = await account.signTypedData({
+  domain: {
+    name: 'Example App',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0x0000000000000000000000000000000000000000'
+  },
+  types: {
+    Transfer: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' }
+    ]
+  },
+  message: {
+    to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+    amount: '1000000'
+  }
+})
+```
+
+## Verify EIP-712 Typed Data
+
+```javascript title="Verify typed data"
+const isValid = await account.verifyTypedData({
+  domain: {
+    name: 'Example App',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0x0000000000000000000000000000000000000000'
+  },
+  types: {
+    Transfer: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' }
+    ]
+  },
+  message: {
+    to: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+    amount: '1000000'
+  }
+}, signature)
+```
+
+Read-only accounts can verify signatures but cannot sign.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens.mdx
@@ -1,0 +1,74 @@
+---
+title: Transfer Tokens
+description: Transfer ERC-20 tokens through EIP-7702 gasless UserOperations.
+docType: how-to
+---
+
+This guide explains how to quote and send ERC-20 transfers.
+
+## Transfer an ERC-20 Token
+
+Use `transfer(options)` with the token address, recipient, and amount in token base units.
+
+```javascript title="Transfer ERC-20 tokens"
+const result = await account.transfer({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  recipient: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+  amount: 1000000n
+})
+
+console.log('UserOperation hash:', result.hash)
+console.log('Fee:', result.fee)
+```
+
+## Quote a Transfer
+
+```javascript title="Quote a transfer"
+const quote = await account.quoteTransfer({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  recipient: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+  amount: 1000000n
+})
+
+console.log('Estimated fee:', quote.fee)
+```
+
+`quoteTransfer()` builds the same ERC-20 transfer transaction shape that `transfer()` sends.
+
+## Cap Transfer Fees
+
+In paymaster-token mode, set `transferMaxFee` to cancel `transfer()` when the estimated fee meets or exceeds the cap.
+
+```javascript title="Cap transfer fee"
+import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
+
+const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
+  provider: 'https://rpc.mevblocker.io/fast',
+  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  },
+  transferMaxFee: 100000000000000n
+})
+```
+
+<Callout type="info">
+`transferMaxFee` applies to `transfer()` in paymaster-token mode. Sponsored transfers return `fee: 0n`.
+</Callout>
+
+## Approve a Spender
+
+Use `approve(options)` when a dapp contract needs allowance for an ERC-20 token.
+
+```javascript title="Approve a spender"
+const result = await account.approve({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  spender: '0x742C4265F5Ba4F8E0842e2b9EfE66302F7a13B6F',
+  amount: 1000000n
+})
+```
+
+<Callout type="warn">
+On Ethereum mainnet, USDT requires an existing non-zero allowance to be reset to `0` before setting a new non-zero allowance. The module throws before sending when this rule would be violated.
+</Callout>

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens.mdx
@@ -39,17 +39,21 @@ console.log('Estimated fee:', quote.fee)
 
 In paymaster-token mode, set `transferMaxFee` to cancel `transfer()` when the estimated fee meets or exceeds the cap.
 
+<Callout type="warn">
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain.
+</Callout>
+
 ```javascript title="Cap transfer fee"
 import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
 
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
-  delegationAddress: '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  transferMaxFee: 100000000000000n
+  transferMaxFee: 100000n // 0.1 USDT when the token has 6 decimals
 })
 ```
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/index.mdx
@@ -1,0 +1,64 @@
+---
+title: Wallet EVM 7702 Gasless Overview
+description: Overview of the @tetherto/wdk-wallet-evm-7702-gasless module.
+docType: explanation
+schemaType: TechArticle
+---
+
+The `@tetherto/wdk-wallet-evm-7702-gasless` module manages EVM externally owned accounts that use EIP-7702 delegation and ERC-4337 UserOperations for gasless transaction flows.
+
+Use this module when your application needs the user to keep an EOA address while submitting transactions through a bundler and paymaster. The module handles EIP-7702 authorization, UserOperation construction, UserOperation signing, paymaster data, and receipt lookup behind the WDK wallet account interface.
+
+## What It Provides
+
+- **EOA-based EIP-7702 accounts**: `getAddress()` returns the EOA address. The account delegates execution to the configured `delegationAddress` when needed.
+- **Sponsored transactions**: Set `isSponsored: true` to use a sponsorship policy. Quotes return a zero fee in sponsored mode.
+- **Paymaster-token transactions**: Configure `paymasterToken` to pay UserOperation costs in an ERC-20 token.
+- **Provider failover**: Pass one provider or an ordered list of RPC URLs / EIP-1193 providers. Provider arrays support `retries`.
+- **UserOperation receipts**: Resolve a UserOperation hash through `getUserOperationReceipt()` or map it to an EVM transaction receipt with `getTransactionReceipt()`.
+- **Read-only and signing accounts**: Use `WalletAccountReadOnlyEvm7702Gasless` for balances, quotes, receipts, allowances, and verification. Use `WalletAccountEvm7702Gasless` when you need signing and sending.
+- **EVM signing support**: Sign plain messages and EIP-712 typed data through the wrapped EVM account.
+
+## Requirements
+
+This module depends on EVM infrastructure that supports both EIP-7702 account delegation and ERC-4337 UserOperations. You need:
+
+- an RPC provider for a chain where the EIP-7702 flow is available;
+- an ERC-4337 bundler URL;
+- a paymaster endpoint, either the same as `bundlerUrl` or a separate `paymasterUrl`;
+- a trusted smart-account implementation address for `delegationAddress`;
+- either a sponsorship policy or an ERC-20 paymaster token configuration.
+
+<Callout type="warn">
+The EOA delegates execution to the configured `delegationAddress`. Treat that address as security-sensitive and verify it before using it with real funds.
+</Callout>
+
+## Fee Modes
+
+| Mode | Required Fields | Quote Behavior |
+|------|-----------------|----------------|
+| Sponsorship policy | `isSponsored: true`, optional `sponsorshipPolicyId` | `quoteSendTransaction()` and `quoteTransfer()` return `fee: 0n`. |
+| Paymaster token | `paymasterToken.address`, optional `paymasterAddress`, optional `transferMaxFee` | Quotes return a fee in the paymaster token's base units. |
+
+## Next Steps
+
+<Cards>
+<Card title="Get Started" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started">
+Install the package and create an EIP-7702 gasless account.
+</Card>
+<Card title="Configuration" href="/sdk/wallet-modules/wallet-evm-7702-gasless/configuration">
+Review required fields, fee modes, provider failover, and per-call overrides.
+</Card>
+<Card title="API Reference" href="/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference">
+See the public classes, methods, config types, and error behavior.
+</Card>
+<Card title="Send Transactions" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions">
+Quote and submit EVM transactions through ERC-4337 UserOperations.
+</Card>
+</Cards>
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/usage.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/usage.mdx
@@ -1,0 +1,56 @@
+---
+title: Wallet EVM 7702 Gasless Usage
+description: Guide to using the @tetherto/wdk-wallet-evm-7702-gasless module.
+docType: how-to
+schemaType: TechArticle
+icon: BookOpen
+---
+
+# Usage
+
+The `@tetherto/wdk-wallet-evm-7702-gasless` module lets EVM EOAs submit gasless transactions through EIP-7702 delegation and ERC-4337 UserOperations.
+
+<Cards>
+<Card title="Get Started" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started">
+Install the package and create your first EIP-7702 gasless account.
+</Card>
+<Card title="Manage Accounts" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts">
+Work with account indices, derivation paths, and existing EVM accounts.
+</Card>
+<Card title="Check Balances" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/check-balances">
+Query native, ERC-20, and paymaster token balances.
+</Card>
+<Card title="Send Transactions" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions">
+Quote and send EVM transactions through UserOperations.
+</Card>
+<Card title="Transfer Tokens" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens">
+Transfer ERC-20 tokens and cap paymaster-token fees.
+</Card>
+<Card title="Sign and Verify Messages" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/sign-verify-messages">
+Sign messages and EIP-712 typed data with the underlying EVM account.
+</Card>
+<Card title="Handle Errors" href="/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors">
+Handle configuration, paymaster, fee-limit, and receipt states.
+</Card>
+</Cards>
+
+<Cards>
+<Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">
+Get started with WDK in a Node.js environment.
+</Card>
+<Card title="Wallet Modules Overview" href="/sdk/wallet-modules">
+Compare WDK wallet modules across supported chains.
+</Card>
+<Card title="Configuration" href="/sdk/wallet-modules/wallet-evm-7702-gasless/configuration">
+Review EIP-7702 gasless wallet configuration.
+</Card>
+<Card title="API Reference" href="/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference">
+Review classes, methods, config types, and return values.
+</Card>
+</Cards>
+
+***
+
+### Need Help?
+
+<SupportCards />

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
@@ -265,9 +265,9 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
 | `sendTransaction(tx, config?)` | Sends a transaction via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max |
 | `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | - |
-| `transfer(options, config?)` | Transfers ERC20 tokens via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max |
-| `quoteTransfer(options, config?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | - |
-| `approve(options)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | - |
+| `transfer(options, config?, txOverrides?)` | Transfers ERC20 tokens via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max |
+| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | - |
+| `approve(options, txOverrides?)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | - |
 | `getBalance()` | Returns the native token balance (in wei) | `Promise\<bigint\>` | - |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific ERC20 token | `Promise\<bigint\>` | - |
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
@@ -374,6 +374,8 @@ const fastResult = await account.sendTransaction({
 ##### `quoteSendTransaction(tx, config?)`
 Estimates the fee for a UserOperation without sending it.
 
+Quoted UserOperations are cached internally for up to 2 minutes. When a later `sendTransaction()` matches the quoted transaction, the account performs a lightweight on-chain nonce check before reuse and re-quotes if the nonce has moved.
+
 **Parameters:**
 - `tx` (EvmErc4337Transaction | EvmErc4337Transaction[]): Transaction object or array (same as sendTransaction)
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
@@ -389,7 +391,7 @@ const quote = await account.quoteSendTransaction({
 console.log('Estimated fee:', quote.fee)
 ```
 
-##### `transfer(options, config?)`
+##### `transfer(options, config?, txOverrides?)`
 Transfers ERC20 tokens via UserOperation.
 
 **Parameters:**
@@ -398,6 +400,7 @@ Transfers ERC20 tokens via UserOperation.
   - `recipient` (string): Recipient address
   - `amount` (number | bigint): Amount in token base units
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{hash: string, fee: bigint}\>` - UserOperation hash and fee
 
@@ -413,17 +416,21 @@ const result = await account.transfer({
   amount: 1000000 // 1 USD₮ (6 decimals)
 }, {
   transferMaxFee: 50000 // Override max fee for this call
+}, {
+  maxFeePerGas: 30000000000n,
+  maxPriorityFeePerGas: 2000000000n
 })
 console.log('Transfer hash:', result.hash)
 console.log('Transfer fee:', result.fee)
 ```
 
-##### `quoteTransfer(options, config?)`
+##### `quoteTransfer(options, config?, txOverrides?)`
 Estimates the fee for an ERC20 token transfer.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options (same as transfer)
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
@@ -478,7 +485,7 @@ if (paymasterBalance < 10000n) {
 }
 ```
 
-##### `approve(options)`
+##### `approve(options, txOverrides?)`
 Approves a spender to spend ERC20 tokens on behalf of the Safe account.
 
 **Parameters:**
@@ -486,6 +493,7 @@ Approves a spender to spend ERC20 tokens on behalf of the Safe account.
   - `token` (string): ERC20 token contract address
   - `spender` (string): The address allowed to spend the tokens
   - `amount` (number | bigint): Amount to approve in token base units
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{hash: string, fee: bigint}\>` - Transaction result
 
@@ -495,6 +503,9 @@ const result = await account.approve({
   token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
   spender: '0xSpenderContract...',
   amount: 1000000n // 1 USD₮
+}, {
+  callGasLimit: 90000n,
+  verificationGasLimit: 120000n
 })
 console.log('Approval hash:', result.hash)
 ```
@@ -742,7 +753,7 @@ const sameAddress = WalletAccountEvmErc4337.predictSafeAddress(
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
 | `getAllowance(token, spender)` | Returns current token allowance for a spender | `Promise\<bigint\>` | - |
 | `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | If simulation fails |
-| `quoteTransfer(options, config?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails |
+| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails |
 | `getTransactionReceipt(hash)` | Returns a transaction receipt | `Promise\<EvmTransactionReceipt \| null\>` | - |
 | `getUserOperationReceipt(hash)` | Returns a UserOperation receipt | `Promise\<UserOperationReceipt \| null\>` | - |
 | `signTypedData(typedData)` | Signs EIP-712 typed structured data | `Promise\<string\>` | - |
@@ -855,12 +866,13 @@ try {
 }
 ```
 
-##### `quoteTransfer(options, config?)`
+##### `quoteTransfer(options, config?, txOverrides?)`
 Estimates the fee for an ERC20 token transfer.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options
 - `config` (optional): Per-call configuration override (see [Config Override](#config-override))
+- `txOverrides` (optional): UserOperation gas and fee overrides (see [EvmErc4337GasOverrides](#evmerc4337gasoverrides))
 
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
@@ -1063,6 +1075,20 @@ interface EvmErc4337Transaction {
 ```
 
 The gas-override fields are optional. When omitted, the gas limits fall back to AbstractionKit's estimation and the fee pair (`maxFeePerGas` / `maxPriorityFeePerGas`) falls back to the bundler-fetched gas price. Setting either fee field disables the bundler-fetched fee fallback for both, so set them together. In a batched call (`tx` passed as an array), only the gas overrides on the first transaction are honored — a UserOperation carries a single set of gas fields regardless of how many calls it batches.
+
+### EvmErc4337GasOverrides
+
+The helper methods `transfer()`, `quoteTransfer()`, and `approve()` accept these same UserOperation gas and fee override fields as a separate `txOverrides` argument.
+
+```typescript
+interface EvmErc4337GasOverrides {
+  callGasLimit?: number | bigint;
+  verificationGasLimit?: number | bigint;
+  preVerificationGas?: number | bigint;
+  maxFeePerGas?: number | bigint;
+  maxPriorityFeePerGas?: number | bigint;
+}
+```
 
 ### TransferOptions
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
@@ -3,7 +3,7 @@ title: Send Transactions
 description: Send gasless transactions and estimate fees.
 ---
 
-This guide explains how to [send a gasless transaction](#send-a-gasless-transaction), [estimate fees](#estimate-fees), and [use a custom paymaster token](#send-with-custom-paymaster-token).
+This guide explains how to [send a gasless transaction](#send-a-gasless-transaction), [estimate fees](#estimate-fees), [reuse a recent quote](#reuse-a-recent-quote), and [use a custom paymaster token](#send-with-custom-paymaster-token).
 
 ## Send a Gasless Transaction
 
@@ -32,6 +32,23 @@ const quote = await account.quoteSendTransaction({
   value: 1000000000000000n
 })
 console.log('Estimated fee:', quote.fee)
+```
+
+## Reuse a Recent Quote
+
+Quotes are cached for up to 2 minutes. If you call `sendTransaction()` with the same transaction during that window, the account checks the current on-chain nonce before reusing the cached UserOperation. If the nonce has moved, it builds a fresh quote before sending.
+
+```javascript title="Quote Then Send"
+const tx = {
+  to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  value: 1000000000000000n
+}
+
+const quote = await account.quoteSendTransaction(tx)
+console.log('Estimated fee:', quote.fee)
+
+const result = await account.sendTransaction(tx)
+console.log('Transaction hash:', result.hash)
 ```
 
 ## Send with Custom Paymaster Token

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
@@ -3,7 +3,7 @@ title: Transfer Tokens
 description: Transfer ERC-20 tokens with gasless transactions.
 ---
 
-This guide explains how to [transfer ERC-20 tokens](#transfer-erc-20-tokens), [estimate transfer fees](#estimate-transfer-fees), and [set a maximum fee limit](#transfer-with-maximum-fee-limit).
+This guide explains how to [transfer ERC-20 tokens](#transfer-erc-20-tokens), [estimate transfer fees](#estimate-transfer-fees), [set a maximum fee limit](#transfer-with-maximum-fee-limit), and [apply UserOperation gas overrides](#transfer-with-useroperation-gas-overrides).
 
 ## Transfer ERC-20 Tokens
 
@@ -49,6 +49,31 @@ const result = await account.transfer({
 <Callout type="warn">
 If the estimated fee exceeds `transferMaxFee`, the transfer is cancelled with an "Exceeded maximum fee" error.
 </Callout>
+
+## Transfer with UserOperation Gas Overrides
+
+Use the third argument to pass UserOperation gas or EIP-1559 fee overrides through `transfer()` or `quoteTransfer()`. Set `maxFeePerGas` and `maxPriorityFeePerGas` together.
+
+```javascript title="Transfer with Gas Overrides"
+const txOverrides = {
+  callGasLimit: 90000n,
+  verificationGasLimit: 120000n,
+  maxFeePerGas: 30000000000n,
+  maxPriorityFeePerGas: 2000000000n
+}
+
+const quote = await account.quoteTransfer({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  amount: 1000000
+}, undefined, txOverrides)
+
+const result = await account.transfer({
+  token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  recipient: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  amount: 1000000
+}, undefined, txOverrides)
+```
 
 ## Next Steps
 

--- a/content/docs/sdk/wallet-modules/wallet-tron/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/api-reference.mdx
@@ -21,8 +21,8 @@ The main class for managing Tron wallets. Extends `WalletManager` from `@tethert
 ### Fee Rate Constants
 
 ```javascript
-const FEE_RATE_NORMAL_MULTIPLIER = 1.1
-const FEE_RATE_FAST_MULTIPLIER = 2.0
+const FEE_RATE_NORMAL_MULTIPLIER = 110n
+const FEE_RATE_FAST_MULTIPLIER = 200n
 ```
 
 ### Constructor
@@ -34,21 +34,31 @@ new WalletManagerTron(seed, config?)
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `config` (TronWalletConfig, optional): Configuration object
-  - `provider` (string | TronWeb, optional): Tron RPC endpoint URL or TronWeb instance
-  - `transferMaxFee` (number, optional): Maximum fee amount for transfer operations (in sun)
+  - `provider` (`string | TronWeb | Array<string | TronWeb>`, optional): Tron RPC endpoint URL, TronWeb instance, or ordered failover list
+  - `retries` (number, optional): Additional failover attempts when `provider` is an array (default: 3)
+  - `transferMaxFee` (`number | bigint`, optional): Maximum fee amount for TRC20 transfer operations (in sun)
 
 **Example:**
 ```javascript
 const wallet = new WalletManagerTron(seedPhrase, {
   provider: 'https://api.trongrid.io', // Tron RPC endpoint
-  transferMaxFee: 10000000 // 10 TRX in sun
+  transferMaxFee: 10000000n // 10 TRX in sun
 })
 
 // Or with TronWeb instance
 const tronWeb = new TronWeb({ fullHost: 'https://api.trongrid.io' })
 const wallet2 = new WalletManagerTron(seedPhrase, {
   provider: tronWeb,
-  transferMaxFee: 10000000
+  transferMaxFee: 10000000n
+})
+
+// Or with ordered provider failover
+const wallet3 = new WalletManagerTron(seedPhrase, {
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ],
+  retries: 3
 })
 ```
 
@@ -58,7 +68,7 @@ const wallet2 = new WalletManagerTron(seedPhrase, {
 |--------|-------------|---------|--------|
 | `getAccount(index?)` | Returns a wallet account at the specified index | `Promise\<WalletAccountTron\>` | - |
 | `getAccountByPath(path)` | Returns a wallet account at the specified BIP-44 derivation path | `Promise\<WalletAccountTron\>` | - |
-| `getFeeRates()` | Returns current fee rates from Tron network | `Promise\<{normal: number, fast: number}\>` | If no provider |
+| `getFeeRates()` | Returns current fee rates from Tron network | `Promise\<{normal: bigint, fast: bigint}\>` | If no provider |
 | `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` | - |
 
 ##### `getAccount(index?)`
@@ -95,7 +105,7 @@ const account = await wallet.getAccountByPath("0'/0/1")
 ##### `getFeeRates()`
 Returns current fee rates from Tron network chain parameters.
 
-**Returns:** `Promise\<{normal: number, fast: number}\>` - Fee rates in sun
+**Returns:** `Promise\<{normal: bigint, fast: bigint}\>` - Fee rates in sun
 - `normal`: Base fee × 1.1
 - `fast`: Base fee × 2.0
 
@@ -124,7 +134,7 @@ Represents an individual Tron wallet account. Extends `WalletAccountReadOnlyTron
 
 ```javascript
 const BIP_44_TRON_DERIVATION_PATH_PREFIX = "m/44'/195'"
-const BANDWIDTH_PRICE = 1_000
+const BANDWIDTH_PRICE = 1_000n
 ```
 
 ### Constructor
@@ -144,7 +154,7 @@ new WalletAccountTron(seed, path, config?)
 ```javascript
 const account = new WalletAccountTron(seedPhrase, "0'/0/0", {
   provider: 'https://api.trongrid.io',
-  transferMaxFee: 10000000 // 10 TRX in sun
+  transferMaxFee: 10000000n // 10 TRX in sun
 })
 ```
 
@@ -155,10 +165,10 @@ const account = new WalletAccountTron(seedPhrase, "0'/0/0", {
 | `getAddress()` | Returns the account's Tron address | `Promise\<string\>` | - |
 | `sign(message)` | Signs a message using the account's private key | `Promise\<string\>` | - |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
-| `sendTransaction(tx)` | Sends a Tron transaction | `Promise\<{hash: string, fee: number}\>` | If no provider or fee exceeds max |
-| `quoteSendTransaction(tx)` | Estimates the fee for a Tron transaction | `Promise\<{fee: number}\>` | If no provider |
-| `transfer(options)` | Transfers TRC20 tokens to another address | `Promise\<{hash: string, fee: number}\>` | If no provider or fee exceeds max |
-| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: number}\>` | If no provider |
+| `sendTransaction(tx)` | Sends a Tron transaction | `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` | If no provider |
+| `quoteSendTransaction(tx)` | Estimates the fee for a Tron transaction | `Promise\<{fee: bigint, activationFee: bigint}\>` | If no provider |
+| `transfer(options)` | Transfers TRC20 tokens to another address | `Promise\<{hash: string, fee: bigint}\>` | If no provider or fee exceeds `transferMaxFee` |
+| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` | If no provider |
 | `getBalance()` | Returns the native TRX balance (in sun) | `Promise\<bigint\>` | If no provider |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific TRC20 token | `Promise\<bigint\>` | If no provider |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise\<TronTransactionReceipt \| null\>` | If no provider |
@@ -207,18 +217,17 @@ console.log('Signature valid:', isValid)
 ```
 
 ##### `sendTransaction(tx)`
-Sends a TRX transaction and returns the result with hash and fee.
+Sends a TRX transaction and returns the result with hash, fee, and activation fee details.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object
   - `to` (string): Recipient Tron address (e.g., 'T...')
-  - `value` (number): Amount in sun (1 TRX = 1,000,000 sun)
+  - `value` (number | bigint): Amount in sun (1 TRX = 1,000,000 sun)
 
-**Returns:** `Promise\<{hash: string, fee: number}\>` - Transaction hash and fee in sun
+**Returns:** `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` - Transaction hash, total fee in sun, and the portion used for account activation
 
 **Throws:** 
 - Error if no TronWeb provider is configured
-- Error if fee exceeds `transferMaxFee`
 
 **Example:**
 ```javascript
@@ -228,15 +237,16 @@ const result = await account.sendTransaction({
 })
 console.log('Transaction hash:', result.hash)
 console.log('Transaction fee:', result.fee, 'sun')
+console.log('Activation fee:', result.activationFee, 'sun')
 ```
 
 ##### `quoteSendTransaction(tx)`
-Estimates the bandwidth cost for a TRX transaction.
+Estimates the bandwidth and activation fee cost for a TRX transaction.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object (same as sendTransaction)
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun
+**Returns:** `Promise\<{fee: bigint, activationFee: bigint}\>` - Fee estimate in sun and the portion used for account activation
 
 **Throws:** Error if no TronWeb provider is configured
 
@@ -247,6 +257,7 @@ const quote = await account.quoteSendTransaction({
   value: 1000000
 })
 console.log('Estimated fee:', quote.fee, 'sun')
+console.log('Activation fee:', quote.activationFee, 'sun')
 ```
 
 ##### `transfer(options)`
@@ -258,7 +269,7 @@ Transfers TRC20 tokens using smart contract call.
   - `recipient` (string): Recipient Tron address (e.g., 'T...')
   - `amount` (number | bigint): Amount in token's base units
 
-**Returns:** `Promise\<{hash: string, fee: number}\>` - Transaction hash and fee in sun
+**Returns:** `Promise\<{hash: string, fee: bigint}\>` - Transaction hash and fee in sun
 
 **Throws:** 
 - Error if no TronWeb provider is configured
@@ -276,12 +287,12 @@ console.log('Transfer fee:', result.fee, 'sun')
 ```
 
 ##### `quoteTransfer(options)`
-Estimates the energy and bandwidth cost for a TRC20 token transfer.
+Estimates the TRC20 token transfer cost from current chain parameters, account resources, contract energy use, and bandwidth use.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options (same as transfer)
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun (energy + bandwidth costs)
+**Returns:** `Promise\<{fee: bigint}\>` - Fee estimate in sun (energy + bandwidth costs)
 
 **Throws:** Error if no TronWeb provider is configured
 
@@ -367,20 +378,21 @@ account.dispose()
 |----------|------|-------------|
 | `index` | `number` | The derivation path's index of this account |
 | `path` | `string` | The full BIP-44 derivation path of this account |
-| `keyPair` | `{privateKey: Buffer, publicKey: Buffer}` | The account's key pair (⚠️ Contains sensitive data) |
+| `keyPair` | `{privateKey: Uint8Array \| null, publicKey: Uint8Array}` | Read-only view of the account's key pair. `privateKey` is `null` after `dispose()` |
 
 **Example:**
 ```javascript
 console.log('Account index:', account.index) // 0, 1, 2, etc.
 console.log('Account path:', account.path) // m/44'/195'/0'/0/0
 
-// ⚠️ SENSITIVE: Handle with care
 const { privateKey, publicKey } = account.keyPair
 console.log('Public key length:', publicKey.length) // 33 bytes (compressed)
-console.log('Private key length:', privateKey.length) // 32 bytes
+console.log('Private key length:', privateKey?.length) // 32 bytes before dispose()
 ```
 
-⚠️ **Security Note**: The `keyPair` property contains sensitive cryptographic material. Never log, display, or expose the private key.
+<Callout type="warn">
+The `keyPair` byte arrays are bound to the wallet account. Treat them as a read-only view: do not mutate, log, display, or expose the private key.
+</Callout>
 
 ## WalletAccountReadOnlyTron
 
@@ -409,8 +421,8 @@ const readOnlyAccount = new WalletAccountReadOnlyTron('TLyqzVGLV1srkB7dToTAEqgDS
 |--------|-------------|---------|--------|
 | `getBalance()` | Returns the native TRX balance (in sun) | `Promise\<bigint\>` | If no provider |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific TRC20 token | `Promise\<bigint\>` | If no provider |
-| `quoteSendTransaction(tx)` | Estimates the fee for a TRX transaction | `Promise\<{fee: number}\>` | If no provider |
-| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: number}\>` | If no provider |
+| `quoteSendTransaction(tx)` | Estimates the fee for a TRX transaction | `Promise\<{fee: bigint, activationFee: bigint}\>` | If no provider |
+| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` | If no provider |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise\<TronTransactionReceipt \| null\>` | If no provider |
 
@@ -444,22 +456,22 @@ console.log('USDT balance:', tokenBalance)
 ```
 
 ##### `quoteSendTransaction(tx)`
-Estimates the bandwidth cost for a TRX transaction.
+Estimates the bandwidth and activation fee cost for a TRX transaction.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun
+**Returns:** `Promise\<{fee: bigint, activationFee: bigint}\>` - Fee estimate in sun and the portion used for account activation
 
 **Throws:** Error if no TronWeb provider is configured
 
 ##### `quoteTransfer(options)`
-Estimates the energy and bandwidth cost for a TRC20 transfer.
+Estimates the TRC20 token transfer cost from current chain parameters, account resources, contract energy use, and bandwidth use.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options
 
-**Returns:** `Promise\<{fee: number}\>` - Fee estimate in sun
+**Returns:** `Promise\<{fee: bigint}\>` - Fee estimate in sun
 
 **Throws:** Error if no TronWeb provider is configured
 
@@ -495,8 +507,9 @@ Returns a transaction's receipt if it has been processed.
 
 ```typescript
 interface TronWalletConfig {
-  provider?: string | TronWeb;        // Tron RPC URL or TronWeb instance
-  transferMaxFee?: number;            // Maximum fee in sun
+  provider?: string | TronWeb | Array<string | TronWeb>; // RPC, TronWeb, or failover list
+  retries?: number;                   // Additional failover attempts, default 3
+  transferMaxFee?: number | bigint;   // Maximum TRC20 transfer fee in sun
 }
 ```
 
@@ -505,7 +518,7 @@ interface TronWalletConfig {
 ```typescript
 interface TronTransaction {
   to: string;                         // Recipient Tron address
-  value: number;                      // Amount in sun (1 TRX = 1,000,000 sun)
+  value: number | bigint;             // Amount in sun (1 TRX = 1,000,000 sun)
 }
 ```
 
@@ -524,7 +537,15 @@ interface TransferOptions {
 ```typescript
 interface TransactionResult {
   hash: string;                       // Transaction hash
-  fee: number;                        // Fee paid in sun
+  fee: bigint;                        // Fee paid in sun
+}
+```
+
+### TronActivationFee
+
+```typescript
+interface TronActivationFee {
+  activationFee: bigint;              // Portion of the fee used for account activation
 }
 ```
 
@@ -533,7 +554,7 @@ interface TransactionResult {
 ```typescript
 interface TransferResult {
   hash: string;                       // Transaction hash
-  fee: number;                        // Fee paid in sun
+  fee: bigint;                        // Fee paid in sun
 }
 ```
 
@@ -542,11 +563,11 @@ interface TransferResult {
 ```typescript
 // Tron-specific constants
 const BIP_44_TRON_DERIVATION_PATH_PREFIX: string = "m/44'/195'";
-const BANDWIDTH_PRICE: number = 1_000;
+const BANDWIDTH_PRICE: bigint = 1_000n;
 
 // Fee rate multipliers
-const FEE_RATE_NORMAL_MULTIPLIER: number = 1.1;
-const FEE_RATE_FAST_MULTIPLIER: number = 2.0;
+const FEE_RATE_NORMAL_MULTIPLIER: bigint = 110n;
+const FEE_RATE_FAST_MULTIPLIER: bigint = 200n;
 ```
 
 <Cards>

--- a/content/docs/sdk/wallet-modules/wallet-tron/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/configuration.mdx
@@ -12,8 +12,12 @@ icon: Settings
 import WalletManagerTron from '@tetherto/wdk-wallet-tron'
 
 const config = {
-  provider: 'https://api.trongrid.io', // Tron RPC endpoint
-  transferMaxFee: 10000000 // Maximum fee in sun (optional)
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ], // Tron RPC endpoints; array enables failover
+  retries: 3, // Additional failover attempts when provider is an array
+  transferMaxFee: 10000000n // Maximum transfer fee in sun (optional)
 }
 
 const wallet = new WalletManagerTron(seedPhrase, config)
@@ -26,7 +30,7 @@ import { WalletAccountTron } from '@tetherto/wdk-wallet-tron'
 
 const accountConfig = {
   provider: 'https://api.trongrid.io',
-  transferMaxFee: 10000000 // Maximum fee in sun (optional)
+  transferMaxFee: 10000000n // Maximum transfer fee in sun (optional)
 }
 
 const account = new WalletAccountTron(seedPhrase, "0'/0/0", accountConfig)
@@ -36,28 +40,65 @@ const account = new WalletAccountTron(seedPhrase, "0'/0/0", accountConfig)
 
 ### Provider
 
-The `provider` option specifies the Tron RPC endpoint or TronWeb instance for blockchain interactions.
+The `provider` option specifies how the wallet connects to Tron. It accepts a Tron RPC endpoint URL, a TronWeb instance, or an ordered list of URLs and TronWeb instances for automatic failover.
 
-**Type:** `string | TronWeb`
+**Type:** `string | TronWeb | Array<string | TronWeb>`
+
+**Examples:**
+```javascript
+// Single RPC endpoint
+const config = {
+  provider: 'https://api.trongrid.io'
+}
+
+// TronWeb instance
+const config = {
+  provider: tronWeb
+}
+
+// Ordered failover list
+const config = {
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ],
+  retries: 3
+}
+```
+
+When `provider` is an array, connection errors fail over to the next provider in the list. Empty arrays throw during provider initialization. Use endpoints that serve the same Tron network.
+
+If the array contains TronWeb instances, the first instance becomes the wallet's primary client. Additional instances contribute their `fullNode`, `solidityNode`, and `eventServer` connections to the failover pool.
+
+### Retries
+
+The `retries` option controls how many additional failover attempts can happen after the initial provider call fails. It only applies when `provider` is an array.
+
+**Type:** `number` (optional)
+**Default:** `3`
 
 **Example:**
 ```javascript
 const config = {
-  provider: 'https://api.trongrid.io'
+  provider: [
+    'https://api.trongrid.io',
+    'https://secondary-tron-rpc.example'
+  ],
+  retries: 1
 }
 ```
 
 ### Transfer Max Fee
 
-The `transferMaxFee` option sets the maximum fee amount (in sun) for transfer operations. This helps prevent transactions from being sent with unexpectedly high fees.
+The `transferMaxFee` option sets the maximum fee amount (in sun) for TRC20 `transfer()` operations. This helps prevent transfers from being sent with unexpectedly high fees.
 
-**Type:** `number` (optional)  
+**Type:** `number | bigint` (optional)
 **Unit:** Sun (1 TRX = 1,000,000 Sun)
 
 **Example:**
 ```javascript
 const config = {
-  transferMaxFee: 10000000 // 10 TRX in sun
+  transferMaxFee: 10000000n // 10 TRX in sun
 }
 ```
 

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
@@ -13,17 +13,25 @@ Wrap transactions in `try/catch` blocks to handle common failure scenarios. Use 
 
 ```javascript title="Transaction Error Handling"
 try {
-  const result = await account.sendTransaction({
+  const tx = {
     to: 'TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH',
     value: 1000000 // 1 TRX in sun
-  })
+  }
+
+  const quote = await account.quoteSendTransaction(tx)
+  if (quote.fee > 10000000n) {
+    throw new Error('Transaction fee exceeds configured threshold')
+  }
+
+  const result = await account.sendTransaction(tx)
   console.log('Transaction hash:', result.hash)
   console.log('Fee paid:', result.fee, 'sun')
+  console.log('Activation fee:', result.activationFee, 'sun')
 } catch (error) {
   if (error.message.toLowerCase().includes('insufficient')) {
     console.error('Not enough TRX to complete transaction')
-  } else if (error.message.toLowerCase().includes('max fee')) {
-    console.error('The transfer fee exceeds your configured maximum')
+  } else if (error.message.toLowerCase().includes('configured threshold')) {
+    console.error('The transaction fee exceeds your configured threshold')
   } else {
     console.error('Transaction failed:', error.message)
   }
@@ -57,7 +65,9 @@ try {
 
 ### Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet to prevent transactions from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron/api-reference):
+Set `transferMaxFee` when creating the wallet to prevent TRC20 transfers from exceeding a maximum cost. For native TRX sends, call [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx) and compare `quote.fee` before calling `sendTransaction()`.
+
+You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron/api-reference):
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
@@ -22,11 +22,12 @@ const result = await account.sendTransaction({
 })
 console.log('Transaction hash:', result.hash)
 console.log('Transaction fee:', result.fee, 'sun')
+console.log('Activation fee:', result.activationFee, 'sun')
 ```
 
 ## Estimate Transaction Fees
 
-You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx):
+You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx). The quote includes `activationFee`, which is non-zero when the recipient account must be activated:
 
 ```javascript title="Quote Transaction Fee"
 const quote = await account.quoteSendTransaction({
@@ -34,6 +35,7 @@ const quote = await account.quoteSendTransaction({
   value: 1000000
 })
 console.log('Estimated fee:', quote.fee, 'sun')
+console.log('Activation fee:', quote.activationFee, 'sun')
 ```
 
 ## Use Dynamic Fee Rates

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/transfer-tokens.mdx
@@ -34,6 +34,8 @@ const transferQuote = await account.quoteTransfer({
 console.log('Transfer fee estimate:', transferQuote.fee, 'sun')
 ```
 
+The quote uses current chain parameters, the sender's available resources, and the TRC20 contract simulation result. It charges only the missing energy after available energy is considered, then adds any bandwidth cost.
+
 ## Transfer with Validation
 
 Validate addresses and check balances before transferring to catch errors early:

--- a/content/docs/sdk/wallet-modules/wallet-tron/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/index.mdx
@@ -14,11 +14,11 @@ A simple and secure package to manage BIP-44 wallets for the Tron blockchain. Th
 - **Multi-Account Management**: Create and manage multiple accounts from a single seed phrase
 - **Tron Address Support:** Generate and manage Tron addresses
 - **Message Signing:** Sign and verify messages using Tron cryptography
-- **Transaction Management**: Send transactions and get fee estimates
+- **Transaction Management**: Send transactions and get fee estimates, including activation fee details for native TRX sends
 - **TRC20 Support:** Query native TRX and TRC20 token balances.
 - **TypeScript Support**: Full TypeScript definitions included
 - **Memory Safety**: Secure private key management with automatic memory cleanup
-- **Provider Flexibility:** Support for custom Tron RPC endpoints
+- **Provider Flexibility:** Support for custom Tron RPC endpoints, TronWeb instances, and ordered failover provider lists
 
 ## Supported Networks
 

--- a/content/docs/tools/asset-registry/api-reference.mdx
+++ b/content/docs/tools/asset-registry/api-reference.mdx
@@ -12,7 +12,7 @@ icon: Code
 
 | Export | Description |
 | --- | --- |
-| `WdkBaseAssetRegistry` | Default base registry class for assets that include `id` and `chainId` |
+| `default` | Base registry class for assets that include `id` and `chainId`; import it as `WdkBaseAssetRegistry` |
 | `WdkTokenAssetRegistry` | Token registry class with token-specific lookup helpers |
 | `BaseAssetSchema` | Zod schema for base asset records |
 | `BaseAssetJsonSchema` | JSON schema for base asset records |
@@ -44,7 +44,7 @@ Pass zero or more asset arrays to preload records.
 | `registerAssets(assets, upsert?)` | Register a list of assets | `void` |
 | `getAssets()` | Return all registered assets | `BaseAsset[]` |
 | `getAssetById(id)` | Return one asset by exact ID | `BaseAsset \| null` |
-| `getAsset(filter, options?)` | Return the first asset matching one or more partial filters | `BaseAsset \| null` |
+| `getAsset(filter, options?)` | Return all assets matching one or more partial filters | `BaseAsset[]` |
 
 #### `registerAsset(asset, upsert?)`
 
@@ -78,10 +78,12 @@ const asset = registry.getAssetById('eip155:1')
 
 #### `getAsset(filter, options?)`
 
-Finds the first asset that matches a partial filter. Keys inside one filter object are AND conditions. Multiple filter objects are OR conditions.
+Finds assets that match one or more partial filters. Pass an array of filter objects. Keys inside one filter object are AND conditions. Multiple filter objects are OR conditions.
 
 ```javascript title="Filter Assets"
-const byChain = registry.getAsset({ chainId: 'eip155:1' })
+const byChain = registry.getAsset([
+  { chainId: 'eip155:1' }
+])
 
 const byOneOfMany = registry.getAsset([
   { chainId: 'eip155:1' },
@@ -108,14 +110,14 @@ const registry = new WdkTokenAssetRegistry(commonTokens)
 | --- | --- | --- |
 | `getTokens()` | Return all registered token assets | `TokenAsset[]` |
 | `getTokenById(id)` | Return one token by exact ID | `TokenAsset \| null` |
-| `getTokenByAddress(address, options?)` | Return the first token matching an address | `TokenAsset \| null` |
-| `getTokenBySymbol(symbol, options?)` | Return the first token matching a symbol | `TokenAsset \| null` |
-| `getTokenByChain(chainId, options?)` | Return the first token matching a chain ID | `TokenAsset \| null` |
+| `getTokenByAddress(address, options?)` | Return all tokens matching an address | `TokenAsset[]` |
+| `getTokenBySymbol(symbol, options?)` | Return all tokens matching a symbol | `TokenAsset[]` |
+| `getTokenByChain(chainId, options?)` | Return all tokens matching a chain ID | `TokenAsset[]` |
 
 ```javascript title="Token Lookups"
-const usdt = registry.getTokenBySymbol('USDT')
-const token = registry.getTokenByAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')
-const chainToken = registry.getTokenByChain('eip155:1')
+const usdtTokens = registry.getTokenBySymbol('USDT')
+const tokensByAddress = registry.getTokenByAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+const chainTokens = registry.getTokenByChain('eip155:1')
 ```
 
 ## Helper Functions
@@ -196,7 +198,7 @@ type BaseAssetFilter<TSchema extends object> = Partial<TSchema>
 
 ## Notes
 
-- Registry lookups return `null` when no asset matches.
+- Exact ID lookups return `null` when no asset matches. Filter and token-helper lookups return an empty array.
 - `registerAssets()` validates and registers each asset sequentially. It is not an atomic batch transaction.
 - The token registry validates records with `TokenAssetSchema`.
 - Asset registry metadata is static and local; use live providers for balances, prices, quotes, chain state, or contract validation.

--- a/content/docs/tools/asset-registry/api-reference.mdx
+++ b/content/docs/tools/asset-registry/api-reference.mdx
@@ -1,0 +1,208 @@
+---
+title: Asset Registry API Reference
+description: Registry classes, schemas, helpers, and types for @tetherto/wdk-asset-registry
+docType: reference
+schemaType: APIReference
+icon: Code
+---
+
+## Package: `@tetherto/wdk-asset-registry`
+
+### Exports
+
+| Export | Description |
+| --- | --- |
+| `WdkBaseAssetRegistry` | Default base registry class for assets that include `id` and `chainId` |
+| `WdkTokenAssetRegistry` | Token registry class with token-specific lookup helpers |
+| `BaseAssetSchema` | Zod schema for base asset records |
+| `BaseAssetJsonSchema` | JSON schema for base asset records |
+| `TokenAssetSchema` | Zod schema for token asset records |
+| `TokenAssetJsonSchema` | JSON schema for token asset records |
+| `fromUniswapToken(token)` | Convert one Uniswap token-list entry into a `TokenAsset` |
+| `fromUniswapTokenList(tokens)` | Convert a list of Uniswap token-list entries into `TokenAsset[]` |
+| `AssetRegistryError` | Error class for registry-level failures such as duplicate asset IDs |
+
+## Class: `WdkBaseAssetRegistry`
+
+In-memory registry for `BaseAsset`-compatible records.
+
+### Constructor
+
+```javascript title="Create A Base Registry"
+import WdkBaseAssetRegistry from '@tetherto/wdk-asset-registry'
+
+const registry = new WdkBaseAssetRegistry(initialAssets)
+```
+
+Pass zero or more asset arrays to preload records.
+
+### Methods
+
+| Method | Description | Returns |
+| --- | --- | --- |
+| `registerAsset(asset, upsert?)` | Validate and register one asset by `asset.id` | `void` |
+| `registerAssets(assets, upsert?)` | Register a list of assets | `void` |
+| `getAssets()` | Return all registered assets | `BaseAsset[]` |
+| `getAssetById(id)` | Return one asset by exact ID | `BaseAsset \| null` |
+| `getAsset(filter, options?)` | Return the first asset matching one or more partial filters | `BaseAsset \| null` |
+
+#### `registerAsset(asset, upsert?)`
+
+Validates the asset before registration. Duplicate IDs throw `AssetRegistryError` unless `upsert` is `true`.
+
+```javascript title="Register A Base Asset"
+registry.registerAsset({
+  id: 'eip155:1',
+  chainId: 'eip155:1'
+})
+```
+
+#### `registerAssets(assets, upsert?)`
+
+Registers each asset by calling `registerAsset()`.
+
+```javascript title="Register Multiple Assets"
+registry.registerAssets([
+  { id: 'eip155:1', chainId: 'eip155:1' },
+  { id: 'eip155:137', chainId: 'eip155:137' }
+])
+```
+
+#### `getAssetById(id)`
+
+Looks up an asset by exact `id`.
+
+```javascript title="Get Asset By ID"
+const asset = registry.getAssetById('eip155:1')
+```
+
+#### `getAsset(filter, options?)`
+
+Finds the first asset that matches a partial filter. Keys inside one filter object are AND conditions. Multiple filter objects are OR conditions.
+
+```javascript title="Filter Assets"
+const byChain = registry.getAsset({ chainId: 'eip155:1' })
+
+const byOneOfMany = registry.getAsset([
+  { chainId: 'eip155:1' },
+  { chainId: 'eip155:137' }
+])
+```
+
+String comparisons are case-insensitive by default. Pass `{ caseSensitive: true }` to require exact casing.
+
+## Class: `WdkTokenAssetRegistry`
+
+Token-specific registry built on `WdkBaseAssetRegistry`.
+
+```javascript title="Create A Token Registry"
+import { WdkTokenAssetRegistry } from '@tetherto/wdk-asset-registry'
+import commonTokens from '@tetherto/wdk-asset-registry/assets/common-tokens' with { type: 'json' }
+
+const registry = new WdkTokenAssetRegistry(commonTokens)
+```
+
+### Methods
+
+| Method | Description | Returns |
+| --- | --- | --- |
+| `getTokens()` | Return all registered token assets | `TokenAsset[]` |
+| `getTokenById(id)` | Return one token by exact ID | `TokenAsset \| null` |
+| `getTokenByAddress(address, options?)` | Return the first token matching an address | `TokenAsset \| null` |
+| `getTokenBySymbol(symbol, options?)` | Return the first token matching a symbol | `TokenAsset \| null` |
+| `getTokenByChain(chainId, options?)` | Return the first token matching a chain ID | `TokenAsset \| null` |
+
+```javascript title="Token Lookups"
+const usdt = registry.getTokenBySymbol('USDT')
+const token = registry.getTokenByAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+const chainToken = registry.getTokenByChain('eip155:1')
+```
+
+## Helper Functions
+
+### `fromUniswapToken(token)`
+
+Converts one Uniswap token-list entry into a `TokenAsset`.
+
+```javascript title="Normalize One Token"
+import { fromUniswapToken } from '@tetherto/wdk-asset-registry'
+
+const token = fromUniswapToken({
+  chainId: 1,
+  address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  symbol: 'USDT',
+  name: 'Tether USD',
+  decimals: 6
+})
+```
+
+### `fromUniswapTokenList(tokens)`
+
+Converts a token-list array into `TokenAsset[]`.
+
+```javascript title="Normalize A Token List"
+import { fromUniswapTokenList } from '@tetherto/wdk-asset-registry'
+
+const tokens = fromUniswapTokenList(uniswapTokenList.tokens)
+```
+
+## Types
+
+### `BaseAsset`
+
+```typescript
+type BaseAsset = {
+  id: string
+  chainId: string | number
+}
+```
+
+### `TokenAsset`
+
+```typescript
+type TokenAsset = BaseAsset & {
+  address: string
+  symbol: string
+  name: string
+  decimals: number
+  isNative: boolean
+}
+```
+
+### `BaseAssetOptions`
+
+```typescript
+type BaseAssetOptions = {
+  caseSensitive?: boolean
+}
+```
+
+### `BaseAssetFilter<TSchema>`
+
+```typescript
+type BaseAssetFilter<TSchema extends object> = Partial<TSchema>
+```
+
+## Bundled Assets
+
+`@tetherto/wdk-asset-registry/assets/common-tokens` exports bundled token metadata. In `v1.0.0-beta.1`, the published list contains USDT, USDT0, and XAUt token records across supported chains.
+
+## Errors
+
+| Error | Cause |
+| --- | --- |
+| `AssetRegistryError` | Registry-level failure, such as duplicate asset registration without `upsert` |
+| `ZodError` | Invalid asset shape passed to registration or normalization helpers |
+
+## Notes
+
+- Registry lookups return `null` when no asset matches.
+- `registerAssets()` validates and registers each asset sequentially. It is not an atomic batch transaction.
+- The token registry validates records with `TokenAssetSchema`.
+- Asset registry metadata is static and local; use live providers for balances, prices, quotes, chain state, or contract validation.
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/tools/asset-registry/configuration.mdx
+++ b/content/docs/tools/asset-registry/configuration.mdx
@@ -1,0 +1,103 @@
+---
+title: Asset Registry Configuration
+description: Install and configure @tetherto/wdk-asset-registry for local asset metadata lookup
+docType: reference
+schemaType: TechArticle
+icon: Settings
+---
+
+`@tetherto/wdk-asset-registry` has no API keys, environment variables, RPC providers, or runtime service configuration. Create an in-memory registry, preload optional asset lists, and register any project-specific asset metadata your app needs.
+
+## Install the package
+
+```bash title="Install @tetherto/wdk-asset-registry"
+npm install @tetherto/wdk-asset-registry
+```
+
+## Create a token registry
+
+Import the token registry and preload the bundled common-token metadata.
+
+```javascript title="Create A Token Registry"
+import { WdkTokenAssetRegistry } from '@tetherto/wdk-asset-registry'
+import commonTokens from '@tetherto/wdk-asset-registry/assets/common-tokens' with { type: 'json' }
+
+const registry = new WdkTokenAssetRegistry(commonTokens)
+
+const usdt = registry.getTokenBySymbol('USDT')
+```
+
+<Callout type="info">
+Plain Node.js ESM requires the JSON import attribute. Some bundlers can load the same asset JSON without `with { type: 'json' }`.
+</Callout>
+
+## Register project assets
+
+Use `registerAsset()` for one token or `registerAssets()` for a list. Duplicate IDs throw `AssetRegistryError` unless you pass `true` as the `upsert` argument.
+
+```javascript title="Register A Token"
+registry.registerAsset({
+  id: 'eip155:1/0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  chainId: 'eip155:1',
+  address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  symbol: 'USDT',
+  name: 'Tether USD',
+  decimals: 6,
+  isNative: false
+})
+
+registry.registerAsset(
+  {
+    id: 'eip155:1/0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    chainId: 'eip155:1',
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    symbol: 'USDT',
+    name: 'Tether USD',
+    decimals: 6,
+    isNative: false
+  },
+  true
+)
+```
+
+## Look up tokens
+
+String lookups are case-insensitive by default. Pass `{ caseSensitive: true }` when casing must match exactly.
+
+```javascript title="Lookup Tokens"
+const bySymbol = registry.getTokenBySymbol('usdt')
+const byAddress = registry.getTokenByAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+const byChain = registry.getTokenByChain('eip155:1')
+const exactSymbol = registry.getTokenBySymbol('USDT', { caseSensitive: true })
+```
+
+## Normalize token lists
+
+Use the Uniswap helpers when importing token metadata from a token-list compatible source.
+
+```javascript title="Normalize Uniswap Tokens"
+import {
+  WdkTokenAssetRegistry,
+  fromUniswapTokenList
+} from '@tetherto/wdk-asset-registry'
+
+const normalizedTokens = fromUniswapTokenList(uniswapTokenList.tokens)
+const registry = new WdkTokenAssetRegistry(normalizedTokens)
+```
+
+`fromUniswapToken()` maps numeric EVM chain IDs to `eip155:<chainId>`, builds token IDs as `<chainId>/<address>`, sets `isNative` to `false`, and validates the result as a `TokenAsset`.
+
+## Runtime notes
+
+- Registries are in-memory. Persist custom asset lists in your application storage if they must survive process restarts.
+- `common-tokens` is static bundled metadata. It is not a freshness guarantee.
+- The package does not fetch balances, prices, quotes, token images, chain state, or contract verification data.
+- `TokenAsset` requires `id`, `chainId`, `address`, `symbol`, `name`, `decimals`, and `isNative`.
+- `decimals` must be an integer between `0` and `255`.
+- Uniswap helpers normalize only fields required by `TokenAsset`; fields such as `logoURI`, `tags`, and `extensions` are not preserved.
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/tools/asset-registry/index.mdx
+++ b/content/docs/tools/asset-registry/index.mdx
@@ -1,0 +1,40 @@
+---
+title: Asset Registry
+description: Standardized asset metadata and lookup helpers for @tetherto/wdk-asset-registry
+docType: explanation
+schemaType: TechArticle
+---
+
+Asset Registry provides in-memory registries for standardized asset metadata. Use `@tetherto/wdk-asset-registry` when a wallet, protocol, UI, or indexing flow needs consistent asset identifiers, symbols, decimals, chain IDs, and token contract addresses without adding an RPC dependency.
+
+Powered by [`@tetherto/wdk-asset-registry`](https://github.com/tetherto/wdk-asset-registry).
+
+## Features
+
+- **Base asset registry**: Register and look up assets by `id` or by partial metadata filters.
+- **Token asset registry**: Work with token metadata including `address`, `symbol`, `name`, `decimals`, and `isNative`.
+- **Bundled asset lists**: Import predefined JSON metadata from `@tetherto/wdk-asset-registry/assets/common-tokens`.
+- **Zod-backed schemas**: Validate base and token asset records before registration.
+- **Uniswap token-list helpers**: Normalize Uniswap-style token entries into WDK `TokenAsset` records.
+- **No RPC dependency**: The package stores and searches metadata locally. It does not read balances, prices, or chain state.
+
+## Why this matters
+
+- Share one asset identity model across WDK wallet modules, pricing flows, protocol integrations, and UI surfaces.
+- Normalize token metadata before it reaches send, swap, bridge, or display logic.
+- Keep static metadata lookup separate from live providers that fetch balances, prices, quotes, or contract state.
+
+<Cards>
+<Card title="Asset Registry Configuration" href="/tools/asset-registry/configuration">
+Install the package, preload common tokens, and register local metadata.
+</Card>
+<Card title="Asset Registry API Reference" href="/tools/asset-registry/api-reference">
+Review registry classes, schemas, helper functions, and result types.
+</Card>
+</Cards>
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/tools/price-rates/api-reference.mdx
+++ b/content/docs/tools/price-rates/api-reference.mdx
@@ -24,13 +24,39 @@ new BitfinexPricingClient(options?)
 
 | Method | Description | Returns |
 |--------|-------------|---------|
-| `getCurrentPrice(base, quote)` | Fetch latest price for base/quote pair | `Promise\<number\>` |
+| `getCurrentPrice(base, quote)` | Fetch latest price for base/quote pair | `Promise\<number \| null\>` |
+| `getMultiCurrentPrices(pairs)` | Fetch latest prices for multiple pairs in one batch | `Promise\<Array\<number \| null\>\>` |
+| `getMultiPriceData(pairs)` | Fetch last price and 24h change data for multiple directly quoted pairs | `Promise\<Array\<PriceData \| null\>\>` |
 | `getHistoricalPrice(from, to, opts?)` | Fetch historical series (downscaled to ≤ 100 points if needed) | `Promise\<HistoricalPriceResult[]\>` |
 
 ##### `getCurrentPrice(base, quote)`
 
+Uses Bitfinex's `/calc/fx/batch` endpoint. If Bitfinex cannot quote the pair directly, the client tries a two-leg USD pivot. Returns `null` when the pair cannot be resolved.
+
 ```javascript title="Current Price"
 const price = await client.getCurrentPrice('BTC', 'USD')
+const brl = await client.getCurrentPrice('BTC', 'BRL')
+```
+
+##### `getMultiCurrentPrices(pairs)`
+
+Returns current prices in the same order as the input pairs. Each unresolved pair returns `null`.
+
+```javascript title="Batch Current Prices"
+const prices = await client.getMultiCurrentPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
+```
+
+##### `getMultiPriceData(pairs)`
+
+Returns last price plus 24-hour absolute and relative change. This method reads Bitfinex ticker data and does not use the USD-pivot fallback, so unsupported entries return `null`.
+
+```javascript title="Batch Price Data"
+const data = await client.getMultiPriceData([
+  { from: 'BTC', to: 'USD' }
+])
 ```
 
 ##### `getHistoricalPrice(from, to, opts?)`
@@ -69,6 +95,9 @@ new PricingProvider({
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getLastPrice(base, quote)` | Returns cached last price; refreshes when TTL expires | `Promise\<number\>` |
+| `getMultiLastPrices(pairs)` | Returns cached last prices for multiple pairs | `Promise\<number[]\>` |
+| `getLastPriceData(base, quote)` | Returns cached last price plus daily change data | `Promise\<PriceData\>` |
+| `getMultiLastPriceData(pairs)` | Returns cached price data for multiple pairs | `Promise\<PriceData[]\>` |
 | `getHistoricalPrice(from, to, opts?)` | Delegates to client for historical data | `Promise\<HistoricalPriceResult[]\>` |
 
 ##### `getLastPrice(base, quote)`
@@ -76,6 +105,30 @@ new PricingProvider({
 ```javascript title="Last Price with Caching"
 const provider = new PricingProvider({ client })
 const last = await provider.getLastPrice('BTC', 'USD')
+```
+
+##### `getMultiLastPrices(pairs)`
+
+```javascript title="Cached Batch Last Prices"
+const prices = await provider.getMultiLastPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
+```
+
+##### `getLastPriceData(base, quote)`
+
+```javascript title="Cached Price Data"
+const data = await provider.getLastPriceData('BTC', 'USD')
+console.log(data.lastPrice, data.dailyChange, data.dailyChangeRelative)
+```
+
+##### `getMultiLastPriceData(pairs)`
+
+```javascript title="Cached Batch Price Data"
+const data = await provider.getMultiLastPriceData([
+  { from: 'BTC', to: 'USD' }
+])
 ```
 
 ##### `getHistoricalPrice(from, to, opts?)`
@@ -93,12 +146,15 @@ Implement this interface to plug your data source into `PricingProvider`.
 
 | Method | Signature | Notes |
 |--------|-----------|-------|
-| `getCurrentPrice` | `(from: string, to: string) =\> Promise\<number\>` | Should return spot price |
+| `getCurrentPrice` | `(from: string, to: string) =\> Promise\<number \| null\>` | Return spot price or `null` when the pair cannot be resolved |
+| `getMultiCurrentPrices` | `(list: PricePair[]) =\> Promise\<Array\<number \| null\>\>` | Return one result per pair; unresolved entries are `null` |
+| `getMultiPriceData` | `(list: PricePair[]) =\> Promise\<Array\<PriceData \| null\>\>` | Return last price and daily change data; unresolved entries are `null` |
 | `getHistoricalPrice` | `(from: string, to: string, opts?: HistoricalPriceOptions) =\> Promise\<HistoricalPriceResult[]\>` | Return series for charting |
 
 ## Notes
 
-- Uses Bitfinex Public HTTP API (`/v2/ticker` and `/v2/candles`) under the hood for the Bitfinex client
+- Uses Bitfinex Public HTTP API (`/v2/calc/fx/batch`, `/v2/tickers`, and `/v2/candles`) under the hood for the Bitfinex client
+- Current-price lookups can pivot through USD for fiat pairs Bitfinex does not quote directly; historical prices and `getMultiPriceData()` do not use that pivot
 - Provider caches last price per pair using in-memory store and TTL
 
 ***

--- a/content/docs/tools/price-rates/configuration.mdx
+++ b/content/docs/tools/price-rates/configuration.mdx
@@ -17,8 +17,36 @@ const client = new BitfinexPricingClient()
 
 ### Current Price
 
+Current-price lookups use Bitfinex's FX conversion endpoint. If Bitfinex cannot quote the pair directly, the client tries a two-leg `from -> USD -> to` conversion. If the pair still cannot be resolved, the result is `null`.
+
 ```javascript title="Get Current Price"
 const price = await client.getCurrentPrice('BTC', 'USD')
+const brlPrice = await client.getCurrentPrice('BTC', 'BRL') // resolved through USD when available
+
+if (price === null) {
+  // Show an unavailable-price state in your UI
+}
+```
+
+### Batch Current Prices
+
+Batch lookups return results in the same order as the input list. Entries that cannot be resolved are `null`.
+
+```javascript title="Get Batch Current Prices"
+const prices = await client.getMultiCurrentPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
+```
+
+### Batch Price Data
+
+Use `getMultiPriceData()` when you need the last price plus 24-hour absolute and relative change. This method uses Bitfinex ticker data and only supports pairs Bitfinex quotes directly.
+
+```javascript title="Get Batch Price Data"
+const priceData = await client.getMultiPriceData([
+  { from: 'BTC', to: 'USD' }
+])
 ```
 
 ### Historical Series
@@ -47,6 +75,10 @@ const provider = new PricingProvider({
 })
 
 const last = await provider.getLastPrice('BTC', 'USD')
+const prices = await provider.getMultiLastPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'BRL' }
+])
 const hist = await provider.getHistoricalPrice('BTC', 'USD', {
   start: 1709906400000,
   end: 1709913600000

--- a/content/docs/tools/price-rates/index.mdx
+++ b/content/docs/tools/price-rates/index.mdx
@@ -11,7 +11,8 @@ Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/w
 
 ## Features
 
-- **Current Prices**: Fetch latest price for a base/quote pair (e.g., BTC/USD)
+- **Current Prices**: Fetch latest price for one pair or many pairs in a batch (e.g., BTC/USD)
+- **Fiat Fallback**: Resolve fiat pairs Bitfinex does not quote directly by pivoting through USD when current FX data is available
 - **Historical Series**: Retrieve historical price series; long histories optionally downscaled to ≤ 100 points
 - **Provider Compatibility**: Works with `@tetherto/wdk-pricing-provider`
 - **Lightweight HTTP Client**: Minimal dependencies; easy to integrate
@@ -20,6 +21,7 @@ Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/w
 
 - Consistent pricing is required for balance valuations, charts, and quotes
 - A unified client reduces integration time and data handling errors
+- Unsupported pairs return `null` from the pricing client so applications can show a clear unavailable-price state
 
 <Cards>
 <Card title="Price Rates Overview" href="/tools/price-rates/configuration">

--- a/content/docs/tools/react-native-core/api-reference.mdx
+++ b/content/docs/tools/react-native-core/api-reference.mdx
@@ -14,6 +14,7 @@ schemaType: APIReference
 | [`useAddresses`](#useaddresses) | Hook | Load and query wallet addresses |
 | [`useBalance`](#usebalance) | Hook | Single asset balance with TanStack Query |
 | [`useBalancesForWallet`](#usebalancesforwallet) | Hook | Bulk balance fetch for multiple assets |
+| [`useBalancesForWallets`](#usebalancesforwallets) | Hook | Bulk balance fetch for multiple assets across account indices |
 | [`useRefreshBalance`](#userefreshbalance) | Hook | Invalidate and refetch balances |
 | [`BaseAsset`](#baseasset) | Class | Default `IAsset` implementation |
 | [`validateMnemonic`](#validatemnemonic) | Utility | Validate BIP39 mnemonic phrases |
@@ -495,6 +496,61 @@ function PortfolioScreen() {
       {balances?.map((b) => (
         <Text key={b.assetId}>
           {b.assetId}: {b.success ? b.balance : 'Error'}
+        </Text>
+      ))}
+    </View>
+  )
+}
+```
+
+---
+
+## useBalancesForWallets
+
+Hook to fetch balances for multiple assets across multiple account indices in a single TanStack Query. The hook loads addresses for every required account/network pair before fetching balances, reuses cached balance data as initial query data, and returns per-account token failures instead of failing the entire query when one account fetch fails.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `accountIndices` | `number[]` | Account indices to fetch balances for |
+| `assetConfigs` | [`IAsset[]`](#iasset) | Array of assets to fetch for each account index |
+| `options` | [`BalanceQueryOptions`](#balancequeryoptions) & `{ concurrencyLimit?: number }` | Optional query configuration and per-account fetch concurrency. Defaults to `2` concurrent account fetches |
+
+### Returns `UseBalancesForWalletsResult`
+
+Same shape as `UseBalancesForWalletResult`; `data` is a flattened `BalanceFetchResult[]` for all requested account indices and assets.
+
+```typescript
+type UseBalancesForWalletsResult = Omit<UseQueryResult<BalanceFetchResult[], Error>, 'isLoading' | 'error'> & {
+  isLoading: boolean
+  error: Error | null
+}
+```
+
+### Example
+
+```tsx
+import { useBalancesForWallets, BaseAsset } from '@tetherto/wdk-react-native-core'
+
+const assets = [
+  new BaseAsset({ id: 'eth', network: 'ethereum', symbol: 'ETH', name: 'Ether', decimals: 18, isNative: true }),
+  new BaseAsset({ id: 'usdt-eth', network: 'ethereum', symbol: 'USDT', name: 'Tether USD', decimals: 6, isNative: false, address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' }),
+]
+
+function AccountsPortfolioScreen() {
+  const { data: balances, isLoading } = useBalancesForWallets([0, 1, 2], assets, {
+    concurrencyLimit: 2,
+    refetchInterval: 60000,
+  })
+
+  if (isLoading) return <Text>Loading balances...</Text>
+
+  return (
+    <View>
+      {balances?.map((b) => (
+        <Text key={`${b.accountIndex}-${b.assetId}`}>
+          Account {b.accountIndex} {b.assetId}: {b.success ? b.balance : 'Error'}
         </Text>
       ))}
     </View>

--- a/content/docs/tools/react-native-core/index.mdx
+++ b/content/docs/tools/react-native-core/index.mdx
@@ -7,8 +7,8 @@ description: Hooks-based React Native library for building multi-chain wallet ap
 
 ## Features
 
-- **Hooks-based architecture** - `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, and more
-- **TanStack Query caching** - automatic balance fetching, per-token fallback for modules without batch balance support, cache invalidation, and optimistic updates
+- **Hooks-based architecture** - `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, `useBalancesForWallets`, and more
+- **TanStack Query caching** - automatic balance fetching across one or many account indices, per-token fallback for modules without batch balance support, cache invalidation, and optimistic updates
 - **Zustand state management** - persisted wallet state with MMKV storage
 - **Worklet runtime** - runs WDK in an isolated Bare worklet
 - **Biometric authentication** - secure storage with device biometrics
@@ -157,9 +157,10 @@ WdkAppProvider
     +-- useWalletManager()  - create, restore, lock, unlock, delete wallets
     +-- useAccount()        - address, send, sign, verify, estimateFee
     +-- useAddresses()      - load and query addresses
-    +-- useBalance()        - single balance with TanStack Query
-    +-- useBalancesForWallet() - bulk balance fetch with per-token fallback
-    +-- useRefreshBalance() - invalidate and refetch balances
+    +-- useBalance()            - single balance with TanStack Query
+    +-- useBalancesForWallet()  - bulk balance fetch for one account index
+    +-- useBalancesForWallets() - bulk balance fetch across account indices
+    +-- useRefreshBalance()     - invalidate and refetch balances
 ```
 
 ---

--- a/content/docs/tools/wdk-utils/api-reference.mdx
+++ b/content/docs/tools/wdk-utils/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils API Reference
-description: Validation, BOLT11, and EIP-681 APIs for @tetherto/wdk-utils
+description: Validation, BIP-21, BOLT11, and EIP-681 APIs for @tetherto/wdk-utils
 docType: reference
 schemaType: APIReference
 ---
@@ -295,6 +295,69 @@ import { resolveUmaUsername } from '@tetherto/wdk-utils'
 
 const result = resolveUmaUsername('$alice@wallet.com')
 ```
+
+### BIP-21 Bitcoin Payment URI Helpers
+
+| Function | Description | Returns |
+| --- | --- | --- |
+| `isBip21Request(input)` | Detect whether a string has the shape of a Bitcoin payment URI. | `boolean` |
+| `parseBip21Request(input)` | Parse a supported `bitcoin:` URI into structured payment details. | `Bip21ParseResult` |
+| `encodeBip21Request(request)` | Encode a validated request object into a `bitcoin:` URI. | `string` |
+
+#### `isBip21Request(input)`
+
+Detect whether a string looks like a BIP-21 Bitcoin payment URI before attempting a full parse. This is a syntactic check only; use `parseBip21Request()` when you need address and parameter validation.
+
+```javascript title="Detect A BIP-21 Request"
+import { isBip21Request } from '@tetherto/wdk-utils'
+
+const looksLikeRequest = isBip21Request(
+  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Coffee'
+)
+```
+
+#### `parseBip21Request(input)`
+
+Parse a BIP-21 Bitcoin payment URI. The helper validates the Bitcoin address, accepts optional `amount`, `label`, and `message` parameters, rejects unsupported `req-` parameters, and returns machine-readable failure reasons.
+
+```javascript title="Parse A BIP-21 Request"
+import { parseBip21Request } from '@tetherto/wdk-utils'
+
+const result = parseBip21Request(
+  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Coffee&message=Thanks'
+)
+```
+
+`Bip21ParseResult` is one of these shapes:
+
+- `{ success: true, type: 'bip21', value: Bip21Request }`
+- `{ success: false, reason: 'INVALID_FORMAT' | 'INVALID_ADDRESS' | 'INVALID_AMOUNT' | 'UNSUPPORTED_REQUIRED_PARAM' }`
+
+`Bip21Request` contains:
+
+- `address: string`
+- `amount?: string`
+- `label?: string`
+- `message?: string`
+
+`amount` is a decimal BTC string with up to eight decimal places and a maximum value of `21000000`.
+
+#### `encodeBip21Request(request)`
+
+Encode a BIP-21 Bitcoin payment URI from a request object. The helper validates the Bitcoin address and amount before returning the URI.
+
+```javascript title="Encode A BIP-21 Request"
+import { encodeBip21Request } from '@tetherto/wdk-utils'
+
+const uri = encodeBip21Request({
+  address: '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
+  amount: '0.001',
+  label: 'Coffee',
+  message: 'Thanks'
+})
+```
+
+`encodeBip21Request()` throws `INVALID_REQUEST`, `INVALID_ADDRESS`, or `INVALID_AMOUNT` when the request object cannot be encoded.
 
 ### EIP-681 Request Parsing Helpers
 

--- a/content/docs/tools/wdk-utils/api-reference.mdx
+++ b/content/docs/tools/wdk-utils/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils API Reference
-description: API for @tetherto/wdk-utils
+description: Validation, BOLT11, and EIP-681 APIs for @tetherto/wdk-utils
 docType: reference
 schemaType: APIReference
 ---
@@ -18,6 +18,10 @@ schemaType: APIReference
 | `validateEVMAddress(address)` | Validate an EVM address, including EIP-55 checksum rules for mixed-case inputs. | `EvmAddressValidationResult` |
 | `stripLightningPrefix(input)` | Remove a leading `lightning:` prefix before other Lightning validation steps. | `string` |
 | `validateLightningInvoice(address)` | Validate a Lightning invoice string. | `LightningInvoiceValidationResult` |
+| `decode(invoice)` | Decode a BOLT11 Lightning invoice into structured invoice data. | `LightningInvoiceDecodingResult` |
+| `getHashToSign(invoiceData)` | Return the SHA-256 hash that must be signed for a BOLT11 invoice. | `LightningInvoiceHashingResult` |
+| `sign(invoiceData, privateKey)` | Sign BOLT11 invoice data with a hex string or `Uint8Array` private key. | `LightningInvoiceSigningResult` |
+| `encode(invoiceData)` | Encode BOLT11 invoice data into an invoice string. | `LightningInvoiceEncodingResult` |
 | `validateLnurl(address)` | Validate an LNURL string. | `LnurlValidationResult` |
 | `decodeLnurl(address)` | Decode an LNURL string into its original URL. | `LnurlDecodingResult` |
 | `validateLightningAddress(address)` | Validate a Lightning Address in `user@domain.tld` form. | `LightningAddressValidationResult` |
@@ -115,6 +119,72 @@ const result = validateLightningInvoice(
 `LightningInvoiceValidationResult` is one of these shapes:
 
 - `{ success: true, type: 'invoice' }`
+- `{ success: false, reason: string }`
+
+#### `decode(invoice)`
+
+Decode a BOLT11 Lightning invoice into structured invoice data. The exported function name is `decode`, so alias it at import sites when your code also decodes other payloads.
+
+Payment descriptions are user-defined. Sanitize `description` tag values before rendering them in HTML or storing them.
+
+```javascript title="Decode A BOLT11 Invoice"
+import { decode as decodeBolt11 } from '@tetherto/wdk-utils'
+
+const result = decodeBolt11(
+  'lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w'
+)
+```
+
+`LightningInvoiceDecodingResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice', data: DecodedLightningInvoice }`
+- `{ success: false, reason: string }`
+
+`DecodedLightningInvoice` includes the invoice `network` (`bitcoin`, `testnet`, `regtest`, or `signet`), optional `millisatoshis`, optional `timestamp`, optional `timeExpireDate`, optional `payeeNodeKey`, optional `signature`, optional `recoveryFlag`, required `tags`, and optional `paymentRequest`.
+
+#### `getHashToSign(invoiceData)`
+
+Return the SHA-256 hash that must be signed for a BOLT11 invoice.
+
+```javascript title="Get The Invoice Signing Hash"
+import { getHashToSign } from '@tetherto/wdk-utils'
+
+const hash = getHashToSign(invoiceData)
+```
+
+`LightningInvoiceHashingResult` is one of these shapes:
+
+- `{ success: true, type: 'hash', data: Uint8Array }`
+- `{ success: false, reason: string }`
+
+#### `sign(invoiceData, privateKey)`
+
+Sign BOLT11 invoice data. The private key can be a hex string or `Uint8Array`.
+
+```javascript title="Sign A BOLT11 Invoice"
+import { sign as signBolt11 } from '@tetherto/wdk-utils'
+
+const signed = signBolt11(invoiceData, privateKey)
+```
+
+`LightningInvoiceSigningResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice', data: DecodedLightningInvoice }`
+- `{ success: false, reason: string }`
+
+#### `encode(invoiceData)`
+
+Encode BOLT11 invoice data into an invoice string.
+
+```javascript title="Encode A BOLT11 Invoice"
+import { encode as encodeBolt11 } from '@tetherto/wdk-utils'
+
+const encoded = encodeBolt11(signed.data)
+```
+
+`LightningInvoiceEncodingResult` is one of these shapes:
+
+- `{ success: true, type: 'invoice', data: string }`
 - `{ success: false, reason: string }`
 
 #### `validateLnurl(address)`

--- a/content/docs/tools/wdk-utils/configuration.mdx
+++ b/content/docs/tools/wdk-utils/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils Configuration
-description: Install and import validation helpers and EIP-681 parsers from @tetherto/wdk-utils
+description: Install and import validation, BOLT11, and EIP-681 helpers from @tetherto/wdk-utils
 ---
 
 This package does not have constructor options or runtime configuration. This page shows how to install `@tetherto/wdk-utils`, import the helpers you need, and understand the published runtime surface.
@@ -43,10 +43,26 @@ import {
 } from '@tetherto/wdk-utils'
 ```
 
+## Import BOLT11 helpers
+
+You can validate, decode, sign, and encode BOLT11 Lightning invoices from the package entrypoint:
+
+```javascript title="Import BOLT11 Helpers"
+import {
+  decode as decodeBolt11,
+  encode as encodeBolt11,
+  getHashToSign,
+  sign as signBolt11,
+  validateLightningInvoice
+} from '@tetherto/wdk-utils'
+```
+
 ## Runtime notes
 
 - `@tetherto/wdk-utils` exports plain functions. There is no client object to initialize.
 - The package publishes a default module entrypoint through `index.js` and a bare runtime entrypoint through `bare.js`.
+- BOLT11 helpers support invoices for `bitcoin`, `testnet`, `regtest`, and `signet` networks.
+- `decode()` returns user-provided invoice descriptions when they are present. Sanitize descriptions before rendering them in HTML or storing them.
 - `decodeLnurl()` returns the decoded URL string when parsing succeeds.
 - `parseEip681Request()` currently supports transfer requests for the schemes implemented in the published runtime: `ethereum`, `pol`, `matic`, `polygon`, `arbitrum`, and `plasma`.
 - `parseEip681Request()` accepts both `uint256` and `value` query parameters for the amount field and normalizes the parsed amount into `amountSmallest`.
@@ -67,6 +83,16 @@ const btc = validateBitcoinAddress('bc1qu9yqnhc6wjj6s62s9x0shnl5l2r7gq5cudm94r7m
 const lightning = validateLightningAddress('sprycomfort92@waletofsatoshi.com')
 const tron = validateTronAddress('TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH')
 const uma = validateUmaAddress('$you@uma.money')
+```
+
+You can decode BOLT11 invoice details before presenting a payment request:
+
+```javascript title="Decode A BOLT11 Invoice"
+import { decode as decodeBolt11 } from '@tetherto/wdk-utils'
+
+const invoice = decodeBolt11(
+  'lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w'
+)
 ```
 
 You can parse a request-shaped EIP-681 transfer string into structured data:

--- a/content/docs/tools/wdk-utils/configuration.mdx
+++ b/content/docs/tools/wdk-utils/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils Configuration
-description: Install and import validation, BOLT11, and EIP-681 helpers from @tetherto/wdk-utils
+description: Install and import validation, BIP-21, BOLT11, and EIP-681 helpers from @tetherto/wdk-utils
 ---
 
 This package does not have constructor options or runtime configuration. This page shows how to install `@tetherto/wdk-utils`, import the helpers you need, and understand the published runtime surface.
@@ -43,6 +43,18 @@ import {
 } from '@tetherto/wdk-utils'
 ```
 
+## Import BIP-21 helpers
+
+You can detect, parse, and encode Bitcoin payment URIs using the BIP-21 helpers:
+
+```javascript title="Import BIP-21 Helpers"
+import {
+  encodeBip21Request,
+  isBip21Request,
+  parseBip21Request
+} from '@tetherto/wdk-utils'
+```
+
 ## Import BOLT11 helpers
 
 You can validate, decode, sign, and encode BOLT11 Lightning invoices from the package entrypoint:
@@ -61,6 +73,9 @@ import {
 
 - `@tetherto/wdk-utils` exports plain functions. There is no client object to initialize.
 - The package publishes a default module entrypoint through `index.js` and a bare runtime entrypoint through `bare.js`.
+- `parseBip21Request()` accepts `bitcoin:` URIs with a validated Bitcoin address and optional `amount`, `label`, and `message` parameters.
+- `encodeBip21Request()` validates the Bitcoin address and amount before returning a `bitcoin:` URI.
+- BIP-21 amounts are decimal BTC strings with up to eight decimal places and a maximum value of `21000000`.
 - BOLT11 helpers support invoices for `bitcoin`, `testnet`, `regtest`, and `signet` networks.
 - `decode()` returns user-provided invoice descriptions when they are present. Sanitize descriptions before rendering them in HTML or storing them.
 - `decodeLnurl()` returns the decoded URL string when parsing succeeds.
@@ -93,6 +108,22 @@ import { decode as decodeBolt11 } from '@tetherto/wdk-utils'
 const invoice = decodeBolt11(
   'lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w'
 )
+```
+
+You can parse and encode a BIP-21 Bitcoin payment request:
+
+```javascript title="Handle A BIP-21 Request"
+import { encodeBip21Request, parseBip21Request } from '@tetherto/wdk-utils'
+
+const parsed = parseBip21Request(
+  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Coffee'
+)
+
+const encoded = encodeBip21Request({
+  address: '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
+  amount: '0.001',
+  label: 'Coffee'
+})
 ```
 
 You can parse a request-shaped EIP-681 transfer string into structured data:

--- a/content/docs/tools/wdk-utils/index.mdx
+++ b/content/docs/tools/wdk-utils/index.mdx
@@ -1,14 +1,15 @@
 ---
 title: WDK Utils
-description: Address validation helpers and EIP-681 request parsers for @tetherto/wdk-utils
+description: Address validation, BOLT11 invoice, and EIP-681 request helpers for @tetherto/wdk-utils
 ---
 
-WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, plus EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, BOLT11 invoice helpers, and EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
 
 ## Features
 
 - **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Spark, Tron, and UMA inputs before you hand them to a wallet flow.
-- **LNURL decoding**: Decode LNURL strings before you display or route payment details.
+- **Lightning payment parsing**: Decode LNURL strings and BOLT11 invoices before you display or route payment details.
+- **BOLT11 invoice helpers**: Validate, decode, hash, sign, and encode BOLT11 invoices for Bitcoin, testnet, regtest, and signet flows.
 - **EIP-681 request parsing**: Detect request-shaped EIP-681 strings and parse transfer payloads into `recipient`, `tokenAddress`, `chainId`, and `amountSmallest`.
 - **No runtime setup**: Import the functions you need. The package has no constructor or runtime configuration.
 - **TypeScript support**: The published package ships typed exports for every validator and parser.
@@ -17,6 +18,7 @@ WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, 
 ## Why this matters
 
 - Validate user input early and return machine-readable failure reasons before you attempt a transaction or resolution flow.
+- Inspect BOLT11 invoice metadata, fallback addresses, routing information, and feature bits before presenting payment details.
 - Normalize EIP-681 payment links into structured transfer data that wallet UIs can inspect before execution.
 - Reuse the same helpers across Node.js and Bare-based environments without adding a larger wallet module dependency.
 

--- a/content/docs/tools/wdk-utils/index.mdx
+++ b/content/docs/tools/wdk-utils/index.mdx
@@ -1,13 +1,14 @@
 ---
 title: WDK Utils
-description: Address validation, BOLT11 invoice, and EIP-681 request helpers for @tetherto/wdk-utils
+description: Address validation, BIP-21, BOLT11 invoice, and EIP-681 request helpers for @tetherto/wdk-utils
 ---
 
-WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, BOLT11 invoice helpers, and EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, BIP-21 Bitcoin payment URI helpers, BOLT11 invoice helpers, and EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
 
 ## Features
 
 - **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Spark, Tron, and UMA inputs before you hand them to a wallet flow.
+- **BIP-21 payment URI helpers**: Detect, parse, and encode `bitcoin:` payment URIs with optional amount, label, and message fields.
 - **Lightning payment parsing**: Decode LNURL strings and BOLT11 invoices before you display or route payment details.
 - **BOLT11 invoice helpers**: Validate, decode, hash, sign, and encode BOLT11 invoices for Bitcoin, testnet, regtest, and signet flows.
 - **EIP-681 request parsing**: Detect request-shaped EIP-681 strings and parse transfer payloads into `recipient`, `tokenAddress`, `chainId`, and `amountSmallest`.
@@ -18,6 +19,7 @@ WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, 
 ## Why this matters
 
 - Validate user input early and return machine-readable failure reasons before you attempt a transaction or resolution flow.
+- Parse and encode BIP-21 Bitcoin payment links before pre-filling send forms.
 - Inspect BOLT11 invoice metadata, fallback addresses, routing information, and feature bits before presenting payment details.
 - Normalize EIP-681 payment links into structured transfer data that wallet UIs can inspect before execution.
 - Reuse the same helpers across Node.js and Bare-based environments without adding a larger wallet module dependency.

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -68,6 +68,7 @@ export const customTree: Node[] = [
           { name: 'Register Wallets', url: '/sdk/core-module/guides/wallet-registration', type: 'page' },
           { name: 'Account Management', url: '/sdk/core-module/guides/account-management', type: 'page' },
           { name: 'Send Transactions', url: '/sdk/core-module/guides/transactions', type: 'page' },
+          { name: 'Transaction Policies', url: '/sdk/core-module/guides/transaction-policies', type: 'page' },
           { name: 'Protocol Integration', url: '/sdk/core-module/guides/protocol-integration', type: 'page' },
           { name: 'Middleware', url: '/sdk/core-module/guides/middleware', type: 'page' },
           { name: 'Error Handling', url: '/sdk/core-module/guides/error-handling', type: 'page' },
@@ -518,6 +519,20 @@ export const customTree: Node[] = [
     children: [
       { name: 'Configuration', url: '/tools/price-rates/configuration', type: 'page', icon: resolveIcon('Settings') },
       { name: 'API Reference', url: '/tools/price-rates/api-reference', type: 'page', icon: resolveIcon('Code') },
+    ],
+  },
+  {
+    name: 'Asset Registry',
+    type: 'folder',
+    icon: resolveIcon('Tags'),
+    index: {
+      name: 'Asset Registry',
+      url: '/tools/asset-registry',
+      type: 'page',
+    },
+    children: [
+      { name: 'Configuration', url: '/tools/asset-registry/configuration', type: 'page', icon: resolveIcon('Settings') },
+      { name: 'API Reference', url: '/tools/asset-registry/api-reference', type: 'page', icon: resolveIcon('Code') },
     ],
   },
   { name: 'Create WDK Module', url: '/tools/create-wdk-module', type: 'page', icon: resolveIcon('Hammer') },

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -152,6 +152,27 @@ export const customTree: Node[] = [
         ],
       },
       {
+        name: 'wallet-evm-7702-gasless', type: 'folder',
+        index: { name: 'wallet-evm-7702-gasless', url: '/sdk/wallet-modules/wallet-evm-7702-gasless', type: 'page' },
+        children: [
+          { name: 'Usage', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/usage', type: 'page' },
+          {
+            name: 'Guides', type: 'folder', icon: resolveIcon('BookOpen'),
+            children: [
+              { name: 'Get Started', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started', type: 'page' },
+              { name: 'Manage Accounts', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts', type: 'page' },
+              { name: 'Check Balances', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/guides/check-balances', type: 'page' },
+              { name: 'Send Transactions', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions', type: 'page' },
+              { name: 'Transfer Tokens', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens', type: 'page' },
+              { name: 'Sign and Verify Messages', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/guides/sign-verify-messages', type: 'page' },
+              { name: 'Handle Errors', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors', type: 'page' },
+            ],
+          },
+          { name: 'Configuration', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/configuration', type: 'page' },
+          { name: 'API Reference', url: '/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference', type: 'page' },
+        ],
+      },
+      {
         name: 'wallet-solana', type: 'folder',
         index: { name: 'wallet-solana', url: '/sdk/wallet-modules/wallet-solana', type: 'page' },
         children: [

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -301,7 +301,6 @@ export const customTree: Node[] = [
       },
     ],
   },
-  { name: 'Swidge Interface', url: '/sdk/swidge-modules', type: 'page', icon: resolveIcon('Route') },
   {
     name: 'Swap Modules',
     type: 'folder',


### PR DESCRIPTION
## Summary

Promotes the current `develop` docs release into `main`. This includes the June release-docs consolidation plus the follow-up Swidge navigation cleanup requested before production.

## Included PRs

- #163: docs: consolidate June release updates
- #165: docs: move swidge out of sidebar

## Release coverage

- [wdk-core v1.0.0-beta.10](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.10): swidge protocol registration, `getSwidgeProtocol()`, account-scoped protocol persistence, and duplicate wallet registration behavior.
- [wdk-core v1.0.0-beta.11](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.11): local transaction policies, scoped ALLOW/DENY rules, policy errors, default-deny behavior, simulation mirrors, and updated core API signatures.
- [wdk-asset-registry v1.0.0-beta.1](https://github.com/tetherto/wdk-asset-registry/releases/tag/v1.0.0-beta.1): first-party Asset Registry docs for base/token registries, Zod schemas, JSON schema exports, Uniswap token-list normalization, and bundled common-token metadata.
- [wdk-wallet-evm-7702-gasless v1.0.0-beta.1](https://github.com/tetherto/wdk-wallet-evm-7702-gasless/releases/tag/v1.0.0-beta.1): EIP-7702 delegated EOA docs covering ERC-4337 submission, sponsored and paymaster-token fee modes, provider failover, quotes, transfers, signing, receipts, and errors.
- [wdk-utils v1.0.0-beta.5](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.5): restored BOLT11 invoice helpers.
- [wdk-utils v1.0.0-beta.6](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.6): BIP-21 Bitcoin payment URI detection, parsing, encoding, validation, optional fields, and unsupported required-parameter errors.
- [wdk-wallet v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.10): `transactionMaxFee` on the base wallet config surface.
- [wallet-tron v1.0.0-beta.6](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.6): provider failover, retries, read-only key-pair behavior, TRX/TRC20 fee quote fields, and activation fee details.
- [wallet-evm-erc-4337 v1.0.0-beta.9](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.9): cached quote nonce validation, re-quoting behavior, and UserOperation gas override propagation.
- [pricing-provider v1.0.0-beta.5](https://github.com/tetherto/wdk-pricing-provider/releases/tag/v1.0.0-beta.5): nullable unresolved price results in the `PricingClient` base type.
- [pricing-bitfinex-http v1.0.0-beta.3](https://github.com/tetherto/wdk-pricing-bitfinex-http/releases/tag/v1.0.0-beta.3): batch FX conversion, USD-pivot fallback, `getMultiCurrentPrices()`, and `getMultiPriceData()` coverage.
- [react-native-core v1.0.0-beta.11](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.11): `useBalancesForWallets()` for multi-account balance fetching, address preloading, concurrency limits, and per-account token failure handling.

## Documentation deliverables

- Adds the dedicated SDK > Core Module > Guides > Transaction Policies page and links it from core usage, transaction guide, protocol integration, and API reference coverage.
- Adds Tools > Asset Registry overview, configuration, and API reference pages.
- Adds SDK > Wallet Modules > wallet-evm-7702-gasless overview, usage, configuration, API reference, and guides.
- Updates WDK Core overview, API reference, protocol integration, usage, and transactions docs.
- Updates WDK Utils overview, configuration, and API reference docs.
- Updates wallet module overview, wallet-tron docs, wallet-evm-erc-4337 docs, price-rates docs, and React Native Core docs.
- Adds `@arkade-os/wdk` to the Community Modules page with npm, GitHub, and README links.
- Updates the changelog with June 4, June 9, June 10, June 12, and June 14 release entries.
- Removes the Swidge Protocol Interface from the left navigation and keeps Swidge guidance as contextual end-of-page guidance on Swap Modules and Bridge Modules for combined swap-plus-bridge routes.

## Validation

- #163 ran `git diff --cached --check`, `npm run check:meta`, `LINK_CHECK_EXTERNAL=false npm run check:links`, and `npm run build`.
- #165 ran `git diff --check`, `npm run check:meta`, `LINK_CHECK_EXTERNAL=false npm run check:links`, and `npm run build`.
- This PR should run the repository quality gates against `develop` -> `main` before merge.