### PR TITLE
fix: prevent Inkeep citation href mutation loop

### DIFF
--- a/src/lib/inkeep.ts
+++ b/src/lib/inkeep.ts
@@ -175,7 +175,9 @@ function dedupeCitationAnchors(root: Document | ShadowRoot) {
         }
 
         const rewrittenHref = rewriteDocsUrl(anchor.href);
-        anchor.href = rewrittenHref;
+        if (rewrittenHref !== anchor.href) {
+          anchor.href = rewrittenHref;
+        }
 
         const isDuplicate = rewrittenHref === previousHref && normalizedLabel === previousLabel;
         anchor.hidden = isDuplicate;


### PR DESCRIPTION
## Summary

- Prevent the Inkeep citation cleanup observer from rewriting an anchor `href` when the rewritten URL is identical to the current value.
- Keeps citation deduplication behavior intact while avoiding unnecessary `href` mutations during streamed Ask AI responses.

## Root Cause

The Ask AI citation cleanup runs from a `MutationObserver` that watches `href` changes. Chrome can emit an attribute mutation even when code assigns the same `anchor.href` value back to the element, so the cleanup loop could retrigger itself while Inkeep was streaming citation links.

## Validation

- `git diff --check`
- `npm run check:meta`
- `npx tsc --noEmit --strict --skipLibCheck --target ESNext --lib DOM,DOM.Iterable,ESNext --moduleResolution bundler --module ESNext --jsx react-jsx src/lib/inkeep.ts`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `npm run build`

## Manual QA

- Reproduced the production Ask AI hang before the patch when submitting a question.
- Local patched Ask AI could not complete answer-stream stress testing because Inkeep returned `403 Not authenticated` for localhost chat completions. Staging should be used for the final manual stress pass after this reaches `develop`, since that origin is expected to be whitelisted.
