### PR TITLE
docs: add CoinGecko pricing module docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -32,6 +32,8 @@
 /sdk/bridge-usdt0-evm/*                        /sdk/bridge-modules/bridge-usdt0-evm/:splat            301
 /sdk/lending-aave-evm                          /sdk/lending-modules/lending-aave-evm                  301
 /sdk/lending-aave-evm/*                        /sdk/lending-modules/lending-aave-evm/:splat           301
+/sdk/pricing-coingecko-http                    /sdk/pricing-modules/pricing-coingecko-http            301
+/sdk/pricing-coingecko-http/*                  /sdk/pricing-modules/pricing-coingecko-http/:splat     301
 /sdk/fiat-moonpay                              /sdk/fiat-modules/fiat-moonpay                         301
 /sdk/fiat-moonpay/*                            /sdk/fiat-modules/fiat-moonpay/:splat                  301
 /*                                             /404.html                                             404

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 20, 2026
+
+**What's New**
+- **pricing-coingecko-http** ([v1.0.0-beta.1](https://github.com/tetherto/wdk-pricing-coingecko-http/releases/tag/v1.0.0-beta.1)): Introduce `@tetherto/wdk-pricing-coingecko-http`, a CoinGecko-backed `PricingClient` with current price lookups, batched current prices, price data with derived 24-hour change, historical price ranges with optional downsampling, Demo/Pro API key support, and configurable CoinGecko ID mappings.
+
+---
+
 ### June 14, 2026
 
 **What's New**

--- a/content/docs/sdk/all-modules.mdx
+++ b/content/docs/sdk/all-modules.mdx
@@ -1,6 +1,6 @@
 ---
 title: All Modules
-description: Complete list of all available WDK modules including wallet, swidge, swap, bridge, lending, and fiat modules.
+description: Complete list of all available WDK modules including wallet, pricing, swidge, swap, bridge, lending, and fiat modules.
 docType: reference
 schemaType: TechArticle
 ---
@@ -37,6 +37,15 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 Swidge is the preferred interface for new protocol providers that can quote and execute asset routes. A route can be swap-only, bridge-only, or a combined swap and bridge route.
 
 No released swidge provider module is listed yet. See the [swidge protocol interface](./swidge-modules/) for the shared API shape that new provider modules should implement.
+
+## Pricing Modules
+
+Pricing modules provide `PricingClient` implementations for market data sources.
+
+| Module | Provider | Description | Documentation |
+|--------|----------|-------------|---------------|
+| [`@tetherto/wdk-pricing-coingecko-http`](https://github.com/tetherto/wdk-pricing-coingecko-http) | CoinGecko | CoinGecko HTTP pricing client for current prices, price data, and historical series | [Docs](/sdk/pricing-modules/pricing-coingecko-http/) |
+| [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/wdk-pricing-bitfinex-http) | Bitfinex | Bitfinex HTTP pricing client for current prices, batched price data, and historical series | [Docs](/tools/price-rates/) |
 
 ## Swap Modules
 

--- a/content/docs/sdk/pricing-modules/index.mdx
+++ b/content/docs/sdk/pricing-modules/index.mdx
@@ -1,0 +1,46 @@
+---
+title: Pricing Modules Overview
+description: Explore WDK pricing modules for current prices, price data, and historical price series.
+docType: explanation
+schemaType: TechArticle
+---
+
+WDK pricing modules provide `PricingClient` implementations for external market data sources. Use them directly when you need raw provider results, or pass them into `PricingProvider` when you want caching and ordered failover across multiple clients.
+
+## Pricing Client Modules
+
+| Module | Provider | Status | Documentation |
+|--------|----------|--------|---------------|
+| [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/wdk-pricing-bitfinex-http) | Bitfinex | Ready | [Price Rates](/tools/price-rates/) |
+| [`@tetherto/wdk-pricing-coingecko-http`](https://github.com/tetherto/wdk-pricing-coingecko-http) | CoinGecko | Ready | [Documentation](/sdk/pricing-modules/pricing-coingecko-http/) |
+
+## Provider Compatibility
+
+Pricing clients implement the shared [`PricingClient`](/tools/price-rates/api-reference#interface-pricingclient-abstract) surface:
+
+- `getCurrentPrice(from, to)`
+- `getMultiCurrentPrices(list)`
+- `getMultiPriceData(list)`
+- `getHistoricalPrice(from, to, opts?)`
+
+Wrap one client with `PricingProvider` for in-memory last-price caching, or pass an ordered array of clients to fail over when one data source is unavailable.
+
+## Next Steps
+
+<Cards>
+<Card title="CoinGecko HTTP" href="/sdk/pricing-modules/pricing-coingecko-http/">
+Fetch current and historical prices through CoinGecko.
+</Card>
+<Card title="Price Rates" href="/tools/price-rates/">
+Use Bitfinex and the shared pricing provider.
+</Card>
+<Card title="API Reference" href="/sdk/pricing-modules/pricing-coingecko-http/api-reference">
+Review the CoinGecko client methods and options.
+</Card>
+</Cards>
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/api-reference.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/api-reference.mdx
@@ -1,0 +1,134 @@
+---
+title: Pricing CoinGecko HTTP API Reference
+description: API Reference for @tetherto/wdk-pricing-coingecko-http.
+docType: reference
+schemaType: APIReference
+icon: Code
+---
+
+# API Reference
+
+## Package
+
+```bash
+npm install @tetherto/wdk-pricing-coingecko-http
+```
+
+```javascript title="Import"
+import { CoingeckoPricingClient } from '@tetherto/wdk-pricing-coingecko-http'
+```
+
+## Class: `CoingeckoPricingClient`
+
+CoinGecko-backed implementation of `PricingClient` from `@tetherto/wdk-pricing-provider`.
+
+### Constructor
+
+```javascript
+new CoingeckoPricingClient(options?)
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `baseURL` | `string` | CoinGecko API base URL. Defaults to `https://api.coingecko.com/api/v3`. |
+| `coinIds` | `Record<string, string>` | Symbol-to-CoinGecko-ID overrides merged with the built-in map. |
+| `apiKey` | `string` | CoinGecko API key. Uses the Demo or Pro header based on `baseURL`. |
+
+### Methods
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `getCurrentPrice(from, to)` | Fetch current price for one pair | `Promise<number \| null>` |
+| `getMultiCurrentPrices(list)` | Fetch current prices for many pairs in one request | `Promise<Array<number \| null>>` |
+| `getMultiPriceData(list)` | Fetch last price plus 24-hour change for many pairs | `Promise<Array<PriceData \| null>>` |
+| `getHistoricalPrice(from, to, opts)` | Fetch historical prices for a pair over a time range | `Promise<HistoricalPriceResult[]>` |
+
+`from` is a ticker symbol resolved through `coinIds`; `to` is a CoinGecko `vs_currency` code. Both are case-insensitive.
+
+### `getCurrentPrice(from, to)`
+
+```javascript title="Current price"
+const price = await client.getCurrentPrice('BTC', 'USD')
+```
+
+Returns the current price as a number, or `null` when CoinGecko returns no data for the pair.
+
+Throws when `from` has no configured CoinGecko ID.
+
+### `getMultiCurrentPrices(list)`
+
+```javascript title="Batch current prices"
+const prices = await client.getMultiCurrentPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'EUR' }
+])
+```
+
+The client de-duplicates CoinGecko IDs and quote currencies before calling `/simple/price`. Results are returned in the same order as the input list. Missing entries return `null`.
+
+An empty input list returns an empty array.
+
+### `getMultiPriceData(list)`
+
+```javascript title="Batch price data"
+const data = await client.getMultiPriceData([
+  { from: 'BTC', to: 'USD' }
+])
+```
+
+Returns `PriceData` objects:
+
+```typescript
+type PriceData = {
+  lastPrice: number
+  dailyChange: number
+  dailyChangeRelative: number
+}
+```
+
+CoinGecko returns 24-hour change as a percentage. The client derives `dailyChange` from `lastPrice` and that percentage, so the absolute change is an approximation.
+
+### `getHistoricalPrice(from, to, opts)`
+
+```javascript title="Historical prices"
+const series = await client.getHistoricalPrice('BTC', 'USD', {
+  start: Date.now() - 7 * 24 * 60 * 60 * 1000,
+  end: Date.now(),
+  maxEntries: 100
+})
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `start` | `number` | Yes | Range start as a Unix timestamp in milliseconds. |
+| `end` | `number` | Yes | Range end as a Unix timestamp in milliseconds. |
+| `maxEntries` | `number` | No | Evenly downsample the returned series to at most this many points. |
+
+Returns points ordered oldest first:
+
+```typescript
+type HistoricalPriceResult = {
+  price: number
+  timestamp: number
+}
+```
+
+When `maxEntries` is set, the client keeps the first and last point and samples the middle of the series evenly. Without `maxEntries`, it returns every point from CoinGecko.
+
+Throws when `start` or `end` is missing. On the public or Demo API host, it also throws when `start` is older than the trailing 365 days. Use the Pro host and Pro key for older ranges.
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Unknown `from` symbol | Throws `Unknown symbol: ...` |
+| Missing `start` or `end` | Throws `start and end timestamps are required` |
+| Historical range older than 365 days on non-Pro host | Throws `Start date older than 365 days requires a CoinGecko Pro API key` |
+| CoinGecko has no data for a pair | Resolves to `null` for current and batched price methods |
+| CoinGecko rate limit or network error | Rejects with the underlying HTTP client error |
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/configuration.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/configuration.mdx
@@ -1,0 +1,101 @@
+---
+title: Pricing CoinGecko HTTP Configuration
+description: Configure @tetherto/wdk-pricing-coingecko-http options.
+docType: reference
+schemaType: TechArticle
+icon: Settings
+---
+
+# Configuration
+
+Create a `CoingeckoPricingClient` with no options for public CoinGecko API access:
+
+```javascript title="Public CoinGecko client"
+import { CoingeckoPricingClient } from '@tetherto/wdk-pricing-coingecko-http'
+
+const client = new CoingeckoPricingClient()
+```
+
+The public host is `https://api.coingecko.com/api/v3`.
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `baseURL` | `string` | `https://api.coingecko.com/api/v3` | CoinGecko API base URL. Use `https://pro-api.coingecko.com/api/v3` with a Pro key. |
+| `apiKey` | `string` | none | CoinGecko API key. The client chooses `x-cg-demo-api-key` or `x-cg-pro-api-key` from `baseURL`. |
+| `coinIds` | `Record<string, string>` | built-in map | Symbol-to-CoinGecko-ID overrides merged on top of defaults. |
+
+## API Keys
+
+Pass `apiKey` when you want CoinGecko authenticated requests:
+
+```javascript title="Demo API key"
+const demoClient = new CoingeckoPricingClient({
+  apiKey: process.env.COINGECKO_API_KEY
+})
+```
+
+Use the Pro API host with a Pro key:
+
+```javascript title="Pro API key"
+const proClient = new CoingeckoPricingClient({
+  baseURL: 'https://pro-api.coingecko.com/api/v3',
+  apiKey: process.env.COINGECKO_PRO_API_KEY
+})
+```
+
+When `baseURL` includes `pro-api.coingecko.com`, the client sends the key with `x-cg-pro-api-key`. Otherwise it sends `x-cg-demo-api-key`.
+
+## Coin ID Overrides
+
+CoinGecko uses asset IDs such as `bitcoin`, `ethereum`, and `tether-gold`. Tickers are not always enough to derive the correct ID, so the client keeps a small default map and lets you extend it.
+
+```javascript title="Add custom symbols"
+const client = new CoingeckoPricingClient({
+  coinIds: {
+    PEPE: 'pepe',
+    SHIB: 'shiba-inu'
+  }
+})
+
+const pepeUsd = await client.getCurrentPrice('PEPE', 'USD')
+```
+
+You can also override a built-in mapping:
+
+```javascript title="Override a default symbol"
+const client = new CoingeckoPricingClient({
+  coinIds: {
+    BTC: 'wrapped-bitcoin'
+  }
+})
+```
+
+## Provider Failover
+
+Use `CoingeckoPricingClient` as a fallback behind another pricing client by passing an ordered array to `PricingProvider`:
+
+```javascript title="Fail over to CoinGecko"
+import { PricingProvider } from '@tetherto/wdk-pricing-provider'
+import { BitfinexPricingClient } from '@tetherto/wdk-pricing-bitfinex-http'
+import { CoingeckoPricingClient } from '@tetherto/wdk-pricing-coingecko-http'
+
+const provider = new PricingProvider({
+  client: [
+    new BitfinexPricingClient(),
+    new CoingeckoPricingClient({ apiKey: process.env.COINGECKO_API_KEY })
+  ],
+  retries: 1
+})
+
+const btcUsd = await provider.getLastPrice('BTC', 'USD')
+```
+
+The provider failover layer retries connection errors. A pair that resolves to `null` is still an unavailable result for that client.
+
+## Runtime Notes
+
+- Install `@tetherto/wdk-pricing-provider` when you want caching or failover through `PricingProvider`.
+- The package exposes a Bare runtime entrypoint through its package export map.
+- Integration tests hit the live CoinGecko API and can fail with `429` under repeated free-tier runs.

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices.mdx
@@ -1,0 +1,90 @@
+---
+title: Fetch Current Prices
+description: Fetch current prices and batched price data with CoingeckoPricingClient.
+docType: how-to
+schemaType: TechArticle
+---
+
+This guide shows how to read current prices for one pair, batch multiple pairs, and use the client through `PricingProvider`.
+
+## One Pair
+
+Use `getCurrentPrice(from, to)` for a single ticker/currency pair:
+
+```javascript title="Fetch one pair"
+const price = await client.getCurrentPrice('BTC', 'USD')
+
+if (price === null) {
+  // Show an unavailable-price state.
+} else {
+  console.log(price)
+}
+```
+
+## Multiple Pairs
+
+Use `getMultiCurrentPrices(list)` to batch pairs into one `/simple/price` request:
+
+```javascript title="Fetch many pairs"
+const prices = await client.getMultiCurrentPrices([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'USD' },
+  { from: 'BTC', to: 'EUR' }
+])
+
+console.log(prices)
+```
+
+The result order matches the input order. If CoinGecko does not return data for one entry, that entry is `null`.
+
+## Price Data with Daily Change
+
+Use `getMultiPriceData(list)` when you need last price and 24-hour change:
+
+```javascript title="Fetch price data"
+const data = await client.getMultiPriceData([
+  { from: 'BTC', to: 'USD' },
+  { from: 'ETH', to: 'USD' }
+])
+
+for (const entry of data) {
+  if (entry === null) continue
+
+  console.log(entry.lastPrice)
+  console.log(entry.dailyChange)
+  console.log(entry.dailyChangeRelative)
+}
+```
+
+CoinGecko returns the 24-hour change as a percentage. The client derives the absolute `dailyChange`, so use it as an approximation.
+
+## Use PricingProvider
+
+Wrap the client with `PricingProvider` for last-price caching:
+
+```javascript title="Cached last prices"
+import { PricingProvider } from '@tetherto/wdk-pricing-provider'
+import { CoingeckoPricingClient } from '@tetherto/wdk-pricing-coingecko-http'
+
+const provider = new PricingProvider({
+  client: new CoingeckoPricingClient(),
+  priceCacheDurationMs: 60 * 60 * 1000
+})
+
+const last = await provider.getLastPrice('BTC', 'USD')
+```
+
+Use an ordered client array when CoinGecko should act as a fallback:
+
+```javascript title="Failover pricing"
+const provider = new PricingProvider({
+  client: [primaryClient, new CoingeckoPricingClient()],
+  retries: 1
+})
+```
+
+## Next Steps
+
+- [Fetch historical prices](/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices)
+- [Handle errors](/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors)
+- [API reference](/sdk/pricing-modules/pricing-coingecko-http/api-reference)

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices.mdx
@@ -1,0 +1,66 @@
+---
+title: Fetch Historical Prices
+description: Fetch historical price series with CoingeckoPricingClient.
+docType: how-to
+schemaType: TechArticle
+---
+
+Use `getHistoricalPrice(from, to, opts)` for chart data over a time range.
+
+## Fetch a Range
+
+Pass `start` and `end` as Unix timestamps in milliseconds:
+
+```javascript title="Fetch seven days of BTC/USD"
+const end = Date.now()
+const start = end - 7 * 24 * 60 * 60 * 1000
+
+const series = await client.getHistoricalPrice('BTC', 'USD', {
+  start,
+  end
+})
+
+console.log(series)
+```
+
+Each point has a `price` and `timestamp`:
+
+```typescript
+type HistoricalPriceResult = {
+  price: number
+  timestamp: number
+}
+```
+
+Results are ordered oldest first.
+
+## Downsample Long Series
+
+Use `maxEntries` when you only need a fixed number of points for a chart:
+
+```javascript title="Downsample to 100 points"
+const series = await client.getHistoricalPrice('BTC', 'USD', {
+  start,
+  end,
+  maxEntries: 100
+})
+```
+
+The client keeps the first and last point and samples the middle of the series evenly.
+
+## Free and Pro Ranges
+
+CoinGecko's public and Demo API host supports historical data inside the trailing 365-day window. For older ranges, configure the Pro host and a Pro key:
+
+```javascript title="Older historical range with Pro"
+const client = new CoingeckoPricingClient({
+  baseURL: 'https://pro-api.coingecko.com/api/v3',
+  apiKey: process.env.COINGECKO_PRO_API_KEY
+})
+```
+
+## Next Steps
+
+- [Configure the client](/sdk/pricing-modules/pricing-coingecko-http/configuration)
+- [Handle errors](/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors)
+- [API reference](/sdk/pricing-modules/pricing-coingecko-http/api-reference)

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/get-started.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/get-started.mdx
@@ -1,0 +1,67 @@
+---
+title: Get Started
+description: Install @tetherto/wdk-pricing-coingecko-http and create a CoinGecko pricing client.
+docType: tutorial
+schemaType: TechArticle
+---
+
+This guide covers installing the package, creating a `CoingeckoPricingClient`, and making a first current-price request.
+
+## Installation
+
+```bash title="Install with npm"
+npm install @tetherto/wdk-pricing-coingecko-http
+```
+
+Install the shared provider package when you want caching or failover:
+
+```bash title="Install with PricingProvider"
+npm install @tetherto/wdk-pricing-coingecko-http @tetherto/wdk-pricing-provider
+```
+
+## Create a Client
+
+```javascript title="Create a public CoinGecko client"
+import { CoingeckoPricingClient } from '@tetherto/wdk-pricing-coingecko-http'
+
+const client = new CoingeckoPricingClient()
+```
+
+The no-options constructor uses CoinGecko's public API host.
+
+## Fetch a Price
+
+```javascript title="Fetch BTC/USD"
+const btcUsd = await client.getCurrentPrice('BTC', 'USD')
+
+if (btcUsd === null) {
+  console.log('BTC/USD is unavailable from CoinGecko')
+} else {
+  console.log('BTC/USD:', btcUsd)
+}
+```
+
+`BTC` is resolved to the CoinGecko ID `bitcoin`, and `USD` is sent as `usd`.
+
+## Add an API Key
+
+```javascript title="Use a Demo API key"
+const client = new CoingeckoPricingClient({
+  apiKey: process.env.COINGECKO_API_KEY
+})
+```
+
+For CoinGecko Pro, set the Pro base URL too:
+
+```javascript title="Use a Pro API key"
+const client = new CoingeckoPricingClient({
+  baseURL: 'https://pro-api.coingecko.com/api/v3',
+  apiKey: process.env.COINGECKO_PRO_API_KEY
+})
+```
+
+## Next Steps
+
+- [Fetch current prices](/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices)
+- [Fetch historical prices](/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices)
+- [Configure symbols and API keys](/sdk/pricing-modules/pricing-coingecko-http/configuration)

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors.mdx
@@ -1,0 +1,84 @@
+---
+title: Handle Errors
+description: Handle unavailable pairs, unknown symbols, range limits, and CoinGecko rate limits.
+docType: how-to
+schemaType: TechArticle
+---
+
+This guide covers the main error and unavailable-data cases from `CoingeckoPricingClient`.
+
+## Unknown Symbols
+
+The client throws when `from` is not in its `coinIds` map:
+
+```javascript title="Add missing symbols"
+const client = new CoingeckoPricingClient({
+  coinIds: {
+    PEPE: 'pepe'
+  }
+})
+```
+
+Handle the error if symbols come from user input:
+
+```javascript title="Catch unknown symbols"
+try {
+  const price = await client.getCurrentPrice(userSymbol, 'USD')
+  console.log(price)
+} catch (error) {
+  if (error.message.includes('Unknown symbol')) {
+    console.log('Add this symbol to coinIds before requesting it.')
+  }
+}
+```
+
+## Unavailable Pairs
+
+Current-price methods resolve to `null` when CoinGecko returns no data for a pair:
+
+```javascript title="Handle null prices"
+const price = await client.getCurrentPrice('BTC', 'USD')
+
+if (price === null) {
+  console.log('Price unavailable')
+}
+```
+
+Batch methods preserve input order and place `null` only at unavailable entries.
+
+## Historical Range Limits
+
+`getHistoricalPrice()` requires both `start` and `end`:
+
+```javascript title="Required range"
+await client.getHistoricalPrice('BTC', 'USD', {
+  start,
+  end
+})
+```
+
+On the public or Demo API host, a `start` value older than the trailing 365 days throws. Use CoinGecko Pro for older ranges.
+
+## Rate Limits and Network Errors
+
+CoinGecko rate-limit and network failures reject with the underlying HTTP client error. Handle those failures separately from `null` results:
+
+```javascript title="Separate unavailable data from request failures"
+try {
+  const price = await client.getCurrentPrice('BTC', 'USD')
+
+  if (price === null) {
+    console.log('Pair unavailable')
+  }
+} catch (error) {
+  console.error('CoinGecko request failed:', error.message)
+}
+```
+
+When using `PricingProvider` with multiple clients, connection errors can trigger failover to the next client in the ordered list. A `null` result means the client completed the request but did not resolve that pair.
+
+## Next Steps
+
+- [Fetch current prices](/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices)
+- [Fetch historical prices](/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices)
+- [Configuration](/sdk/pricing-modules/pricing-coingecko-http/configuration)

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/index.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/index.mdx
@@ -1,0 +1,73 @@
+---
+title: Pricing CoinGecko HTTP Overview
+description: Overview of the @tetherto/wdk-pricing-coingecko-http module
+docType: explanation
+schemaType: TechArticle
+---
+
+The `@tetherto/wdk-pricing-coingecko-http` module provides a CoinGecko-backed `PricingClient` for current prices, batched price lookups, price data with 24-hour change, and historical price series.
+
+Use it when you want a CoinGecko data source for WDK price displays, balance valuation, charts, or as a fallback client behind [`PricingProvider`](/tools/price-rates/api-reference#class-pricingprovider).
+
+<Callout type="info">
+This module is published as `v1.0.0-beta.1`. It uses CoinGecko's HTTP API and is subject to CoinGecko rate limits, data availability, and API-key tier behavior.
+</Callout>
+
+## Features
+
+- **Current prices**: Fetch one asset/currency pair with `getCurrentPrice()`
+- **Batch prices**: Fetch multiple pairs in one request with `getMultiCurrentPrices()`
+- **Price data**: Fetch last price plus derived 24-hour change with `getMultiPriceData()`
+- **Historical series**: Fetch range-based price points with optional downsampling
+- **Coin ID mapping**: Extend or override ticker-to-CoinGecko ID mappings per client
+- **API key support**: Use Demo or Pro CoinGecko API keys with automatic auth-header selection
+- **Bare runtime entrypoint**: Import through the package's `bare` export in Bare environments
+
+## Default Assets
+
+The built-in ticker map covers:
+
+| Symbol | CoinGecko ID |
+|--------|--------------|
+| `BTC` | `bitcoin` |
+| `ETH` | `ethereum` |
+| `USDT` | `tether` |
+| `XAUT` | `tether-gold` |
+| `USAT` | `usa` |
+
+Add other assets through the `coinIds` constructor option.
+
+## Provider Integration
+
+`CoingeckoPricingClient` extends the shared `PricingClient` base class from `@tetherto/wdk-pricing-provider`. You can pass it directly to `PricingProvider`:
+
+```javascript title="Use with PricingProvider"
+import { PricingProvider } from '@tetherto/wdk-pricing-provider'
+import { CoingeckoPricingClient } from '@tetherto/wdk-pricing-coingecko-http'
+
+const provider = new PricingProvider({
+  client: new CoingeckoPricingClient()
+})
+
+const btcUsd = await provider.getLastPrice('BTC', 'USD')
+```
+
+## Next Steps
+
+<Cards>
+<Card title="Usage" href="/sdk/pricing-modules/pricing-coingecko-http/usage">
+Install the module and follow the task guides.
+</Card>
+<Card title="Configuration" href="/sdk/pricing-modules/pricing-coingecko-http/configuration">
+Configure API keys, Pro host access, and custom coin IDs.
+</Card>
+<Card title="API Reference" href="/sdk/pricing-modules/pricing-coingecko-http/api-reference">
+Review constructor options, methods, return values, and errors.
+</Card>
+</Cards>
+
+***
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/sdk/pricing-modules/pricing-coingecko-http/usage.mdx
+++ b/content/docs/sdk/pricing-modules/pricing-coingecko-http/usage.mdx
@@ -1,0 +1,37 @@
+---
+title: Pricing CoinGecko HTTP Guides
+description: Install and use @tetherto/wdk-pricing-coingecko-http for current and historical prices.
+docType: how-to
+schemaType: TechArticle
+icon: BookOpen
+---
+
+# Usage
+
+The `@tetherto/wdk-pricing-coingecko-http` module exposes a CoinGecko-backed pricing client for spot prices, batched price data, and historical series.
+
+<Cards>
+<Card title="Get Started" href="/sdk/pricing-modules/pricing-coingecko-http/guides/get-started">
+Install the package and create a CoinGecko pricing client.
+</Card>
+<Card title="Fetch Current Prices" href="/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices">
+Fetch one pair, batch multiple pairs, and wrap the client with PricingProvider.
+</Card>
+<Card title="Fetch Historical Prices" href="/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices">
+Read historical price points and downsample chart data.
+</Card>
+<Card title="Handle Errors" href="/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors">
+Handle unknown symbols, unavailable pairs, old free-tier ranges, and rate limits.
+</Card>
+</Cards>
+
+<Cards>
+<Card title="Configuration" href="/sdk/pricing-modules/pricing-coingecko-http/configuration">
+Configure API hosts, API keys, and symbol mappings.
+</Card>
+<Card title="API Reference" href="/sdk/pricing-modules/pricing-coingecko-http/api-reference">
+Review method signatures and return values.
+</Card>
+</Cards>
+
+<SupportCards />

--- a/content/docs/tools/price-rates/api-reference.mdx
+++ b/content/docs/tools/price-rates/api-reference.mdx
@@ -155,6 +155,7 @@ Implement this interface to plug your data source into `PricingProvider`.
 
 - Uses Bitfinex Public HTTP API (`/v2/calc/fx/batch`, `/v2/tickers`, and `/v2/candles`) under the hood for the Bitfinex client
 - Current-price lookups can pivot through USD for fiat pairs Bitfinex does not quote directly; historical prices and `getMultiPriceData()` do not use that pivot
+- Use [`@tetherto/wdk-pricing-coingecko-http`](/sdk/pricing-modules/pricing-coingecko-http/) when you need a CoinGecko-backed `PricingClient`
 - Provider caches last price per pair using in-memory store and TTL
 
 ***

--- a/content/docs/tools/price-rates/configuration.mdx
+++ b/content/docs/tools/price-rates/configuration.mdx
@@ -98,6 +98,22 @@ const provider = new PricingProvider({
 const last = await provider.getLastPrice('BTC', 'USD')
 ```
 
+Use [`@tetherto/wdk-pricing-coingecko-http`](/sdk/pricing-modules/pricing-coingecko-http/) as another `PricingClient` when you want CoinGecko as a fallback or primary data source:
+
+```javascript title="CoinGecko fallback client"
+import { PricingProvider } from '@tetherto/wdk-pricing-provider'
+import { BitfinexPricingClient } from '@tetherto/wdk-pricing-bitfinex-http'
+import { CoingeckoPricingClient } from '@tetherto/wdk-pricing-coingecko-http'
+
+const provider = new PricingProvider({
+  client: [
+    new BitfinexPricingClient(),
+    new CoingeckoPricingClient({ apiKey: process.env.COINGECKO_API_KEY })
+  ],
+  retries: 1
+})
+```
+
 ***
 
 ## Need Help?

--- a/content/docs/tools/price-rates/index.mdx
+++ b/content/docs/tools/price-rates/index.mdx
@@ -7,7 +7,7 @@ schemaType: TechArticle
 
 Pricing utilities for WDK apps. Includes HTTP clients and providers to retrieve current and historical prices from supported services.
 
-Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/wdk-pricing-bitfinex-http) and compatible with [`@tetherto/wdk-pricing-provider`](https://github.com/tetherto/wdk-pricing-provider).
+Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/wdk-pricing-bitfinex-http), compatible with [`@tetherto/wdk-pricing-provider`](https://github.com/tetherto/wdk-pricing-provider), and usable with [`@tetherto/wdk-pricing-coingecko-http`](/sdk/pricing-modules/pricing-coingecko-http/) as a CoinGecko fallback client.
 
 ## Features
 
@@ -15,6 +15,7 @@ Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/w
 - **Fiat Fallback**: Resolve fiat pairs Bitfinex does not quote directly by pivoting through USD when current FX data is available
 - **Historical Series**: Retrieve historical price series; long histories optionally downscaled to ≤ 100 points
 - **Provider Compatibility**: Works with `@tetherto/wdk-pricing-provider`
+- **CoinGecko Fallback**: Use `@tetherto/wdk-pricing-coingecko-http` when you want a CoinGecko-backed pricing client
 - **Lightweight HTTP Client**: Minimal dependencies; easy to integrate
 
 ## Why this matters
@@ -29,6 +30,9 @@ Get started with WDK price clients
 </Card>
 <Card title="Price Rates API" href="/tools/price-rates/api-reference">
 Check the API Reference and examples
+</Card>
+<Card title="CoinGecko HTTP" href="/sdk/pricing-modules/pricing-coingecko-http/">
+Use CoinGecko for current prices and historical series
 </Card>
 </Cards>
 

--- a/scripts/check-redirects.mjs
+++ b/scripts/check-redirects.mjs
@@ -22,6 +22,7 @@ const moduleRedirects = [
   ['/sdk/swap-velora-evm', '/sdk/swap-modules/swap-velora-evm'],
   ['/sdk/bridge-usdt0-evm', '/sdk/bridge-modules/bridge-usdt0-evm'],
   ['/sdk/lending-aave-evm', '/sdk/lending-modules/lending-aave-evm'],
+  ['/sdk/pricing-coingecko-http', '/sdk/pricing-modules/pricing-coingecko-http'],
   ['/sdk/fiat-moonpay', '/sdk/fiat-modules/fiat-moonpay'],
 ].map(([source, target]) => ({ source, target }));
 

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -302,6 +302,36 @@ export const customTree: Node[] = [
     ],
   },
   {
+    name: 'Pricing Modules',
+    type: 'folder',
+    icon: resolveIcon('TrendingUp'),
+    index: {
+      name: 'Pricing Modules',
+      url: '/sdk/pricing-modules',
+      type: 'page',
+    },
+    children: [
+      {
+        name: 'pricing-coingecko-http', type: 'folder',
+        index: { name: 'pricing-coingecko-http', url: '/sdk/pricing-modules/pricing-coingecko-http', type: 'page' },
+        children: [
+          { name: 'Usage', url: '/sdk/pricing-modules/pricing-coingecko-http/usage', type: 'page' },
+          {
+            name: 'Guides', type: 'folder', icon: resolveIcon('BookOpen'),
+            children: [
+              { name: 'Get Started', url: '/sdk/pricing-modules/pricing-coingecko-http/guides/get-started', type: 'page' },
+              { name: 'Fetch Current Prices', url: '/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices', type: 'page' },
+              { name: 'Fetch Historical Prices', url: '/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices', type: 'page' },
+              { name: 'Handle Errors', url: '/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors', type: 'page' },
+            ],
+          },
+          { name: 'Configuration', url: '/sdk/pricing-modules/pricing-coingecko-http/configuration', type: 'page' },
+          { name: 'API Reference', url: '/sdk/pricing-modules/pricing-coingecko-http/api-reference', type: 'page' },
+        ],
+      },
+    ],
+  },
+  {
     name: 'Swap Modules',
     type: 'folder',
     icon: resolveIcon('ArrowLeftRight'),


### PR DESCRIPTION
## Summary
- Add a new SDK pricing module section for `@tetherto/wdk-pricing-coingecko-http`.
- Document CoinGecko client setup, API keys, custom coin IDs, current prices, price data, historical prices, error handling, and `PricingProvider` integration.
- Wire the module into SDK navigation, all modules, legacy redirects, redirect validation, Price Rates docs, and the changelog.

## Source context
- Source repo: `tetherto/wdk-pricing-coingecko-http`.
- Release state: `v1.0.0-beta.1` is published on GitHub and npm, with npm `latest` set to `1.0.0-beta.1`.
- Source PRs checked: implementation PR `#1` and publish-prep PR `#6` are merged.
- Public surface: `CoingeckoPricingClient` extends `PricingClient` and exposes `getCurrentPrice()`, `getMultiCurrentPrices()`, `getMultiPriceData()`, and `getHistoricalPrice()`.

## Validation
- `git diff --cached --check`
- `npm run check:meta`
- `npm run check:redirects`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run build`

## Notes
- The production build passes with Node 22. The local default Node 25 hits a Next.js require-hook error, so validation used the repo-compatible Node 22 toolchain.
