### PR TITLE
docs: update WDK release docs for June releases

### DIFF
--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -17,6 +17,28 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 19, 2026
+
+**What's New**
+- **wdk-utils** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.7)): Add passphrase-based seed encryption helpers with AES-256-GCM, scrypt key derivation, `encrypt()`, `decrypt()`, `deriveKey()`, `decryptWithKey()`, and persisted scrypt cost parameters on encrypted payloads.
+- **wallet-spark** ([v1.0.0-beta.20](https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.20)): Add the `enableLogging` wallet config option for Spark SDK logging, update the Spark SDK and Bare dependencies, and avoid creating duplicate Spark wallet instances during account setup.
+
+**Fixes**
+- **wallet-tron-gasfree** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-tron-gasfree/releases/tag/v1.0.0-beta.7)): Return `activationFee` alongside `fee` from gas-free transfer quotes and transfer results, so apps can show the activation portion separately when the GasFree account is not active yet.
+
+---
+
+### June 18, 2026
+
+**What's New**
+- **wdk-wallet** ([v1.0.0-beta.11](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.11)): Add the base `ISigner` interface, `SignerError`, default-signer construction, named signer registration, signer lookup helpers, and signer-aware account retrieval hooks for modules that support external signing.
+
+**Fixes**
+- **wdk-core** ([v1.0.0-beta.12](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.12)): Harden transaction policy enforcement by snapshotting governed method arguments once, evaluating policies against that snapshot, forwarding the same approved values to the wallet method, and failing closed with `PolicyConfigurationError` for non-cloneable governed arguments.
+- **wallet-solana** ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.10)): Align the Solana `keyPair` behavior and types so key arrays are documented as read-only views, while `keyPair.privateKey` still returns `null` after `dispose()` clears the internal private key.
+
+---
+
 ### June 14, 2026
 
 **What's New**

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -177,7 +177,7 @@ For policy scoping, default-deny behavior, account-level overrides, and protocol
 
 **Returns:** `WDK` - The WDK instance (supports method chaining)
 
-**Throws:** `PolicyConfigurationError` if a policy or option fails validation, if an account-scoped policy omits its account binding, or if a policy references a wallet identifier that has not been registered.
+**Throws:** `PolicyConfigurationError` if a policy or option fails validation, if an account-scoped policy omits its account binding, or if a policy references a wallet identifier that has not been registered. Governed write calls also throw `PolicyConfigurationError` when WDK cannot snapshot a method argument safely.
 
 **Example:**
 ```typescript title="Register A Send Policy"
@@ -239,6 +239,8 @@ try {
 Supported `PolicyOperation` values are `sendTransaction`, `signTransaction`, `transfer`, `approve`, `sign`, `signTypedData`, `signAuthorization`, `delegate`, `revokeDelegation`, `swap`, `bridge`, `supply`, `withdraw`, `borrow`, `repay`, `buy`, `sell`, `swidge`, and `*`.
 
 Use `sign` for message-style signing in this release. `signMessage` and `signHash` are not valid policy operation names.
+
+Policy-enforced calls snapshot method arguments before evaluation and forward the same approved values to the wallet method. Pass structured-cloneable values such as primitives, plain objects, arrays, `bigint`, and typed arrays. Non-cloneable governed arguments fail closed with `PolicyConfigurationError`.
 
 ##### `getAccount(blockchain, index?)`
 Returns a wallet account for a specific blockchain and index using BIP-44 derivation.

--- a/content/docs/sdk/core-module/guides/transaction-policies.mdx
+++ b/content/docs/sdk/core-module/guides/transaction-policies.mdx
@@ -172,6 +172,8 @@ Conditions receive a frozen `PolicyContext`:
 | `params` | The first argument passed to the wrapped method |
 | `args` | All arguments passed to the wrapped method |
 
+For governed write calls, WDK snapshots the method arguments once before policy evaluation. Conditions see that snapshot, and WDK forwards the same approved values to the underlying wallet method. This prevents a caller from mutating a transaction object while an asynchronous policy condition is running.
+
 Conditions can be synchronous or asynchronous. `conditionTimeoutMs` defaults to `30000` milliseconds and can be set through `registerPolicy(policies, options)`. If a `DENY` condition throws or times out, WDK blocks the call. If an `ALLOW` condition throws or times out, WDK treats that allow rule as unmatched.
 
 ## Simulate Before Execution
@@ -197,7 +199,7 @@ In this beta, `simulate` is added at runtime but is not typed on the account ret
 
 ## Handle Errors
 
-`PolicyConfigurationError` means WDK rejected the policy setup. Common causes include invalid scopes, actions, operation names, condition functions, timeout options, missing account bindings, or wallet identifiers that have not been registered.
+`PolicyConfigurationError` means WDK rejected the policy setup or could not safely evaluate a governed call. Common causes include invalid scopes, actions, operation names, condition functions, timeout options, missing account bindings, wallet identifiers that have not been registered, or governed method arguments that are not structured-cloneable.
 
 `PolicyViolationError` means an enforced write call was blocked by a matching `DENY` rule or by default-deny when no `ALLOW` rule matched. Catch it around the write call and surface the `reason` to the user or approval workflow.
 
@@ -206,6 +208,7 @@ In this beta, `simulate` is added at runtime but is not typed on the account ret
 - Policies wrap the WDK account/protocol proxy surface. Private fields, underscore methods, protocol internals, or nested calls made inside a module can bypass local policy evaluation.
 - Quote and read methods are not wrapped. Policies apply to write methods such as sends, signs, swaps, bridges, lending writes, fiat writes, and swidge execution.
 - Wallet accounts must expose a read-only account view when a policy applies, otherwise `getAccount()` fails with `PolicyConfigurationError`.
+- Governed write-call arguments must be structured-cloneable, such as primitives, plain objects, arrays, `bigint`, and typed arrays. Functions, live class instances, and other non-cloneable values fail closed with `PolicyConfigurationError` instead of being forwarded unsafely.
 - Avoid relying on engine-managed durable policy state in this beta. Use explicit application state or closures for local checks that need state.
 
 ## Next Steps

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -16,6 +16,22 @@ Wallet modules can expose fee caps through their configuration objects. Use the 
 | `transferMaxFee` | `transfer()` | Caps token transfer fees in the module's base fee unit. |
 | `transactionMaxFee` | `sendTransaction()` and `signTransaction()` | Caps native transaction send/sign flows separately from token transfers when the module supports that base wallet option. |
 
+## Shared Signer Interface
+
+The base `@tetherto/wdk-wallet` package defines a cross-chain `ISigner` interface for wallet modules that support external signing. Signer-aware modules can be constructed from a default signer instead of a seed, can register named signers with `addSigner(name, signer)`, and can resolve accounts by passing `signerName` to account retrieval methods.
+
+| Surface | Description |
+| --- | --- |
+| `ISigner.derive(relPath)` | Derives a child signer from a relative derivation path, when the signer supports derivation. |
+| `ISigner.signTransaction(tx)` | Signs a chain-specific transaction without broadcasting it. |
+| `ISigner.getAddress()` | Returns the address controlled by the signer. |
+| `ISigner.dispose()` | Clears signer-held secret material or external resources. |
+| `WalletManager.addSigner(name, signer)` | Registers a named signer. Blank names throw an error. |
+| `WalletManager.getSigner(name?)` | Returns a named signer, or the default signer when called without a name. |
+| `WalletManager.getSigners()` | Returns a shallow copy of the named signer map. |
+
+Module support depends on the chain-specific wallet implementation. Check each module's reference before relying on signer-based account creation.
+
 ## Supported Networks
 
 This package works with multiple blockchain networks through wallet registration.

--- a/content/docs/sdk/wallet-modules/wallet-solana/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/api-reference.mdx
@@ -360,9 +360,9 @@ account.dispose()
 |----------|------|-------------|
 | `index` | `number` | The derivation path's index of this account |
 | `path` | `string` | The full derivation path of this account |
-| `keyPair` | `{publicKey: Uint8Array, privateKey: Uint8Array \| null}` | The account's Ed25519 key pair. `privateKey` is `null` after `dispose()` is called. |
+| `keyPair` | `{publicKey: Uint8Array, privateKey: Uint8Array \| null}` | The account's Ed25519 key pair. The returned arrays are bound to the account and should be treated as read-only. `privateKey` is `null` after `dispose()` is called. |
 
-⚠️ **Security Note**: The `keyPair` property contains sensitive cryptographic material. Never log, display, or expose the private key.
+⚠️ **Security Note**: The `keyPair` property contains sensitive cryptographic material. Never log, display, mutate, or expose the private key.
 
 ### WalletAccountReadOnlySolana
 
@@ -527,7 +527,7 @@ interface TransferOptions {
 ```typescript
 interface KeyPair {
   publicKey: Uint8Array
-  privateKey: Uint8Array
+  privateKey: Uint8Array | null
 }
 ```
 

--- a/content/docs/sdk/wallet-modules/wallet-spark/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/api-reference.mdx
@@ -30,6 +30,7 @@ new WalletManagerSpark(seed, config)
   - `network` (string, optional): 'MAINNET', 'SIGNET', or 'REGTEST' (default: 'MAINNET')
   - `sparkscan` (`SparkScanConfig`, optional): SparkScan configuration for balance polling
   - `syncAndRetry` (boolean, optional): When true, failed sends and Lightning payments sync wallet state and retry once
+  - `enableLogging` (boolean, optional): When true, forwards logging to the underlying Spark SDK (default: false)
 
 ### Methods
 

--- a/content/docs/sdk/wallet-modules/wallet-spark/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/configuration.mdx
@@ -16,7 +16,8 @@ const config = {
   sparkscan: {
     apiKey: 'your-api-key-here'
   },
-  syncAndRetry: true
+  syncAndRetry: true,
+  enableLogging: false
 }
 
 const wallet = new WalletManagerSpark(seedPhrase, config)
@@ -93,6 +94,22 @@ const config = {
 
 You can also call [`syncWalletBalance()`](/sdk/wallet-modules/wallet-spark/api-reference) directly when you want to reconcile wallet state before retrying an operation.
 
+### Spark SDK Logging
+
+The `enableLogging` option forwards logging to the underlying Spark SDK.
+
+**Type:** `boolean` (optional)
+
+**Default:** `false`
+
+**Example:**
+```javascript
+const config = {
+  network: 'REGTEST',
+  enableLogging: true
+}
+```
+
 ## Network Configuration
 
 The wallet can be configured for different Spark networks:
@@ -138,7 +155,8 @@ const wallet = new WalletManagerSpark(seedPhrase, {
   sparkscan: {
     apiKey: 'your-api-key-here'
   },
-  syncAndRetry: true
+  syncAndRetry: true,
+  enableLogging: false
 })
 
 // Get accounts (no additional configuration needed)

--- a/content/docs/sdk/wallet-modules/wallet-spark/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-spark/index.mdx
@@ -16,6 +16,7 @@ A simple and secure package to manage BIP-32 wallets for the Spark blockchain. T
 - **Spark Invoices**: Create and pay Spark invoices for receiving sats and tokens directly on the Spark network
 - **SparkScan Balance Polling**: Use SparkScan-backed balance polling in [`getBalance()`](/sdk/wallet-modules/wallet-spark/api-reference) when `sparkscan` is configured
 - **Sync and Retry**: Optionally sync wallet state and retry failed [`sendTransaction()`](/sdk/wallet-modules/wallet-spark/api-reference) and [`payLightningInvoice()`](/sdk/wallet-modules/wallet-spark/api-reference) calls once
+- **Spark SDK Logging**: Enable Spark SDK logs with the `enableLogging` configuration option when debugging wallet setup or runtime behavior
 - **Token Transfers**: Transfer tokens to other Spark addresses
 - **Bitcoin Layer 1 Bridge**: Deposit and withdraw Bitcoin between layer 1 and Spark
 - **Static Deposit Addresses**: Reusable deposit addresses for Bitcoin layer 1 deposits

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/api-reference.mdx
@@ -129,8 +129,8 @@ new WalletAccountTronGasfree(seed, path, config)
 | `getAddress()` | Returns the account's address | `Promise\<string\>` |
 | `getBalance()` | Returns the native TRX balance (in sun) | `Promise\<bigint\>` |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific TRC20 token | `Promise\<bigint\>` |
-| `transfer(options)` | Transfers TRC20 tokens to another address | `Promise\<{hash: string, fee: bigint}\>` |
-| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` |
+| `transfer(options)` | Transfers TRC20 tokens to another address | `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` |
+| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint, activationFee: bigint}\>` |
 | `sign(message)` | Signs a message using the account's private key | `Promise\<string\>` |
 | `signTransaction(tx)` | Unsupported on Tron GasFree; always throws | `Promise\<never\>` |
 | `sendTransaction(tx)` | Unsupported on Tron GasFree; always throws | `Promise\<TransactionResult\>` |
@@ -183,7 +183,7 @@ Transfers TRC20 tokens to another address using the gas-free service.
   - `recipient` (string): Recipient's Tron address
   - `amount` (number): Amount in token base units
 
-**Returns:** `Promise\<{hash: string, fee: bigint}\>` - Object containing transaction hash and fee paid in token base units. The returned fee includes the estimated transfer fee plus any activation fee returned by the GasFree service.
+**Returns:** `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` - Object containing transaction hash, total fee paid in token base units, and the activation-fee portion. `activationFee` is `0n` when no account activation fee applies.
 
 **Example:**
 ```javascript
@@ -194,6 +194,7 @@ const result = await account.transfer({
 })
 console.log('Transaction hash:', result.hash)
 console.log('Fee paid:', result.fee, 'token base units')
+console.log('Activation fee:', result.activationFee, 'token base units')
 ```
 
 ##### `quoteTransfer(options)`
@@ -202,7 +203,7 @@ Estimates the fee for a TRC20 token transfer.
 **Parameters:**
 - `options` (TransferOptions): Transfer options (same as transfer method)
 
-**Returns:** `Promise\<{fee: bigint}\>` - Estimated fee in token base units. The estimate includes the token's transfer fee and, when the GasFree account is inactive, the token activation fee.
+**Returns:** `Promise\<{fee: bigint, activationFee: bigint}\>` - Estimated total fee in token base units, plus the activation-fee portion. `activationFee` is `0n` when no account activation fee applies.
 
 **Example:**
 ```javascript
@@ -212,6 +213,7 @@ const quote = await account.quoteTransfer({
   amount: 1000000
 })
 console.log('Estimated fee:', quote.fee, 'token base units')
+console.log('Activation fee:', quote.activationFee, 'token base units')
 ```
 
 ##### `sign(message)`
@@ -303,7 +305,7 @@ new WalletAccountReadOnlyTronGasfree(address, config)
 | `getAddress()` | Returns the account's address | `Promise\<string\>` |
 | `getBalance()` | Returns the native TRX balance (in sun) | `Promise\<bigint\>` |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific TRC20 token | `Promise\<bigint\>` |
-| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` |
+| `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint, activationFee: bigint}\>` |
 | `quoteSendTransaction(tx)` | Unsupported on Tron GasFree; always throws | `Promise\<Omit\<TransactionResult, 'hash'\>\>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` |
 
@@ -352,7 +354,7 @@ Estimates the fee for a TRC20 token transfer without requiring private keys.
   - `recipient` (string): Recipient's Tron address
   - `amount` (number): Amount in token base units
 
-**Returns:** `Promise\<{fee: bigint}\>` - Estimated fee in token base units. The estimate includes the token's transfer fee and, when the GasFree account is inactive, the token activation fee.
+**Returns:** `Promise\<{fee: bigint, activationFee: bigint}\>` - Estimated total fee in token base units, plus the activation-fee portion. `activationFee` is `0n` when no account activation fee applies.
 
 **Example:**
 ```javascript
@@ -362,6 +364,7 @@ const quote = await readOnlyAccount.quoteTransfer({
   amount: 1000000
 })
 console.log('Estimated fee:', quote.fee, 'token base units')
+console.log('Activation fee:', quote.activationFee, 'token base units')
 ```
 
 ##### `quoteSendTransaction(tx)`

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/send-transactions.mdx
@@ -28,9 +28,10 @@ const quote = await account.quoteTransfer({
   amount: 1000000
 })
 console.log('Gas-free transfer fee estimate:', quote.fee, 'token units')
+console.log('Activation fee estimate:', quote.activationFee, 'token units')
 ```
 
-The fee estimate includes the token transfer fee and, when the GasFree account is inactive, the token activation fee returned by the provider.
+The fee estimate includes the token transfer fee and, when the GasFree account is inactive, the token activation fee returned by the provider. The activation portion is exposed separately as `activationFee`.
 
 ## Next Steps
 

--- a/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens.mdx
@@ -19,9 +19,10 @@ const transferResult = await account.transfer({
 })
 console.log('Transfer hash:', transferResult.hash)
 console.log('Transfer fee:', transferResult.fee, 'token units')
+console.log('Activation fee:', transferResult.activationFee, 'token units')
 ```
 
-The returned `fee` includes the GasFree transfer fee and, when the GasFree account is not active yet, the token activation fee returned by the provider.
+The returned `fee` includes the GasFree transfer fee and, when the GasFree account is not active yet, the token activation fee returned by the provider. Use `activationFee` to show that activation portion separately; it is `0n` when no activation fee applies.
 
 ## Override Fee Limit
 
@@ -37,6 +38,7 @@ const result = await account.transfer({
 })
 console.log('Transfer hash:', result.hash)
 console.log('Transfer fee:', result.fee, 'token units')
+console.log('Activation fee:', result.activationFee, 'token units')
 ```
 
 ## Estimate Transfer Fees
@@ -50,9 +52,10 @@ const transferQuote = await account.quoteTransfer({
   amount: 1000000
 })
 console.log('Transfer fee estimate:', transferQuote.fee, 'token units')
+console.log('Activation fee estimate:', transferQuote.activationFee, 'token units')
 ```
 
-If the GasFree account is inactive, the quote includes the token's activation fee in addition to the transfer fee.
+If the GasFree account is inactive, the quote includes the token's activation fee in addition to the transfer fee and exposes that portion as `activationFee`.
 
 ## Transfer with Validation
 
@@ -83,6 +86,7 @@ async function transferWithValidation(account, tokenAddress, recipient, amount) 
     amount
   })
   console.log('Transfer fee estimate:', quote.fee, 'token units')
+  console.log('Activation fee estimate:', quote.activationFee, 'token units')
 
   const result = await account.transfer({
     token: tokenAddress,
@@ -91,6 +95,7 @@ async function transferWithValidation(account, tokenAddress, recipient, amount) 
   })
   console.log('Transfer completed:', result.hash)
   console.log('Fee paid:', result.fee, 'token units')
+  console.log('Activation fee paid:', result.activationFee, 'token units')
 
   return result
 }

--- a/content/docs/tools/wdk-utils/api-reference.mdx
+++ b/content/docs/tools/wdk-utils/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils API Reference
-description: Validation, BIP-21, BOLT11, and EIP-681 APIs for @tetherto/wdk-utils
+description: Validation, encryption, BIP-21, BOLT11, and EIP-681 APIs for @tetherto/wdk-utils
 docType: reference
 schemaType: APIReference
 ---
@@ -294,6 +294,71 @@ Resolve a valid UMA string into the local part, domain, and underlying Lightning
 import { resolveUmaUsername } from '@tetherto/wdk-utils'
 
 const result = resolveUmaUsername('$alice@wallet.com')
+```
+
+### Seed Encryption Helpers
+
+| Function | Description | Returns |
+| --- | --- | --- |
+| `encrypt(plaintext, password, scryptParams?)` | Encrypt a string with AES-256-GCM using a scrypt-derived key. | `EncryptedPayload` |
+| `decrypt(payload, password)` | Decrypt an encrypted payload with the passphrase used to create it. | `string` |
+| `deriveKey(password, salt, scryptParams?)` | Derive a 32-byte AES key from a passphrase and salt. | `Uint8Array` |
+| `decryptWithKey(payload, key)` | Decrypt an encrypted payload with a pre-derived 32-byte AES key. | `string` |
+| `DEFAULT_SCRYPT_PARAMS` | Default scrypt cost parameters. | `{ N: 65536, r: 8, p: 1 }` |
+
+#### `encrypt(plaintext, password, scryptParams?)`
+
+Encrypt a plaintext string with AES-256-GCM. The helper generates a random 32-byte salt and 12-byte initialization vector, derives a 32-byte key with scrypt, and returns a versioned payload with hex-encoded binary fields.
+
+```javascript title="Encrypt A Seed Phrase"
+import { encrypt } from '@tetherto/wdk-utils'
+
+const encrypted = encrypt(seedPhrase, passphrase)
+```
+
+`EncryptedPayload` contains:
+
+- `version: 1`
+- `salt: string`
+- `iv: string`
+- `tag: string`
+- `ciphertext: string`
+- `scryptN?: number`
+- `scryptR?: number`
+- `scryptP?: number`
+
+Pass optional scrypt cost parameters as `{ N, r, p }`. Defaults are `N: 65536`, `r: 8`, and `p: 1`.
+
+#### `decrypt(payload, password)`
+
+Decrypt a payload produced by `encrypt()`. The helper reads `scryptN`, `scryptR`, and `scryptP` from the payload when present, then clears the derived key from memory after decryption.
+
+```javascript title="Decrypt A Seed Phrase"
+import { decrypt } from '@tetherto/wdk-utils'
+
+const seedPhrase = decrypt(encrypted, passphrase)
+```
+
+`decrypt()` throws if the payload version is unsupported, the password is wrong, or the authentication tag does not verify.
+
+#### `deriveKey(password, salt, scryptParams?)`
+
+Derive a 32-byte AES key from a passphrase and salt. Use this when your app needs to manage the derived key explicitly before calling `decryptWithKey()`.
+
+```javascript title="Derive An Encryption Key"
+import { deriveKey } from '@tetherto/wdk-utils'
+
+const key = deriveKey(passphrase, saltBytes)
+```
+
+#### `decryptWithKey(payload, key)`
+
+Decrypt a payload with a pre-derived key. The key must be a 32-byte `Uint8Array`.
+
+```javascript title="Decrypt With A Pre-Derived Key"
+import { decryptWithKey } from '@tetherto/wdk-utils'
+
+const plaintext = decryptWithKey(encrypted, key)
 ```
 
 ### BIP-21 Bitcoin Payment URI Helpers

--- a/content/docs/tools/wdk-utils/configuration.mdx
+++ b/content/docs/tools/wdk-utils/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: WDK Utils Configuration
-description: Install and import validation, BIP-21, BOLT11, and EIP-681 helpers from @tetherto/wdk-utils
+description: Install and import validation, encryption, BIP-21, BOLT11, and EIP-681 helpers from @tetherto/wdk-utils
 ---
 
 This package does not have constructor options or runtime configuration. This page shows how to install `@tetherto/wdk-utils`, import the helpers you need, and understand the published runtime surface.
@@ -55,6 +55,19 @@ import {
 } from '@tetherto/wdk-utils'
 ```
 
+## Import seed encryption helpers
+
+You can encrypt and decrypt seed phrases or other local strings with the AES-256-GCM helpers:
+
+```javascript title="Import Seed Encryption Helpers"
+import {
+  decrypt,
+  decryptWithKey,
+  deriveKey,
+  encrypt
+} from '@tetherto/wdk-utils'
+```
+
 ## Import BOLT11 helpers
 
 You can validate, decode, sign, and encode BOLT11 Lightning invoices from the package entrypoint:
@@ -75,6 +88,9 @@ import {
 - The package publishes a default module entrypoint through `index.js` and a bare runtime entrypoint through `bare.js`.
 - `parseBip21Request()` accepts `bitcoin:` URIs with a validated Bitcoin address and optional `amount`, `label`, and `message` parameters.
 - `encodeBip21Request()` validates the Bitcoin address and amount before returning a `bitcoin:` URI.
+- `encrypt()` returns a versioned payload with hex-encoded `salt`, `iv`, `tag`, and `ciphertext` fields plus the scrypt cost parameters used for key derivation.
+- `decrypt()` reads the scrypt cost parameters from the encrypted payload when they are present.
+- `deriveKey()` returns a 32-byte `Uint8Array` key, and `decryptWithKey()` can reuse that key for decrypting a payload.
 - BIP-21 amounts are decimal BTC strings with up to eight decimal places and a maximum value of `21000000`.
 - BOLT11 helpers support invoices for `bitcoin`, `testnet`, `regtest`, and `signet` networks.
 - `decode()` returns user-provided invoice descriptions when they are present. Sanitize descriptions before rendering them in HTML or storing them.
@@ -134,6 +150,15 @@ import { parseEip681Request } from '@tetherto/wdk-utils'
 const request = parseEip681Request(
   'pol:0xc2132D05D31c914a87C6611C10748AEb04B58e8F@137/transfer?address=0xA9e338082A061d657014c08e652D96B38639F22a&uint256=0.175309000e6'
 )
+```
+
+You can protect a seed phrase with a passphrase before storing it in local app state:
+
+```javascript title="Encrypt A Seed Phrase"
+import { decrypt, encrypt } from '@tetherto/wdk-utils'
+
+const encrypted = encrypt(seedPhrase, passphrase)
+const restoredSeedPhrase = decrypt(encrypted, passphrase)
 ```
 
 ***

--- a/content/docs/tools/wdk-utils/index.mdx
+++ b/content/docs/tools/wdk-utils/index.mdx
@@ -1,14 +1,15 @@
 ---
 title: WDK Utils
-description: Address validation, BIP-21, BOLT11 invoice, and EIP-681 request helpers for @tetherto/wdk-utils
+description: Address validation, seed encryption, BIP-21, BOLT11 invoice, and EIP-681 request helpers for @tetherto/wdk-utils
 ---
 
-WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, BIP-21 Bitcoin payment URI helpers, BOLT11 invoice helpers, and EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, and UMA identifiers, passphrase-based seed encryption helpers, BIP-21 Bitcoin payment URI helpers, BOLT11 invoice helpers, and EIP-681 request parsing helpers for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
 
 ## Features
 
 - **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Spark, Tron, and UMA inputs before you hand them to a wallet flow.
 - **BIP-21 payment URI helpers**: Detect, parse, and encode `bitcoin:` payment URIs with optional amount, label, and message fields.
+- **Seed encryption helpers**: Encrypt and decrypt seed phrases or other strings with AES-256-GCM and scrypt-derived keys.
 - **Lightning payment parsing**: Decode LNURL strings and BOLT11 invoices before you display or route payment details.
 - **BOLT11 invoice helpers**: Validate, decode, hash, sign, and encode BOLT11 invoices for Bitcoin, testnet, regtest, and signet flows.
 - **EIP-681 request parsing**: Detect request-shaped EIP-681 strings and parse transfer payloads into `recipient`, `tokenAddress`, `chainId`, and `amountSmallest`.
@@ -19,6 +20,7 @@ WDK Utils provides validation helpers for Bitcoin, EVM, Lightning, Spark, Tron, 
 ## Why this matters
 
 - Validate user input early and return machine-readable failure reasons before you attempt a transaction or resolution flow.
+- Protect seed phrases or other local strings with passphrase-based encryption before storing them in app-managed persistence.
 - Parse and encode BIP-21 Bitcoin payment links before pre-filling send forms.
 - Inspect BOLT11 invoice metadata, fallback addresses, routing information, and feature bits before presenting payment details.
 - Normalize EIP-681 payment links into structured transfer data that wallet UIs can inspect before execution.


### PR DESCRIPTION
## Summary
- Update the changelog for the June 18-19 WDK package releases.
- Document the new signer interface, policy argument snapshot behavior, seed encryption helpers, Spark `enableLogging`, Tron GasFree `activationFee`, and Solana `keyPair.privateKey` nullability.

## Release Coverage
- wdk-core v1.0.0-beta.12: https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.12
- wdk-wallet v1.0.0-beta.11: https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.11
- wallet-solana v1.0.0-beta.10: https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.10
- wallet-spark v1.0.0-beta.20: https://github.com/tetherto/wdk-wallet-spark/releases/tag/v1.0.0-beta.20
- wallet-tron-gasfree v1.0.0-beta.7: https://github.com/tetherto/wdk-wallet-tron-gasfree/releases/tag/v1.0.0-beta.7
- wdk-utils v1.0.0-beta.7: https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.7

## Validation
- `git diff --check`
- `npm run check:meta`
- `npm run check:redirects`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `npm run build`