### PR TITLE
docs: use Candide unified chain-ID endpoints

### DIFF
--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/api-reference.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/api-reference.mdx
@@ -389,9 +389,9 @@ async function gaslessBridge() {
   const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
     chainId: 42161,
     provider: 'https://arb1.arbitrum.io/rpc',
-    bundlerUrl: 'https://api.candide.dev/public/v3/arbitrum',
+    bundlerUrl: 'https://api.candide.dev/public/v3/42161',
     safeModulesVersion: '0.3.0',
-    paymasterUrl: 'https://api.candide.dev/public/v3/arbitrum',
+    paymasterUrl: 'https://api.candide.dev/public/v3/42161',
     paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
     paymasterToken: { address: '0x...' } // Paymaster token configuration
   })

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.mdx
@@ -22,9 +22,9 @@ const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon aban
 const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   chainId: 42161,
   provider: 'https://arb1.arbitrum.io/rpc',
-  bundlerUrl: 'https://api.candide.dev/public/v3/arbitrum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/42161',
   safeModulesVersion: '0.3.0',
-  paymasterUrl: 'https://api.candide.dev/public/v3/arbitrum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/42161',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: { address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9' }
 })

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
@@ -127,20 +127,24 @@ const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
 
 When `paymasterAddress` is set, the account checks the paymaster address returned by the RPC response and throws `ConfigurationError` if it does not match.
 
-## Separate Paymaster Endpoint
+## Using Candide
 
-Some providers use different bundler and paymaster URLs. Set `paymasterUrl` when the paymaster service is not available at `bundlerUrl`.
+Candide serves the bundler and paymaster from a single unified URL, so you only need `bundlerUrl` — the paymaster is reached at the same endpoint. The chain is selected by its chain ID in the path. Use the public endpoint (rate-limited, no key required) or an authenticated endpoint with an API key from the [dashboard](https://dashboard.candide.dev):
 
-```javascript title="Separate paymaster endpoint"
+- Public: `https://api.candide.dev/public/v3/{chainId}`
+- Authenticated: `https://api.candide.dev/api/v3/{chainId}/{apiKey}`
+
+```javascript title="Using Candide"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
   delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
-  bundlerUrl: 'https://api.candide.dev/bundler/v3/1/YOUR_KEY',
-  paymasterUrl: 'https://api.candide.dev/paymaster/v3/1/YOUR_KEY',
+  bundlerUrl: 'https://api.candide.dev/api/v3/1/YOUR_API_KEY',
   isSponsored: true,
   sponsorshipPolicyId: 'your_policy_id'
 })
 ```
+
+If a provider serves its paymaster from a different URL than the bundler, set `paymasterUrl` to that endpoint; otherwise it defaults to `bundlerUrl`.
 
 ## Per-call Overrides
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
@@ -60,10 +60,10 @@ Fees are paid using an ERC-20 token through a paymaster service.
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
   // Paymaster token mode
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USD₮
@@ -83,11 +83,11 @@ Fees are sponsored by a third party via a sponsorship policy.
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
   // Sponsorship mode
   isSponsored: true,
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   sponsorshipPolicyId: 'your-policy-id' // Optional
 })
 ```
@@ -102,7 +102,7 @@ Fees are paid using the chain's native token (e.g., ETH).
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
   // Native coins mode
   useNativeCoins: true,
@@ -245,9 +245,9 @@ new WalletAccountEvmErc4337(seed, path, config)
 const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -700,9 +700,9 @@ new WalletAccountReadOnlyEvmErc4337(address, config)
 const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
@@ -50,8 +50,8 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
   {
     chainId: 1,
     provider: 'https://rpc.mevblocker.io/fast',
-    bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-    paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+    bundlerUrl: 'https://api.candide.dev/public/v3/1',
+    paymasterUrl: 'https://api.candide.dev/public/v3/1',
     paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
     safeModulesVersion: '0.3.0',
     paymasterToken: {
@@ -150,7 +150,7 @@ The `bundlerUrl` option specifies the URL of the ERC-4337 bundler service that h
 **Example:**
 ```javascript
 const config = {
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum'
+  bundlerUrl: 'https://api.candide.dev/public/v3/1'
 }
 ```
 
@@ -164,7 +164,7 @@ The `paymasterUrl` option specifies the URL of the paymaster service that sponso
 **Example:**
 ```javascript
 const config = {
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum'
+  paymasterUrl: 'https://api.candide.dev/public/v3/1'
 }
 ```
 
@@ -274,7 +274,7 @@ Enables Sponsorship Policy mode, where a sponsor covers transaction fees.
 ```javascript
 const config = {
   isSponsored: true,
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum'
+  paymasterUrl: 'https://api.candide.dev/public/v3/1'
 }
 ```
 
@@ -338,8 +338,8 @@ The following tokens are supported for gas payments on Ethereum Mainnet:
 const ethereumConfig = {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
@@ -355,8 +355,8 @@ const ethereumConfig = {
 const polygonConfig = {
   chainId: 137,
   provider: 'https://polygon-rpc.com',
-  bundlerUrl: 'https://api.candide.dev/public/v3/polygon',
-  paymasterUrl: 'https://api.candide.dev/public/v3/polygon',
+  bundlerUrl: 'https://api.candide.dev/public/v3/137',
+  paymasterUrl: 'https://api.candide.dev/public/v3/137',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
@@ -58,8 +58,8 @@ import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-43
 const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started.mdx
@@ -28,8 +28,8 @@ const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon aban
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {

--- a/content/docs/start-building/react-native-quickstart.mdx
+++ b/content/docs/start-building/react-native-quickstart.mdx
@@ -239,8 +239,8 @@ export const wdkConfigs: WdkConfigs = {
       config: {
         chainId: 11155111, // Sepolia testnet
         provider: 'https://rpc.sepolia.org',
-        bundlerUrl: 'https://api.candide.dev/public/v3/sepolia',
-        paymasterUrl: 'https://api.candide.dev/public/v3/sepolia',
+        bundlerUrl: 'https://api.candide.dev/public/v3/11155111',
+        paymasterUrl: 'https://api.candide.dev/public/v3/11155111',
         paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
         transferMaxFee: 5000000,
         paymasterToken: {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -4505,9 +4505,9 @@ async function gaslessBridge() {
   const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
     chainId: 42161,
     provider: 'https://arb1.arbitrum.io/rpc',
-    bundlerUrl: 'https://api.candide.dev/public/v3/arbitrum',
+    bundlerUrl: 'https://api.candide.dev/public/v3/42161',
     safeModulesVersion: '0.3.0',
-    paymasterUrl: 'https://api.candide.dev/public/v3/arbitrum',
+    paymasterUrl: 'https://api.candide.dev/public/v3/42161',
     paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
     paymasterToken: { address: '0x...' } // Paymaster token configuration
   })
@@ -5132,9 +5132,9 @@ const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon aban
 const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   chainId: 42161,
   provider: 'https://arb1.arbitrum.io/rpc',
-  bundlerUrl: 'https://api.candide.dev/public/v3/arbitrum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/42161',
   safeModulesVersion: '0.3.0',
-  paymasterUrl: 'https://api.candide.dev/public/v3/arbitrum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/42161',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: { address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9' }
 })
@@ -13158,10 +13158,10 @@ Fees are paid using an ERC-20 token through a paymaster service.
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
   // Paymaster token mode
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USD₮
@@ -13181,11 +13181,11 @@ Fees are sponsored by a third party via a sponsorship policy.
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
   // Sponsorship mode
   isSponsored: true,
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   sponsorshipPolicyId: 'your-policy-id' // Optional
 })
 ```
@@ -13200,7 +13200,7 @@ Fees are paid using the chain's native token (e.g., ETH).
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
   // Native coins mode
   useNativeCoins: true,
@@ -13343,9 +13343,9 @@ new WalletAccountEvmErc4337(seed, path, config)
 const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -13787,9 +13787,9 @@ new WalletAccountReadOnlyEvmErc4337(address, config)
 const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
   safeModulesVersion: '0.3.0',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
@@ -14359,8 +14359,8 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
   {
     chainId: 1,
     provider: 'https://rpc.mevblocker.io/fast',
-    bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-    paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+    bundlerUrl: 'https://api.candide.dev/public/v3/1',
+    paymasterUrl: 'https://api.candide.dev/public/v3/1',
     paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
     safeModulesVersion: '0.3.0',
     paymasterToken: {
@@ -14459,7 +14459,7 @@ The `bundlerUrl` option specifies the URL of the ERC-4337 bundler service that h
 **Example:**
 ```javascript
 const config = {
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum'
+  bundlerUrl: 'https://api.candide.dev/public/v3/1'
 }
 ```
 
@@ -14473,7 +14473,7 @@ The `paymasterUrl` option specifies the URL of the paymaster service that sponso
 **Example:**
 ```javascript
 const config = {
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum'
+  paymasterUrl: 'https://api.candide.dev/public/v3/1'
 }
 ```
 
@@ -14583,7 +14583,7 @@ Enables Sponsorship Policy mode, where a sponsor covers transaction fees.
 ```javascript
 const config = {
   isSponsored: true,
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum'
+  paymasterUrl: 'https://api.candide.dev/public/v3/1'
 }
 ```
 
@@ -14647,8 +14647,8 @@ The following tokens are supported for gas payments on Ethereum Mainnet:
 const ethereumConfig = {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
@@ -14664,8 +14664,8 @@ const ethereumConfig = {
 const polygonConfig = {
   chainId: 137,
   provider: 'https://polygon-rpc.com',
-  bundlerUrl: 'https://api.candide.dev/public/v3/polygon',
-  paymasterUrl: 'https://api.candide.dev/public/v3/polygon',
+  bundlerUrl: 'https://api.candide.dev/public/v3/137',
+  paymasterUrl: 'https://api.candide.dev/public/v3/137',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
@@ -14852,8 +14852,8 @@ import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-43
 const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
@@ -14900,8 +14900,8 @@ const seedPhrase = 'abandon abandon abandon abandon abandon abandon abandon aban
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/ethereum',
-  paymasterUrl: 'https://api.candide.dev/public/v3/ethereum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  paymasterUrl: 'https://api.candide.dev/public/v3/1',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
@@ -26841,8 +26841,8 @@ export const wdkConfigs: WdkConfigs = {
       config: {
         chainId: 11155111, // Sepolia testnet
         provider: 'https://rpc.sepolia.org',
-        bundlerUrl: 'https://api.candide.dev/public/v3/sepolia',
-        paymasterUrl: 'https://api.candide.dev/public/v3/sepolia',
+        bundlerUrl: 'https://api.candide.dev/public/v3/11155111',
+        paymasterUrl: 'https://api.candide.dev/public/v3/11155111',
         paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
         transferMaxFee: 5000000,
         paymasterToken: {

--- a/skills/wdk/references/wallet-evm.md
+++ b/skills/wdk/references/wallet-evm.md
@@ -67,8 +67,8 @@ const wallet = new WalletManagerEvm(seedPhrase, {
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   provider: 'https://arb1.arbitrum.io/rpc',
   chainId: 42161,
-  bundlerUrl: 'https://api.candide.dev/public/v3/arbitrum',
-  paymasterUrl: 'https://api.candide.dev/public/v3/arbitrum',
+  bundlerUrl: 'https://api.candide.dev/public/v3/42161',
+  paymasterUrl: 'https://api.candide.dev/public/v3/42161',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   entrypointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
   paymasterToken: {


### PR DESCRIPTION
## What

Updates all Candide example endpoints in the docs to the **unified, chain-ID** format that Candide rolled out (one URL serves both bundler and paymaster; chain selected by chain ID):

- Public: `https://api.candide.dev/public/v3/{chainId}`
- Authenticated: `https://api.candide.dev/api/v3/{chainId}/{apiKey}`

## Why

The docs still showed the old format, which is now inaccurate:

- **Split-path** `https://api.candide.dev/bundler/v3/...` and `/paymaster/v3/...` (in the 7702 configuration page) → these now return **HTTP 404**.
- **Chain slugs** (`/public/v3/ethereum`, `/polygon`, `/arbitrum`, `/sepolia`) → still resolve, but chain ID is the documented convention and now matches the `chainId` field in each config block.

## Changes

- **7702 `configuration.mdx`** — replaced the broken "Separate Paymaster Endpoint" split-path example with a "Using Candide" section on the unified endpoint (only `bundlerUrl` needed; `paymasterUrl` defaults to it). Kept a note that `paymasterUrl` still exists for providers that genuinely split.
- **4337 / bridge-usdt0 / react-native-quickstart / `skills/wdk/references/wallet-evm.md`** — converted chain slugs to chain IDs (`ethereum→1`, `polygon→137`, `arbitrum→42161`, `sepolia→11155111`).
- **`public/llms-full.txt`** — synced the mirrored endpoints. Note: this file is a committed mirror with no in-repo generator; a full regeneration from `content/` is recommended on the next docs build (it was already missing the 7702 section).

## Verification

Tested live against the Candide API:

| Endpoint | Result |
|---|---|
| `public/v3/{1,137,42161,11155111,9745}` | ✅ 200, correct `eth_chainId` |
| `public/v3/11155111` `pm_supportedERC20Tokens` | ✅ paymaster served on same URL |
| `api/v3/11155111/<bad key>` | ✅ route exists, `Unauthorized` |
| old `bundler/v3/...`, `paymaster/v3/...` | ❌ 404 (confirms the fix) |