### PR TITLE
Fix browser-relative route validation in link checker

### DIFF
--- a/content/docs/ai/agent-skills.mdx
+++ b/content/docs/ai/agent-skills.mdx
@@ -9,7 +9,7 @@ icon: Brain
 WDK provides agent skills: structured instruction sets that teach AI agents how to create wallets, send transactions, swap tokens, bridge assets, and interact with DeFi protocols across 20+ blockchains. All operations are self-custodial. Keys stay on your machine, with no third-party custody dependency.
 
 <Callout type="info">
-**Skill vs MCP Toolkit**: Use an **agent skill** when your agent platform works with file-based instructions (e.g., OpenClaw, Cursor). Use the [MCP Toolkit](mcp-toolkit/) when your agent supports the Model Context Protocol natively (e.g., Claude, Cursor). Use both for maximum coverage.
+**Skill vs MCP Toolkit**: Use an **agent skill** when your agent platform works with file-based instructions (e.g., OpenClaw, Cursor). Use the [MCP Toolkit](/ai/mcp-toolkit/) when your agent supports the Model Context Protocol natively (e.g., Claude, Cursor). Use both for maximum coverage.
 </Callout>
 
 ## What Are Agent Skills?
@@ -54,7 +54,7 @@ WDK's agent skills use a self-custodial model where your agent controls its own 
 | Custody model | Self-custodial | Coinbase-hosted | Privy-hosted (server) |
 | Multi-chain | Yes (EVM, Bitcoin, Solana, TON, Tron, Spark + more) | EVM + Solana | EVM + Solana + Bitcoin + more |
 | Open source | Yes (SDK + skills) | CLI/skills open, infra closed | Skills open, API closed |
-| MCP support | Yes ([MCP Toolkit](mcp-toolkit/)) | Via skills | Via skills |
+| MCP support | Yes ([MCP Toolkit](/ai/mcp-toolkit/)) | Via skills | Via skills |
 | OpenClaw support | Yes ([ClawHub skill](https://clawhub.ai/HumanRupert/tether-wallet-development-kit)) | Yes (npx skills) | Yes (ClawHub skill) |
 | x402 payments | Via [community extensions](#community-projects) | Yes (native) | No |
 | Key management | Local / self-managed | Coinbase infrastructure | Privy infrastructure |
@@ -63,10 +63,10 @@ WDK's agent skills use a self-custodial model where your agent controls its own 
 
 | Platform | How to Use |
 | --- | --- |
-| **OpenClaw** | Install from [ClawHub](openclaw) or clone to workspace. See [OpenClaw Integration](openclaw) |
+| **OpenClaw** | Install from [ClawHub](/ai/openclaw/) or clone to workspace. See [OpenClaw Integration](/ai/openclaw/) |
 | **Claude** | Upload `SKILL.md` as project knowledge, or paste into conversation |
 | **Cursor / Windsurf** | Clone to `.cursor/skills/wdk` or `.windsurf/skills/wdk` |
-| **Any MCP-compatible agent** | Use the [MCP Toolkit](mcp-toolkit/) for structured tool calling |
+| **Any MCP-compatible agent** | Use the [MCP Toolkit](/ai/mcp-toolkit/) for structured tool calling |
 | **Any other agent** | Copy `SKILL.md` into system prompt or conversation context |
 
 ## Community Projects

--- a/content/docs/ai/mcp-toolkit/get-started.mdx
+++ b/content/docs/ai/mcp-toolkit/get-started.mdx
@@ -7,7 +7,7 @@ icon: Rocket
 ---
 
 <Callout type="info">
-**Building a LangChain agent?** The `serve` command provides zero-config MCP server startup -- no server script needed. See [LangChain Integration](langchain).
+**Building a LangChain agent?** The `serve` command provides zero-config MCP server startup -- no server script needed. See [LangChain Integration](/ai/mcp-toolkit/langchain/).
 </Callout>
 
 ## Setup Wizard
@@ -293,8 +293,8 @@ server.registerTools([
 
 ## Next Steps
 
-* [**Configuration**](configuration) - Wallets, tokens, protocols, custom tools, and security
-* [**API Reference**](api-reference) - All 35 built-in MCP tools with parameters and schemas
+* [**Configuration**](/ai/mcp-toolkit/configuration/) - Wallets, tokens, protocols, custom tools, and security
+* [**API Reference**](/ai/mcp-toolkit/api-reference/) - All 35 built-in MCP tools with parameters and schemas
 
 ***
 

--- a/content/docs/ai/mcp-toolkit/langchain.mdx
+++ b/content/docs/ai/mcp-toolkit/langchain.mdx
@@ -13,7 +13,7 @@ This approach uses LangChain's MCP adapters to connect to the WDK MCP server. WD
 </Callout>
 
 <Callout type="info">
-**Want more control?** The `serve` command is the fastest way to get running, but you can also [write your own MCP server](get-started#manual-setup) with the programmatic API for full control over wallets, tools, and protocols. Then point LangChain's `MultiServerMCPClient` at it using `node your-server.js` instead of the `serve` command.
+**Want more control?** The `serve` command is the fastest way to get running, but you can also [write your own MCP server](/ai/mcp-toolkit/get-started/#manual-setup) with the programmatic API for full control over wallets, tools, and protocols. Then point LangChain's `MultiServerMCPClient` at it using `node your-server.js` instead of the `serve` command.
 </Callout>
 
 ***

--- a/content/docs/ai/openclaw.mdx
+++ b/content/docs/ai/openclaw.mdx
@@ -69,7 +69,7 @@ Once the skill is loaded, your agent can:
 - **Lend and borrow** through Aave V3
 - **Buy and sell crypto** via MoonPay fiat on/off-ramps
 
-For the full list of capabilities and how skills work, see [Agent Skills](agent-skills).
+For the full list of capabilities and how skills work, see [Agent Skills](/ai/agent-skills/).
 
 ## Security Risks and Safety Precautions
 
@@ -112,8 +112,8 @@ OpenClaw makes use of artificial intelligence and machine learning technologies.
 
 ## Next Steps
 
-- [Agent Skills](agent-skills) - Full capabilities, how skills work, and a comparison with other agentic wallet solutions
-- [MCP Toolkit](mcp-toolkit/) - Programmatic wallet access for MCP-compatible agents
+- [Agent Skills](/ai/agent-skills/) - Full capabilities, how skills work, and a comparison with other agentic wallet solutions
+- [MCP Toolkit](/ai/mcp-toolkit/) - Programmatic wallet access for MCP-compatible agents
 - [OpenClaw Skills Documentation](https://docs.openclaw.ai/tools/skills) - How OpenClaw discovers and loads skills
 
 ***

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -109,7 +109,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 ### May 19, 2026
 
 **What's New**
-- **[Swidge Protocol Interface](../sdk/swidge-modules)**: New page covering WDK's preferred route interface for new swap, bridge, and combined route providers, including discovery, quote, execution, status, fee, and migration guidance for the existing standalone swap and bridge interfaces.
+- **[Swidge Protocol Interface](/sdk/swidge-modules)**: New page covering WDK's preferred route interface for new swap, bridge, and combined route providers, including discovery, quote, execution, status, fee, and migration guidance for the existing standalone swap and bridge interfaces.
 
 ---
 

--- a/content/docs/sdk/all-modules.mdx
+++ b/content/docs/sdk/all-modules.mdx
@@ -36,7 +36,7 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 
 Swidge is the preferred interface for new protocol providers that can quote and execute asset routes. A route can be swap-only, bridge-only, or a combined swap and bridge route.
 
-No released swidge provider module is listed yet. See the [swidge protocol interface](./swidge-modules/) for the shared API shape that new provider modules should implement.
+No released swidge provider module is listed yet. See the [swidge protocol interface](/sdk/swidge-modules/) for the shared API shape that new provider modules should implement.
 
 ## Pricing Modules
 

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell.mdx
@@ -153,6 +153,6 @@ window.open(result.sellUrl, '_blank')
 
 ## Next Steps
 
-- [Manage transactions](manage-transactions)
-- [Get started](get-started)
+- [Manage transactions](/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions/)
+- [Get started](/sdk/fiat-modules/fiat-moonpay/guides/get-started/)
 - [API reference](/sdk/fiat-modules/fiat-moonpay/api-reference)

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/guides/get-started.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/guides/get-started.mdx
@@ -34,5 +34,5 @@ See [Configuration](/sdk/fiat-modules/fiat-moonpay/configuration) for `cacheTime
 
 ## Next Steps
 
-- [Buy and sell](buy-and-sell)
-- [Manage transactions](manage-transactions)
+- [Buy and sell](/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell/)
+- [Manage transactions](/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions/)

--- a/content/docs/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions.mdx
+++ b/content/docs/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions.mdx
@@ -45,6 +45,6 @@ The second argument defaults to `buy` when omitted; set it explicitly for sell f
 
 ## Next Steps
 
-- [Buy and sell](buy-and-sell)
-- [Get started](get-started)
+- [Buy and sell](/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell/)
+- [Get started](/sdk/fiat-modules/fiat-moonpay/guides/get-started/)
 - [Configuration](/sdk/fiat-modules/fiat-moonpay/configuration)

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/get-started.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/get-started.mdx
@@ -38,5 +38,5 @@ Use contract addresses for Aave-supported reserves. On Ethereum mainnet, USD₮ 
 
 ## Next Steps
 
-- [Lending operations](lending-operations)
-- [Handle errors](handle-errors)
+- [Lending operations](/sdk/lending-modules/lending-aave-evm/guides/lending-operations/)
+- [Handle errors](/sdk/lending-modules/lending-aave-evm/guides/handle-errors/)

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/handle-errors.mdx
@@ -60,6 +60,6 @@ For ERC-4337 accounts, use [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337
 
 ## Next Steps
 
-- [Lending operations](lending-operations)
-- [Get started](get-started)
+- [Lending operations](/sdk/lending-modules/lending-aave-evm/guides/lending-operations/)
+- [Get started](/sdk/lending-modules/lending-aave-evm/guides/get-started/)
 - [API reference](/sdk/lending-modules/lending-aave-evm/api-reference)

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/lending-operations.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/lending-operations.mdx
@@ -146,6 +146,6 @@ console.log({
 
 ## Next Steps
 
-- [Handle errors](handle-errors)
-- [Get started](get-started)
+- [Handle errors](/sdk/lending-modules/lending-aave-evm/guides/handle-errors/)
+- [Get started](/sdk/lending-modules/lending-aave-evm/guides/get-started/)
 - [API reference](/sdk/lending-modules/lending-aave-evm/api-reference)

--- a/content/docs/sdk/lending-modules/lending-morpho-evm/guides/get-started.mdx
+++ b/content/docs/sdk/lending-modules/lending-morpho-evm/guides/get-started.mdx
@@ -68,5 +68,5 @@ Send any returned transaction requirements with your EVM account flow before cal
 
 ## Next Steps
 
-- [Lending operations](lending-operations)
-- [Handle errors](handle-errors)
+- [Lending operations](/sdk/lending-modules/lending-morpho-evm/guides/lending-operations/)
+- [Handle errors](/sdk/lending-modules/lending-morpho-evm/guides/handle-errors/)

--- a/content/docs/sdk/lending-modules/lending-morpho-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/lending-modules/lending-morpho-evm/guides/handle-errors.mdx
@@ -108,6 +108,6 @@ For ERC-4337 accounts, use [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337
 
 ## Next Steps
 
-- [Lending operations](lending-operations)
-- [Get started](get-started)
+- [Lending operations](/sdk/lending-modules/lending-morpho-evm/guides/lending-operations/)
+- [Get started](/sdk/lending-modules/lending-morpho-evm/guides/get-started/)
 - [API reference](/sdk/lending-modules/lending-morpho-evm/api-reference)

--- a/content/docs/sdk/lending-modules/lending-morpho-evm/guides/lending-operations.mdx
+++ b/content/docs/sdk/lending-modules/lending-morpho-evm/guides/lending-operations.mdx
@@ -313,6 +313,6 @@ console.log({
 
 ## Next Steps
 
-- [Handle errors](handle-errors)
-- [Get started](get-started)
+- [Handle errors](/sdk/lending-modules/lending-morpho-evm/guides/handle-errors/)
+- [Get started](/sdk/lending-modules/lending-morpho-evm/guides/get-started/)
 - [API reference](/sdk/lending-modules/lending-morpho-evm/api-reference)

--- a/content/docs/tools/indexer-api/api-reference.mdx
+++ b/content/docs/tools/indexer-api/api-reference.mdx
@@ -23,7 +23,7 @@ x-api-key: your-api-key-here
 ```
 
 <Callout type="info">
-**Don't have an API key yet?** Request one by following the steps in our [Get Started](get-started) guide.
+**Don't have an API key yet?** Request one by following the steps in our [Get Started](/tools/indexer-api/get-started/) guide.
 </Callout>
 
 ***
@@ -104,7 +104,7 @@ The API returns standard HTTP error codes:
 
 ## Next Steps
 
-* [**Get Started**](get-started) - Quick start guide with setup instructions
+* [**Get Started**](/tools/indexer-api/get-started/) - Quick start guide with setup instructions
 * [**React Native Starter**](/examples-and-starters/react-native-starter) - See it in action
 
 ***

--- a/content/docs/tools/indexer-api/get-started.mdx
+++ b/content/docs/tools/indexer-api/get-started.mdx
@@ -64,14 +64,14 @@ console.log(`Balance: ${balance.amount} ${balance.token.toUpperCase()}`);
 </Tabs>
 
 <Callout type="info">
-**Want more info?** Check out the complete [API Reference](api-reference) for detailed method documentation, parameters, and response formats.
+**Want more info?** Check out the complete [API Reference](/tools/indexer-api/api-reference/) for detailed method documentation, parameters, and response formats.
 </Callout>
 
 ***
 
 ## Next Steps
 
-* [**API Reference**](api-reference) - Complete method documentation with examples and response formats
+* [**API Reference**](/tools/indexer-api/api-reference/) - Complete method documentation with examples and response formats
 
 ***
 

--- a/content/docs/ui-kits/react-native-ui-kit/api-reference.mdx
+++ b/content/docs/ui-kits/react-native-ui-kit/api-reference.mdx
@@ -10,15 +10,15 @@ icon: Code
 
 | Component | Description |
 | --- | --- |
-| [`AmountInput`](api-reference) | Numeric input with token/fiat toggle, balance helper and Max action |
-| [`AssetSelector`](api-reference) | Token search & pick list with recent items and empty states |
-| [`NetworkSelector`](api-reference) | Network picker with gas level indicators and colors |
-| [`Balance`](api-reference) | Displays a balance value with optional masking and custom loader |
-| [`CryptoAddressInput`](api-reference) | Address input with QR scan and paste helpers, validation state |
-| [`QRCode`](api-reference) | QR renderer for addresses/payment requests with labeling and styling |
-| [`TransactionItem`](api-reference) | Single transaction row (sent/received) with token, amounts, network |
-| [`TransactionList`](api-reference) | Virtualized list of transactions using `TransactionItem` |
-| [`SeedPhrase`](api-reference) | Grid of seed words with optional editing and loading states |
+| [`AmountInput`](/ui-kits/react-native-ui-kit/api-reference/) | Numeric input with token/fiat toggle, balance helper and Max action |
+| [`AssetSelector`](/ui-kits/react-native-ui-kit/api-reference/) | Token search & pick list with recent items and empty states |
+| [`NetworkSelector`](/ui-kits/react-native-ui-kit/api-reference/) | Network picker with gas level indicators and colors |
+| [`Balance`](/ui-kits/react-native-ui-kit/api-reference/) | Displays a balance value with optional masking and custom loader |
+| [`CryptoAddressInput`](/ui-kits/react-native-ui-kit/api-reference/) | Address input with QR scan and paste helpers, validation state |
+| [`QRCode`](/ui-kits/react-native-ui-kit/api-reference/) | QR renderer for addresses/payment requests with labeling and styling |
+| [`TransactionItem`](/ui-kits/react-native-ui-kit/api-reference/) | Single transaction row (sent/received) with token, amounts, network |
+| [`TransactionList`](/ui-kits/react-native-ui-kit/api-reference/) | Virtualized list of transactions using `TransactionItem` |
+| [`SeedPhrase`](/ui-kits/react-native-ui-kit/api-reference/) | Grid of seed words with optional editing and loading states |
 
 
 ***
@@ -406,8 +406,8 @@ function WalletBackup({ seedWords, editable, onWordChange }) {
 
 ## Next Steps
 
-- [Get Started](get-started) - Quick start guide and basic usage
-- [Theming Guide](theming) - Deep dive into theming capabilities
+- [Get Started](/ui-kits/react-native-ui-kit/get-started/) - Quick start guide and basic usage
+- [Theming Guide](/ui-kits/react-native-ui-kit/theming/) - Deep dive into theming capabilities
 - [React Native Quickstart](/start-building/react-native-quickstart) - Complete implementation example
 
 ***

--- a/content/docs/ui-kits/react-native-ui-kit/get-started.mdx
+++ b/content/docs/ui-kits/react-native-ui-kit/get-started.mdx
@@ -49,15 +49,15 @@ export default function App() {
 
 | Component | Description |
 | --- | --- |
-| [`AmountInput`](api-reference) | Numeric input with token/fiat toggle, balance helper and Max action |
-| [`AssetSelector`](api-reference) | Token search & pick list with recent items and empty states |
-| [`NetworkSelector`](api-reference) | Network picker with gas level indicators and colors |
-| [`Balance`](api-reference) | Displays a balance value with optional masking and custom loader |
-| [`CryptoAddressInput`](api-reference) | Address input with QR scan and paste helpers, validation state |
-| [`QRCode`](api-reference) | QR renderer for addresses/payment requests with labeling and styling |
-| [`TransactionItem`](api-reference) | Single transaction row (sent/received) with token, amounts, network |
-| [`TransactionList`](api-reference) | Virtualized list of transactions using `TransactionItem` |
-| [`SeedPhrase`](api-reference) | Grid of seed words with optional editing and loading states |
+| [`AmountInput`](/ui-kits/react-native-ui-kit/api-reference/) | Numeric input with token/fiat toggle, balance helper and Max action |
+| [`AssetSelector`](/ui-kits/react-native-ui-kit/api-reference/) | Token search & pick list with recent items and empty states |
+| [`NetworkSelector`](/ui-kits/react-native-ui-kit/api-reference/) | Network picker with gas level indicators and colors |
+| [`Balance`](/ui-kits/react-native-ui-kit/api-reference/) | Displays a balance value with optional masking and custom loader |
+| [`CryptoAddressInput`](/ui-kits/react-native-ui-kit/api-reference/) | Address input with QR scan and paste helpers, validation state |
+| [`QRCode`](/ui-kits/react-native-ui-kit/api-reference/) | QR renderer for addresses/payment requests with labeling and styling |
+| [`TransactionItem`](/ui-kits/react-native-ui-kit/api-reference/) | Single transaction row (sent/received) with token, amounts, network |
+| [`TransactionList`](/ui-kits/react-native-ui-kit/api-reference/) | Virtualized list of transactions using `TransactionItem` |
+| [`SeedPhrase`](/ui-kits/react-native-ui-kit/api-reference/) | Grid of seed words with optional editing and loading states |
 
 ***
 
@@ -129,7 +129,7 @@ export function SendScreen() {
 
 The UI Kit provides a comprehensive theming system that allows you to use built-in light and dark themes, create custom brand themes from your colors and fonts, customize individual components with fine-grained control, and access theme values anywhere in your application. You can also switch themes dynamically based on user preferences.
 
-For detailed theming documentation, including brand integration, custom themes, component customization, and advanced usage patterns, see the [Theming Guide](theming).
+For detailed theming documentation, including brand integration, custom themes, component customization, and advanced usage patterns, see the [Theming Guide](/ui-kits/react-native-ui-kit/theming/).
 
 ***
 

--- a/content/docs/ui-kits/react-native-ui-kit/index.mdx
+++ b/content/docs/ui-kits/react-native-ui-kit/index.mdx
@@ -7,4 +7,4 @@ schemaType: TechArticle
 
 The WDK React Native UI Kit provides ready-made, themeable components for building wallet applications.
 
-**[Get Started →](get-started)**
+**[Get Started →](/ui-kits/react-native-ui-kit/get-started/)**

--- a/content/docs/ui-kits/react-native-ui-kit/theming.mdx
+++ b/content/docs/ui-kits/react-native-ui-kit/theming.mdx
@@ -365,8 +365,8 @@ function Settings() {
 
 ## Next Steps
 
-* [Get Started](get-started) - Quick start guide for the UI Kit
-* [Components List](api-reference) - Complete API Reference for all components
+* [Get Started](/ui-kits/react-native-ui-kit/get-started/) - Quick start guide for the UI Kit
+* [Components List](/ui-kits/react-native-ui-kit/api-reference/) - Complete API Reference for all components
 * [React Native Quickstart](/start-building/react-native-quickstart) - See theming in action
 
 ***

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -170,10 +170,10 @@ function fileToRoute(relativeMdxPath) {
   return normalizeRoute(`/${noExt}`);
 }
 
-function fileToBaseRoute(relativeMdxPath, route) {
-  const noExt = stripMarkdownExtension(toPosix(relativeMdxPath));
-  if (noExt === 'index' || noExt.endsWith('/index')) return route;
-  return normalizeRoute(path.posix.dirname(route));
+function fileToBaseRoute(_relativeMdxPath, route) {
+  // Exported pages use trailingSlash, so browser-relative hrefs resolve from
+  // the rendered page URL, not from the source MDX file's parent directory.
+  return route;
 }
 
 function createLineResolver(content) {


### PR DESCRIPTION
## Summary

- Update the MDX link checker to resolve relative docs routes the same way exported trailing-slash pages resolve them in the browser.
- Convert affected relative docs links to root-relative routes so generated pages do not resolve one level too deep.
- Cover the AI, MCP Toolkit, Fiat, Lending, Indexer API, UI Kit, and Swidge links that the stricter checker now validates correctly.

## Root Cause

The static export uses `trailingSlash: true`, so a rendered link like `href="openclaw"` on `/ai/agent-skills/` resolves to `/ai/agent-skills/openclaw/` in the browser. The custom checker was resolving the same MDX source link from the source parent route, treating it as `/ai/openclaw`, so the quality gate missed real 404s.

## Validation

Node 22.22.2 / npm 10.9.7 from a clean `upstream/develop` worktree:

- `npm ci`
- `git diff --check`
- `npm run check:meta`
- `npm run check:redirects`
- `LINK_CHECK_EXTERNAL=false npm run check:links` - 232 files, 2065 links, 0 errors
- `npm run build` - passed, rendered-link crawler found 0 broken links
- Custom rendered HTML audit - `broken unique=0`
- `npm run quality` - passed; external-link warnings were 403/redirect informational results, with 0 broken links
