### PR TITLE
Update wallet release documentation for June 29 releases

### DIFF
--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,17 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### June 29, 2026
+
+**What's New**
+- **wdk-wallet** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.12)): Remove `signTransaction()` from the base `ISigner` interface. Transaction signing remains an account-level wallet operation, and the base account types now let modules accept unsigned or module-specific signed payloads in `sendTransaction()` and `quoteSendTransaction()` where supported.
+- **wallet-solana** ([v1.0.0-beta.11](https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.11)): Add `transactionMaxFee` for native SOL `sendTransaction()` and `signTransaction()` flows. The Solana module keeps `transferMaxFee` scoped to SPL token transfers, and fee caps reject estimated fees above the configured cap.
+
+**Changes**
+- **wallet-ton-gasless** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.7)): Add `transactionMaxFee` to the shared gasless wallet config typing for base-wallet alignment while `sendTransaction()`, `quoteSendTransaction()`, and `signTransaction()` remain unsupported on the gasless module. Gasless Jetton transfers continue to use `transferMaxFee`, fee caps reject estimated fees above the configured cap, and the package refreshes its TON wallet and security dependency set.
+
+---
+
 ### June 25, 2026
 
 **Changes**

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -23,12 +23,13 @@ The base `@tetherto/wdk-wallet` package defines a cross-chain `ISigner` interfac
 | Surface | Description |
 | --- | --- |
 | `ISigner.derive(relPath)` | Derives a child signer from a relative derivation path, when the signer supports derivation. |
-| `ISigner.signTransaction(tx)` | Signs a chain-specific transaction without broadcasting it. |
 | `ISigner.getAddress()` | Returns the address controlled by the signer. |
 | `ISigner.dispose()` | Clears signer-held secret material or external resources. |
 | `WalletManager.addSigner(name, signer)` | Registers a named signer. Blank names throw an error. |
 | `WalletManager.getSigner(name?)` | Returns a named signer, or the default signer when called without a name. |
 | `WalletManager.getSigners()` | Returns a shallow copy of the named signer map. |
+
+`signTransaction(tx)` is an account-level operation, not part of `ISigner`. Use the chain account's `IWalletAccount.signTransaction(tx)` when a module supports signing without broadcast. Modules can also type their signed transaction payloads so `sendTransaction(tx)` and `quoteSendTransaction(tx)` accept either unsigned transactions or module-specific signed payloads where that behavior is implemented.
 
 Module support depends on the chain-specific wallet implementation. Check each module's reference before relying on signer-based account creation.
 

--- a/content/docs/sdk/wallet-modules/wallet-solana/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/api-reference.mdx
@@ -32,14 +32,16 @@ new WalletManagerSolana(seed, config)
   - `rpcUrl` (string | string[], optional): Deprecated alias for `provider`. If both are set, `provider` takes precedence
   - `commitment` (string, optional): Commitment level ('processed', 'confirmed', or 'finalized')
   - `retries` (number, optional): Additional retry attempts for ordered provider failover (default: 3)
-  - `transferMaxFee` (number, optional): Maximum fee amount for transfer operations (in lamports)
+  - `transferMaxFee` (number | bigint, optional): Maximum fee amount for SPL token transfer operations (in lamports)
+  - `transactionMaxFee` (number | bigint, optional): Maximum fee amount for native SOL send/sign operations (in lamports)
 
 **Example:**
 ```javascript
 const wallet = new WalletManagerSolana(seedPhrase, {
   provider: 'https://api.mainnet-beta.solana.com',
   commitment: 'confirmed',
-  transferMaxFee: 5000 // Maximum fee in lamports
+  transferMaxFee: 5000, // Maximum SPL transfer fee in lamports
+  transactionMaxFee: 5000 // Maximum native send/sign fee in lamports
 })
 ```
 
@@ -173,7 +175,7 @@ When `tx` is a `TransactionMessage`, WDK preserves an existing recent blockhash 
 
 **Returns:** `Promise<FullySignedTransaction>` - The signed transaction
 
-**Throws:** Error if wallet is not connected to a provider
+**Throws:** Error if wallet is not connected to a provider or if the estimated fee is greater than `transactionMaxFee`
 
 **Example:**
 ```javascript
@@ -211,7 +213,7 @@ When `tx` is a `TransactionMessage`, WDK preserves an existing recent blockhash 
 
 **Returns:** `Promise<{hash: string, fee: bigint}>` - Object containing transaction hash and fee (in lamports)
 
-**Throws:** Error if wallet is not connected to a provider
+**Throws:** Error if wallet is not connected to a provider or if the estimated fee is greater than `transactionMaxFee`
 
 **Example:**
 ```javascript
@@ -509,6 +511,7 @@ interface SolanaWalletConfig {
   commitment?: 'processed' | 'confirmed' | 'finalized';
   retries?: number;
   transferMaxFee?: number | bigint;
+  transactionMaxFee?: number | bigint;
 }
 ```
 

--- a/content/docs/sdk/wallet-modules/wallet-solana/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/configuration.mdx
@@ -15,7 +15,8 @@ import WalletManagerSolana from '@tetherto/wdk-wallet-solana'
 
 const config = {
   provider: 'https://api.mainnet-beta.solana.com', // Recommended: Solana RPC endpoint
-  transferMaxFee: 10000000 // Optional: Maximum fee in lamports
+  transferMaxFee: 10000000, // Optional: Maximum SPL transfer fee in lamports
+  transactionMaxFee: 10000000 // Optional: Maximum native send/sign fee in lamports
 }
 
 const wallet = new WalletManagerSolana(seedPhrase, config)
@@ -30,7 +31,8 @@ import WalletManagerSolana from '@tetherto/wdk-wallet-solana'
 
 const accountConfig = {
   provider: 'https://api.mainnet-beta.solana.com',
-  transferMaxFee: 10000000 // Optional: Maximum fee in lamports
+  transferMaxFee: 10000000, // Optional: Maximum SPL transfer fee in lamports
+  transactionMaxFee: 10000000 // Optional: Maximum native send/sign fee in lamports
 }
 
 const wallet = new WalletManagerSolana(seedPhrase, accountConfig)
@@ -107,9 +109,9 @@ const config = {
 
 ### transferMaxFee
 
-The `transferMaxFee` option sets the maximum allowed fee (in lamports) for transfer operations. This helps prevent unexpectedly high transaction fees.
+The `transferMaxFee` option sets the maximum allowed fee, in lamports, for SPL token `transfer()` operations. This helps prevent unexpectedly high token-transfer fees.
 
-**Type:** `number` (optional)
+**Type:** `number | bigint` (optional)
 
 **Unit:** Lamports (1 SOL = 1,000,000,000 lamports)
 
@@ -117,6 +119,23 @@ The `transferMaxFee` option sets the maximum allowed fee (in lamports) for trans
 ```javascript
 const config = {
   transferMaxFee: 10000000 // 0.01 SOL in lamports
+}
+```
+
+### transactionMaxFee
+
+The `transactionMaxFee` option sets the maximum allowed fee, in lamports, for native SOL `sendTransaction()` and `signTransaction()` operations. This is separate from `transferMaxFee`, which applies to SPL token transfers.
+
+**Type:** `number | bigint` (optional)
+
+**Unit:** Lamports (1 SOL = 1,000,000,000 lamports)
+
+WDK rejects native send/sign operations when the estimated fee is greater than `transactionMaxFee`. A fee equal to the configured cap is allowed.
+
+**Example:**
+```javascript
+const config = {
+  transactionMaxFee: 10000000 // 0.01 SOL in lamports
 }
 ```
 
@@ -130,7 +149,8 @@ const config = {
   provider: 'https://api.mainnet-beta.solana.com',
 
   // Optional: Fee protection
-  transferMaxFee: 10000000 // 0.01 SOL maximum fee
+  transferMaxFee: 10000000, // 0.01 SOL maximum SPL transfer fee
+  transactionMaxFee: 10000000 // 0.01 SOL maximum native send/sign fee
 }
 
 const wallet = new WalletManagerSolana(seedPhrase, config)
@@ -174,7 +194,7 @@ Use [`getAccountByPath`](/sdk/wallet-modules/wallet-solana/api-reference#getacco
 
 - Always use HTTPS URLs for RPC endpoints
 - Use RPC endpoints that serve the same Solana network when enabling failover
-- Set appropriate `transferMaxFee` limits for your use case
+- Set appropriate `transferMaxFee` and `transactionMaxFee` limits for your use case
 - Consider using environment variables for configuration in production
 - Use trusted RPC providers or run your own Solana validator for production applications
 

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/error-handling.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/error-handling.mdx
@@ -61,8 +61,8 @@ async function safeTransfer(account, wallet) {
       console.error('Please add more SOL to your wallet')
     } else if (error.message.includes('invalid address')) {
       console.error('The recipient address is invalid')
-    } else if (error.message.includes('max fee')) {
-      console.error('The transfer fee exceeds your configured maximum')
+    } else if (error.message.toLowerCase().includes('fee')) {
+      console.error('The transaction fee exceeds your configured maximum')
     } else {
       console.error('Transaction failed:', error.message)
     }
@@ -84,12 +84,18 @@ Durable nonce flows still need a valid nonce account and signer setup in the mes
 
 ## Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet to prevent transactions from exceeding a maximum cost. Retrieve current network rates with [`getFeeRates()`](/sdk/wallet-modules/wallet-solana/api-reference) to make informed decisions.
+Set `transactionMaxFee` when creating the wallet to cap native SOL `sendTransaction()` and `signTransaction()` costs. Set `transferMaxFee` separately for SPL token `transfer()` costs. Fee caps reject estimates greater than the configured limit, so an estimate equal to the cap is allowed. Retrieve current network rates with [`getFeeRates()`](/sdk/wallet-modules/wallet-solana/api-reference#getfeerates) to make informed decisions.
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()
 console.log('Normal fee rate:', feeRates.normal, 'lamports')
 console.log('Fast fee rate:', feeRates.fast, 'lamports')
+
+const walletWithCaps = new WalletManagerSolana(seedPhrase, {
+  provider: 'https://api.mainnet-beta.solana.com',
+  transactionMaxFee: 10000000n,
+  transferMaxFee: 10000000n
+})
 ```
 
 ## Dispose of Sensitive Data

--- a/content/docs/sdk/wallet-modules/wallet-solana/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-solana/guides/send-transactions.mdx
@@ -5,7 +5,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-This guide explains how to [send native SOL](#send-native-sol), [sign a transaction without broadcasting](#sign-a-transaction-without-broadcasting), [estimate transaction fees](#estimate-transaction-fees), [quote or send a TransactionMessage](#quote-or-send-a-transactionmessage), [use dynamic fee rates](#use-dynamic-fee-rates), and [run a complete SOL transfer flow](#complete-example).
+This guide explains how to [send native SOL](#send-native-sol), [sign a transaction without broadcasting](#sign-a-transaction-without-broadcasting), [estimate transaction fees](#estimate-transaction-fees), [cap native transaction fees](#cap-native-transaction-fees), [quote or send a TransactionMessage](#quote-or-send-a-transactionmessage), [use dynamic fee rates](#use-dynamic-fee-rates), and [run a complete SOL transfer flow](#complete-example).
 
 <Callout type="warn">
 **BigInt Usage:** Always use `BigInt` (the `n` suffix) for monetary values to avoid precision loss with large numbers.
@@ -50,6 +50,17 @@ const quote = await account.quoteSendTransaction({
   value: 1000000000n
 })
 console.log('Estimated fee:', quote.fee, 'lamports')
+```
+
+## Cap Native Transaction Fees
+
+Set [`transactionMaxFee`](/sdk/wallet-modules/wallet-solana/configuration#transactionmaxfee) when you create the wallet to stop native `sendTransaction()` and `signTransaction()` calls if the estimated fee is greater than your limit. A fee equal to the configured cap is allowed. Use `transferMaxFee` separately for SPL token transfers.
+
+```javascript title="Set a Native Transaction Fee Cap"
+const wallet = new WalletManagerSolana(seedPhrase, {
+  provider: 'https://api.mainnet-beta.solana.com',
+  transactionMaxFee: 10000000n // 0.01 SOL in lamports
+})
 ```
 
 ## Quote or Send a TransactionMessage

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/api-reference.mdx
@@ -36,7 +36,8 @@ new WalletManagerTonGasless(seed, config)
   - `paymasterToken` (object): Paymaster token configuration
     - `address` (string): Paymaster Jetton master contract address
   - `retries` (number, optional): Failover retries used when `tonClient` and `tonApiClient` are arrays (default: 3)
-  - `transferMaxFee` (number | bigint, optional): Maximum fee for transfer operations
+  - `transferMaxFee` (number | bigint, optional): Maximum fee for gasless transfer operations
+  - `transactionMaxFee` (number | bigint, optional): Shared wallet config option; native `sendTransaction()`, `quoteSendTransaction()`, and `signTransaction()` are unsupported on this module
 
 **Example:**
 ```javascript
@@ -136,7 +137,8 @@ new WalletAccountTonGasless(seed, path, config)
 | `getAddress()` | Returns the account's TON address | `Promise\<string\>` |
 | `sign(message)` | Signs a message using the account's private key | `Promise\<string\>` |
 | `signTransaction(tx)` | Not supported on gasless; always throws | `Promise\<never\>` |
-| `sendTransaction(tx)` | Not supported on gasless; always throws | `Promise\<never\>` |
+| `sendTransaction(tx)` | Not supported on gasless; always rejects | `Promise\<TransactionResult\>` |
+| `quoteSendTransaction(tx)` | Not supported on gasless; always rejects | `Promise\<Omit\<TransactionResult, 'hash'\>\>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` |
 | `transfer(options, config?)` | Transfers tokens using gasless transactions | `Promise\<{hash: string, fee: number}\>` |
 | `quoteTransfer(options, config?)` | Estimates the fee for a token transfer | `Promise\<{fee: number}\>` |
@@ -186,17 +188,31 @@ await account.signTransaction({ to: 'EQ...', value: 1000000000n })
 ```
 
 ##### `sendTransaction(tx)`
-Not supported on the gasless module. This method always throws. To move funds, use [`transfer()`](#transferoptions-config), which relays a paymaster-funded Jetton transfer.
+Not supported on the gasless module. This method is typed as `Promise<TransactionResult>` for wallet-interface compatibility, but it always rejects at runtime. To move funds, use [`transfer()`](#transferoptions-config), which relays a paymaster-funded Jetton transfer.
 
 **Parameters:**
 - `tx` (TonTransaction): The transaction
 
-**Returns:** `Promise\<never\>` - Never resolves; always throws
+**Returns:** `Promise\<TransactionResult\>` - Interface-compatible return type; never resolves successfully on this module
 
 **Example:**
 ```javascript
 // Throws: "Method 'sendTransaction(tx)' not supported on ton gasless."
 await account.sendTransaction({ to: 'EQ...', value: 1000000000n })
+```
+
+##### `quoteSendTransaction(tx)`
+Not supported on the gasless module. This method is inherited for wallet-interface compatibility and always rejects at runtime. Use [`quoteTransfer()`](#quotetransferoptions) to estimate gasless Jetton transfer fees.
+
+**Parameters:**
+- `tx` (TonTransaction): The transaction
+
+**Returns:** `Promise\<Omit\<TransactionResult, 'hash'\>\>` - Interface-compatible return type; never resolves successfully on this module
+
+**Example:**
+```javascript
+// Throws: "Method 'quoteSendTransaction(tx)' not supported on ton gasless."
+await account.quoteSendTransaction({ to: 'EQ...', value: 1000000000n })
 ```
 
 ##### `verify(message, signature)`
@@ -215,7 +231,7 @@ console.log('Signature valid:', isValid)
 ```
 
 ##### `transfer(options, config?)`
-Transfers a Jetton using a gasless transaction, paying the fee with the configured paymaster token. This is the only way to move funds on the gasless module: `sendTransaction()` and `signTransaction()` are not supported and throw.
+Transfers a Jetton using a gasless transaction, paying the fee with the configured paymaster token. This is the only way to move funds on the gasless module: `sendTransaction()`, `quoteSendTransaction()`, and `signTransaction()` are not supported and reject or throw.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options
@@ -225,7 +241,7 @@ Transfers a Jetton using a gasless transaction, paying the fee with the configur
 - `config` (object, optional): Override configuration
   - `paymasterToken` (object, optional): Override default paymaster token
     - `address` (string): Paymaster token address
-  - `transferMaxFee` (number, optional): Override maximum fee
+  - `transferMaxFee` (number | bigint, optional): Override maximum fee. Transfers throw only when the estimated fee is greater than this cap, so an equal estimate is allowed.
 
 **Returns:** `Promise\<{hash: string, fee: number}\>` - Transfer result
 
@@ -357,6 +373,7 @@ new WalletAccountReadOnlyTonGasless(publicKey, config)
 | `getBalance()` | Returns the native TON balance | `Promise\<bigint\>` |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific token | `Promise\<bigint\>` |
 | `getPaymasterTokenBalance()` | Returns the balance of the paymaster token | `Promise\<bigint\>` |
+| `quoteSendTransaction(tx)` | Not supported on gasless; always rejects | `Promise\<Omit\<TransactionResult, 'hash'\>\>` |
 | `quoteTransfer(options, config?)` | Estimates the fee for a token transfer | `Promise\<{fee: number}\>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise\<TonTransactionReceipt \| null\>` |
@@ -406,6 +423,20 @@ Returns the balance of the paymaster token (used for gasless fees).
 ```javascript
 const paymasterBalance = await readOnlyAccount.getPaymasterTokenBalance()
 console.log('Paymaster token balance:', paymasterBalance)
+```
+
+##### `quoteSendTransaction(tx)`
+Not supported on the gasless module. This method is present for wallet-interface compatibility and always rejects. Use [`quoteTransfer()`](#quotetransferoptions-config) to estimate gasless Jetton transfer fees.
+
+**Parameters:**
+- `tx` (TonTransaction): The transaction
+
+**Returns:** `Promise\<Omit\<TransactionResult, 'hash'\>\>` - Interface-compatible return type; never resolves successfully on this module
+
+**Example:**
+```javascript
+// Throws: "Method 'quoteSendTransaction(tx)' not supported on ton gasless."
+await readOnlyAccount.quoteSendTransaction({ to: 'EQ...', value: 1000000000n })
 ```
 
 ##### `quoteTransfer(options, config?)`
@@ -515,6 +546,13 @@ type TonGaslessWalletConfig = {
    * Maximum fee for transfer operations (in paymaster Jetton base units)
    */
   transferMaxFee?: number | bigint;
+
+  /**
+   * Shared wallet config option. Native sendTransaction(), quoteSendTransaction(),
+   * and signTransaction() are unsupported on this gasless module; use transferMaxFee
+   * for gasless transfers.
+   */
+  transactionMaxFee?: number | bigint;
 };
 ```
 
@@ -593,4 +631,3 @@ Get started with WDK's TON Gasless Wallet Configuration
 ## Need Help?
 
 <SupportCards />
-

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/configuration.mdx
@@ -163,7 +163,7 @@ const config = {
 
 ### transferMaxFee
 
-The `transferMaxFee` option sets the maximum allowed fee in paymaster Jetton base units for transfer operations. A transfer throws if its estimated fee reaches this limit.
+The `transferMaxFee` option sets the maximum allowed fee in paymaster Jetton base units for transfer operations. A transfer throws if its estimated fee is greater than this limit, so an estimate equal to the configured cap is allowed.
 
 **Type:** `number | bigint`
 
@@ -176,9 +176,17 @@ const config = {
 }
 ```
 
+### transactionMaxFee
+
+`TonGaslessWalletConfig` includes `transactionMaxFee` for alignment with the shared wallet config shape. The gasless module does not support `sendTransaction()`, `quoteSendTransaction()`, or `signTransaction()`, so this option does not cap gasless Jetton transfers. Use `transferMaxFee` for `transfer()` fee enforcement, and use `quoteTransfer()` to inspect estimated fees before transferring.
+
+**Type:** `number | bigint`
+
+**Required:** No
+
 ## Complete Configuration Example
 
-Here's a complete configuration example with all options, including failover:
+Here's a complete configuration example with required clients, failover, and gasless transfer fee protection:
 
 ```javascript
 const config = {
@@ -203,7 +211,7 @@ const config = {
   retries: 3,
 
   // Fee Limits (Optional)
-  transferMaxFee: 10000000 // Maximum fee in paymaster Jetton base units
+  transferMaxFee: 10000000 // Maximum gasless transfer fee in paymaster Jetton base units
 }
 ```
 
@@ -216,7 +224,8 @@ The default derivation path changed in `1.0.0-beta.5`. Accounts now derive at `m
 - Keep API keys and secrets secure and never expose them in client-side code
 - Use environment variables for sensitive configuration values
 - Always use HTTPS URLs for API endpoints
-- Set appropriate `transferMaxFee` limits to prevent excessive fees
+- Set appropriate `transferMaxFee` limits to prevent excessive gasless transfer fees
+- Do not rely on `transactionMaxFee` for gasless transfers; native send, quote, and sign methods are unsupported in this module
 - Validate the paymaster token address before using it in configuration
 
 <Cards>

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.mdx
@@ -26,7 +26,7 @@ try {
     console.error('Please add more paymaster tokens for gas fees')
   } else if (error.message.includes('invalid address')) {
     console.error('The recipient address is invalid')
-  } else if (error.message.includes('max fee')) {
+  } else if (error.message.toLowerCase().includes('fee')) {
     console.error('The transfer fee exceeds your configured maximum')
   } else {
     console.error('Transfer failed:', error.message)
@@ -36,7 +36,7 @@ try {
 
 ## Handle Unsupported Method Errors
 
-The gasless module supports only paymaster-funded Jetton transfers. Both [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#sendtransactiontx) and [`account.signTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#signtransactiontx) throw when called. Use [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config) instead, and guard any code path that might reach these methods:
+The gasless module supports only paymaster-funded Jetton transfers. [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#sendtransactiontx), [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#quotesendtransactiontx), and [`account.signTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#signtransactiontx) reject or throw when called. Use [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config) instead, and guard any code path that might reach these methods:
 
 ```javascript title="Unsupported Method Handling"
 try {
@@ -54,7 +54,7 @@ try {
 
 ### Manage Fee Limits
 
-Set `transferMaxFee` when creating the wallet to prevent gasless transfers from exceeding a maximum cost. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#getfeerates):
+Set `transferMaxFee` when creating the wallet to prevent gasless transfers from exceeding a maximum cost. Fee caps reject estimates greater than the configured limit, so an estimate equal to the cap is allowed. Native `sendTransaction()`, `quoteSendTransaction()`, and `signTransaction()` are unsupported on this module, so `transactionMaxFee` does not cap gasless transfers. You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#getfeerates):
 
 ```javascript title="Fee Management"
 const feeRates = await wallet.getFeeRates()

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.mdx
@@ -9,7 +9,7 @@ This guide explains why [native TON sends are not supported](#native-ton-sends-a
 
 ## Native TON Sends Are Not Supported
 
-The gasless module does not send native TON. Both [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#sendtransactiontx) and [`account.signTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#signtransactiontx) throw on this module. The module's purpose is to relay paymaster-funded Jetton transfers, so the only way to move funds is [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config).
+The gasless module does not send native TON. [`account.sendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#sendtransactiontx), [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#quotesendtransactiontx), and [`account.signTransaction()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#signtransactiontx) reject or throw on this module. The module's purpose is to relay paymaster-funded Jetton transfers, so the only way to move funds is [`account.transfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#transferoptions-config).
 
 Calling `sendTransaction()` throws an error:
 

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.mdx
@@ -40,6 +40,8 @@ console.log('Transfer hash:', result.hash)
 console.log('Transfer fee:', result.fee, 'paymaster token units')
 ```
 
+`transferMaxFee` rejects estimates greater than the configured cap. A fee estimate equal to the cap is allowed.
+
 ## Estimate Transfer Fees
 
 You can get a fee estimate before executing the transfer using [`account.quoteTransfer()`](/sdk/wallet-modules/wallet-ton-gasless/api-reference#quotetransferoptions):

--- a/content/docs/sdk/wallet-modules/wallet-ton-gasless/usage.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-ton-gasless/usage.mdx
@@ -18,8 +18,8 @@ Work with multiple accounts and custom derivation paths.
 <Card title="Check Balances" href="/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances">
 Query native TON, Jetton, and paymaster token balances.
 </Card>
-<Card title="Send TON" href="/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions">
-Send native TON transactions.
+<Card title="Native Sends Unsupported" href="/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions">
+Understand why native TON sends throw and when to use the standard TON module.
 </Card>
 <Card title="Transfer Jetton Tokens" href="/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens">
 Transfer Jetton tokens gaslessly with paymaster fees.

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -172,7 +172,7 @@ export const customTree: Node[] = [
         page('Get Started', '/sdk/wallet-modules/wallet-ton-gasless/guides/get-started'),
         page('Manage Accounts', '/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts'),
         page('Check Balances', '/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances'),
-        page('Send TON', '/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions'),
+        page('Native Sends Unsupported', '/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions'),
         page('Transfer Jetton Tokens', '/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens'),
         page('Sign and Verify Messages', '/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages'),
         page('Handle Errors', '/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors'),


### PR DESCRIPTION
## Summary
- Add the June 29 changelog entries for `wdk-wallet` v1.0.0-beta.12, `wallet-solana` v1.0.0-beta.11, and `wallet-ton-gasless` v1.0.0-beta.7.
- Update shared wallet interface docs to remove `ISigner.signTransaction()` and clarify account-level signed transaction handling.
- Document Solana `transactionMaxFee` for native send/sign flows and clarify TON gasless fee-cap behavior and unsupported native transaction methods.
- Rename the TON gasless native-send navigation/card label to make the unsupported flow explicit.

## Release Sources
- https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.12
- https://github.com/tetherto/wdk-wallet-solana/releases/tag/v1.0.0-beta.11
- https://github.com/tetherto/wdk-wallet-ton-gasless/releases/tag/v1.0.0-beta.7

## Validation
- `git diff --check`
- `npm run check:meta`
- `npm run check:redirects`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `npm run build`
- `npm run quality` before the final rebase; it passed with existing unrelated external-link warnings/redirect notices and existing unrelated SEO `docType` warnings.
