### PR TITLE
Update July release documentation

### DIFF
--- a/content/docs/ai/mcp-toolkit/configuration.mdx
+++ b/content/docs/ai/mcp-toolkit/configuration.mdx
@@ -201,7 +201,7 @@ server.registerTools([getAddress, getBalance, getCurrentPrice])
 
 ### Custom Tools
 
-Add your own MCP tools alongside the built-in ones using the standard `registerTool()` method (inherited from `McpServer`). See the [MCP SDK tools documentation](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/server.md#tools) for full details.
+Add your own MCP tools alongside the built-in ones using the standard `registerTool()` method (inherited from `McpServer`). See the [MCP SDK tools documentation](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/servers/tools.md) for full details.
 
 ```javascript
 server.registerTool(

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,11 +10,46 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### July 07, 2026
+
+**Changes**
+- **pricing-bitfinex-http** ([v1.0.0-beta.4](https://github.com/tetherto/wdk-pricing-bitfinex-http/releases/tag/v1.0.0-beta.4)): Remove the USD-pivot fallback from Bitfinex price lookups. Current-price and price-data methods now return `null` for pairs Bitfinex cannot quote directly, while historical lookups return an empty series when Bitfinex has no matching history.
+
+---
+
+### July 04, 2026
+
+**Changes**
+- **wdk-utils** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.8)): Refresh Noble crypto dependencies and import paths used by address validation, Lightning invoice helpers, BIP-21 parsing, and seed-encryption internals. No new public helper API is introduced in this release.
+
+---
+
+### July 03, 2026
+
+**What's New**
+- **wallet-evm** ([v1.0.0-beta.15](https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.15)): Add signer-backed EVM accounts with the new `@tetherto/wdk-wallet-evm/signers` entrypoint, `SeedSignerEvm`, `PrivateKeySignerEvm`, signer-based account retrieval, standalone private-key accounts via `WalletAccountEvm.fromPrivateKey()`, contract-creation transactions with omitted or `null` `to`, and ERC-7702 authorization/delegation helpers. The release also updates `ethers` to `6.17.0` and aligns with `@tetherto/wdk-wallet` v1.0.0-beta.13.
+- **wallet-tron** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.8)): Add arbitrary transaction support. `quoteSendTransaction()`, `signTransaction()`, and `sendTransaction()` now accept native TRX transfers, smart-contract call descriptors, or pre-built TronWeb transactions. Fee quotes cover bandwidth, smart-contract energy, and activation fees where applicable.
+
+**Fixes**
+- **wdk-wallet** ([v1.0.0-beta.13](https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.13)): Default `IWalletAccount<TSignedTransaction>` to `unknown`, restoring bare `IWalletAccount` TypeScript compatibility for downstream packages without runtime behavior changes.
+- **wallet-evm-erc-4337** ([v1.0.0-beta.11](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.11)): Fix UserOperation signing compatibility with the `@tetherto/wdk-wallet-evm` v1.0.0-beta.15 signer model and align dependencies with `@tetherto/wdk-wallet` v1.0.0-beta.13 and `ethers` 6.17.0.
+
+**Changes**
+- **worklet-bundler** ([v1.0.0-beta.4](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.4)): Publish source changes for JSON-RPC transport, native addon linking, ESM-to-CJS conversion, generic `modules` config support, lazy wallet-module loading, and the generated `./.wdk` import path. The npm artifact for this tag is missing built CLI/API files, so the Worklet Bundler usage pages remain on the prior documented workflow until a fixed package is available.
+- **wdk-core** ([v1.0.0-beta.13](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.13)): Align the core package with `@tetherto/wdk-wallet` v1.0.0-beta.13. No new core runtime API changes were found in this tag diff.
+- **bridge-usdt0-evm** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/releases/tag/v1.0.0-beta.6)): Align dependencies with the latest base wallet, EVM wallet, and ERC-4337 wallet releases. No production bridge API changes were found in this tag diff.
+
+---
+
 ### July 01, 2026
 
 **What's New**
 - **wallet-evm-erc-4337** ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.10)): Add `transactionMaxFee` for non-sponsored `sendTransaction()` and `signTransaction()` UserOperation flows, separate from `transferMaxFee` for token transfers. The module also reserves local nonces for rapid or concurrent sends from the same account instance and releases them when a submission fails before bundler acceptance.
 - **react-native-core** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.12)): Add `useProtocol()` for calling bridge, swap, lending, and fiat protocol methods from React Native through the active WDK worklet account.
+
+---
+
+### June 30, 2026
 
 **Changes**
 - **swap-velora-evm** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-protocol-swap-velora-evm/releases/tag/v1.0.0-beta.6)): Document the optional ERC-4337 per-call config argument for `swap()` and `quoteSwap()`, plus the `swap()` per-call `swapMaxFee` override. The package also refreshes dependency and repository metadata.

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,17 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### July 01, 2026
+
+**What's New**
+- **wallet-evm-erc-4337** ([v1.0.0-beta.10](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.10)): Add `transactionMaxFee` for non-sponsored `sendTransaction()` and `signTransaction()` UserOperation flows, separate from `transferMaxFee` for token transfers. The module also reserves local nonces for rapid or concurrent sends from the same account instance and releases them when a submission fails before bundler acceptance.
+- **react-native-core** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.12)): Add `useProtocol()` for calling bridge, swap, lending, and fiat protocol methods from React Native through the active WDK worklet account.
+
+**Changes**
+- **swap-velora-evm** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-protocol-swap-velora-evm/releases/tag/v1.0.0-beta.6)): Document the optional ERC-4337 per-call config argument for `swap()` and `quoteSwap()`, plus the `swap()` per-call `swapMaxFee` override. The package also refreshes dependency and repository metadata.
+
+---
+
 ### June 29, 2026
 
 **What's New**

--- a/content/docs/sdk/swap-modules/swap-velora-evm/api-reference.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/api-reference.mdx
@@ -31,7 +31,7 @@ const swap = new VeloraProtocolEvm(account, { swapMaxFee: 200000000000000n })
 
 | Method | Description | Returns |
 |--------|-------------|---------|
-| `swap(options, config?)` | Perform a token swap | `Promise<{hash: string, fee: bigint, tokenInAmount: bigint, tokenOutAmount: bigint, approveHash?: string, resetAllowanceHash?: string}>` |
+| `swap(options, config?)` | Perform a token swap | `Promise<{hash: string, fee: bigint, tokenInAmount: bigint, tokenOutAmount: bigint}>` |
 | `quoteSwap(options, config?)` | Get estimated fee and amounts | `Promise<{fee: bigint, tokenInAmount: bigint, tokenOutAmount: bigint}>` |
 
 ---
@@ -47,15 +47,18 @@ Options:
 - `to` (`string`, optional): Recipient address (defaults to account address)
 
 Config (ERC‑4337 only):
-- `paymasterToken` (`string`, optional): Token symbol/address for fee sponsorship
+- `paymasterToken` (`{ address: string }`, optional): Paymaster token override for this swap
+- `isSponsored` (`true`, optional): Use sponsorship mode for this swap
+- `sponsorshipPolicyId` (`string`, optional): Sponsorship policy override
+- `useNativeCoins` (`true`, optional): Pay fees in the chain's native token
 - `swapMaxFee` (`bigint`, optional): Per‑swap fee cap (wei)
 
 Returns:
-- Standard account: `{ hash, fee, tokenInAmount, tokenOutAmount, approveHash?, resetAllowanceHash? }`
-- ERC‑4337 account: `{ hash, fee, tokenInAmount, tokenOutAmount }` (approve may be bundled)
+- Standard account: `{ hash, fee, tokenInAmount, tokenOutAmount }`
+- ERC‑4337 account: `{ hash, fee, tokenInAmount, tokenOutAmount }`
 
 Notes:
-- On Ethereum mainnet, selling USD₮ may first set allowance to 0, then approve.
+- Approve the input token with the wallet account before swapping if the spender does not already have enough allowance.
 - Requires a provider; requires a non read‑only account to send transactions.
 
 Example:
@@ -78,7 +81,10 @@ Options are the same as `swap`.
 Returns: `{ fee, tokenInAmount, tokenOutAmount }`
 
 Config (ERC‑4337 only):
-- `paymasterToken` (`string`, optional): Token symbol/address for fee sponsorship
+- `paymasterToken` (`{ address: string }`, optional): Paymaster token override for fee estimation
+- `isSponsored` (`true`, optional): Use sponsorship mode for fee estimation
+- `sponsorshipPolicyId` (`string`, optional): Sponsorship policy override
+- `useNativeCoins` (`true`, optional): Estimate fees in the chain's native token
 
 Works with read‑only accounts.
 
@@ -108,7 +114,7 @@ Common errors include:
 
 - `swapMaxFee: bigint` — Upper bound for gas fees (wei)
 - `tokenInAmount/tokenOutAmount: bigint` — ERC‑20 base units
-- `paymasterToken: string` — token symbol or address (AA only)
+- `paymasterToken: { address: string }` — ERC‑4337 paymaster token override
 
 <Cards>
 <Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">

--- a/content/docs/sdk/swap-modules/swap-velora-evm/configuration.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/configuration.mdx
@@ -95,9 +95,14 @@ import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
 
 const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   chainId: 1,
-  provider: 'https://arb1.arbitrum.io/rpc',
+  provider: 'https://ethereum-rpc.publicnode.com',
   bundlerUrl: 'YOUR_BUNDLER_URL',
-  paymasterUrl: 'YOUR_PAYMASTER_URL'
+  paymasterUrl: 'YOUR_PAYMASTER_URL',
+  paymasterAddress: 'YOUR_PAYMASTER_ADDRESS',
+  safeModulesVersion: '0.3.0',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  }
 })
 
 const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 200000000000000n })
@@ -107,17 +112,18 @@ const result = await swapAA.swap({
   tokenOut: '0xTokenOut',
   tokenInAmount: 1000000n
 }, {
-  paymasterToken: 'USDT', // Token used to pay for gas
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  },
   swapMaxFee: 200000000000000n // Per‑swap override
 })
 ```
 
-### Paymaster Token (ERC‑4337)
+### Per-call ERC‑4337 Config
 
-The `paymasterToken` option indicates which token the paymaster should use to sponsor gas.
+The second argument to `swap()` and `quoteSwap()` accepts ERC‑4337 wallet config overrides. Use it to switch paymaster token, sponsorship policy, or native-coin fee behavior for a single call. `swap()` also accepts `swapMaxFee` as a per-swap fee cap.
 
-**Type:** `string` (optional)  
-**Format:** Token symbol or address
+**Type:** partial ERC‑4337 wallet config (optional)
 
 **Example:**
 
@@ -127,7 +133,10 @@ const result = await swapAA.swap({
   tokenOut: '0xC02a...6Cc2', // WETH
   tokenInAmount: 1000000n
 }, {
-  paymasterToken: 'USDT'
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  },
+  swapMaxFee: 200000000000000n
 })
 ```
 
@@ -191,4 +200,3 @@ Get started with WDK's velora Swap Protocol usage
 ## Need Help?
 
 <SupportCards />
-

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/execute-swaps.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/execute-swaps.mdx
@@ -51,10 +51,15 @@ import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
 import VeloraProtocolEvm from '@tetherto/wdk-protocol-swap-velora-evm'
 
 const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
-  chainId: 42161,
-  provider: 'https://arb1.arbitrum.io/rpc',
+  chainId: 1,
+  provider: 'https://ethereum-rpc.publicnode.com',
   bundlerUrl: process.env.BUNDLER_URL,
-  paymasterUrl: process.env.PAYMASTER_URL
+  paymasterUrl: process.env.PAYMASTER_URL,
+  paymasterAddress: process.env.PAYMASTER_ADDRESS,
+  safeModulesVersion: '0.3.0',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  }
 })
 
 const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 200000000000000n })
@@ -64,7 +69,9 @@ const result = await swapAA.swap({
   tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
   tokenInAmount: 1000000n
 }, {
-  paymasterToken: 'USDT',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  },
   swapMaxFee: 200000000000000n
 })
 

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes.mdx
@@ -34,6 +34,20 @@ console.log('Estimated fee (wei):', quote.fee)
 console.log('Required token in (base units):', quote.tokenInAmount)
 ```
 
+With an ERC‑4337 account, pass the optional second argument to preview the fee for a specific paymaster, sponsorship, or native-fee configuration:
+
+```javascript title="Quote with ERC-4337 fee config"
+const quote = await swapAA.quoteSwap({
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  tokenInAmount: 1000000n
+}, {
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  }
+})
+```
+
 ## Fee estimation
 
 You can read `quote.fee` from [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) as the estimated total swap fee in wei before calling [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):

--- a/content/docs/sdk/swap-modules/swap-velora-evm/index.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/index.mdx
@@ -12,7 +12,7 @@ Use the Velora swap module to quote and execute token swaps on EVM chains. It wo
 - **Token Swapping**: Execute token swaps through velora on supported EVM networks
 - **Account Abstraction**: Compatible with standard EVM accounts and ERC‑4337 smart accounts
 - **Fee Controls**: Optional `swapMaxFee` to cap gas costs
-- **Allowance Safety**: Handles USD₮ mainnet pattern (reset allowance to 0 before approve)
+- **Approval-aware swaps**: Approve input tokens with the wallet account before swapping when allowance is required
 - **Provider Flexibility**: Works with JSON‑RPC URLs and EIP‑1193 providers
 - **TypeScript Support**: Full TypeScript definitions included
 
@@ -32,8 +32,8 @@ The swap service supports multiple EVM wallet types:
 
 - **velora Integration**: Uses velora aggregator for routing and quotes
 - **Quote System**: Pre‑transaction fee and amount estimation via `quoteSwap`
-- **AA Integration**: Optional paymaster token and fee cap overrides when using ERC‑4337
-- **Allowance Management**: Approve flow handled automatically when required
+- **AA Integration**: Optional paymaster, sponsorship, native-fee, and fee-cap overrides when using ERC‑4337
+- **Read-only quoting**: Quote swaps from read-only EVM and ERC‑4337 accounts
 
 ## Next Steps
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
@@ -54,6 +54,7 @@ Fees are paid using an ERC-20 token through a paymaster service.
 - `paymasterAddress` (string): The address of the paymaster smart contract
 - `paymasterToken` (object): The paymaster token configuration
   - `address` (string): The address of the ERC-20 token used for fees
+- `transactionMaxFee` (number | bigint, optional): Maximum fee limit for `sendTransaction()` and `signTransaction()` in paymaster token units
 - `transferMaxFee` (number | bigint, optional): Maximum fee limit in paymaster token units
 
 ```javascript
@@ -68,6 +69,7 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USD₮
   },
+  transactionMaxFee: 100000, // Optional: max send/sign fee in token units
   transferMaxFee: 100000 // Optional: max fee in token units
 })
 ```
@@ -96,6 +98,7 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
 Fees are paid using the chain's native token (e.g., ETH).
 
 - `useNativeCoins` (true): Enables native coin fee payment
+- `transactionMaxFee` (number | bigint, optional): Maximum fee limit for `sendTransaction()` and `signTransaction()` in native token units
 - `transferMaxFee` (number | bigint, optional): Maximum fee limit in native token units
 
 ```javascript
@@ -106,6 +109,7 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   safeModulesVersion: '0.3.0',
   // Native coins mode
   useNativeCoins: true,
+  transactionMaxFee: 100000000000000n, // Optional: max send/sign fee in wei
   transferMaxFee: 100000000000000n // Optional: max fee in wei
 })
 ```
@@ -335,7 +339,7 @@ Sends a transaction via UserOperation through the bundler.
 
 **Returns:** `Promise\<{hash: string, fee: bigint}\>` - UserOperation hash and fee
 
-**Throws:** Error if fee exceeds `transferMaxFee`
+**Throws:** Error if fee exceeds `transactionMaxFee`
 
 **Example:**
 ```javascript
@@ -370,6 +374,8 @@ const fastResult = await account.sendTransaction({
   maxPriorityFeePerGas: 2000000000n  // 2 gwei
 })
 ```
+
+The account reserves a local nonce for each pending `sendTransaction()` or `transfer()` from the same account instance. Pre-acceptance failures release the reserved nonce; ambiguous transport failures keep it reserved to avoid nonce reuse.
 
 ##### `quoteSendTransaction(tx, config?)`
 Estimates the fee for a UserOperation without sending it.
@@ -693,7 +699,7 @@ new WalletAccountReadOnlyEvmErc4337(address, config)
 
 **Parameters:**
 - `address` (string): The EOA address (owner address)
-- `config` (`Omit<EvmErc4337WalletConfig, 'transferMaxFee'>`): Configuration object without `transferMaxFee`
+- `config` (`Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`): Configuration object without send-only fee caps
 
 **Example:**
 ```javascript
@@ -1011,7 +1017,8 @@ interface EvmErc4337WalletPaymasterTokenConfig {
   paymasterUrl: string;                     // Paymaster service URL
   paymasterAddress: string;                 // Paymaster contract address
   paymasterToken: { address: string };      // ERC-20 token for fees
-  transferMaxFee?: number | bigint;         // Maximum fee limit
+  transferMaxFee?: number | bigint;         // Maximum transfer fee limit
+  transactionMaxFee?: number | bigint;      // Maximum send/sign fee limit
 }
 
 // Mode 2: Sponsorship Policy
@@ -1026,7 +1033,8 @@ interface EvmErc4337WalletSponsorshipPolicyConfig {
 interface EvmErc4337WalletNativeCoinsConfig {
   isSponsored?: false;
   useNativeCoins: true;
-  transferMaxFee?: number | bigint;         // Maximum fee limit
+  transferMaxFee?: number | bigint;         // Maximum transfer fee limit
+  transactionMaxFee?: number | bigint;      // Maximum send/sign fee limit
 }
 
 // Full config type
@@ -1038,7 +1046,7 @@ type EvmErc4337WalletConfig = EvmErc4337WalletCommonConfig &
 
 ### Config Override
 
-The `config` parameter on `sendTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
+The `config` parameter on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
 
 ```typescript
 type ConfigOverride = Partial<
@@ -1055,6 +1063,7 @@ type ConfigOverride = Partial<
 - `paymasterAddress` (string): Override paymaster contract
 - `paymasterToken` (\{address: string\}): Override paymaster token
 - `sponsorshipPolicyId` (string): Set sponsorship policy
+- `transactionMaxFee` (number | bigint): Override maximum fee for `sendTransaction()` and `signTransaction()`
 - `transferMaxFee` (number | bigint): Override maximum fee
 
 ### EvmErc4337Transaction

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
@@ -21,10 +21,11 @@ const config = {
   bundlerUrl: `https://api.pimlico.io/v1/ethereum/rpc?apikey=${PIMLICO_API_KEY}`,
   paymasterUrl: `https://api.pimlico.io/v2/ethereum/rpc?apikey=${PIMLICO_API_KEY}`,
   paymasterAddress: '0x777777777777AeC03fd955926DbF81597e66834C',
-  transferMaxFee: 100000000000000,
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
-  }
+  },
+  transactionMaxFee: 100000,
+  transferMaxFee: 100000
 }
 
 const wallet = new WalletManagerEvmErc4337(seedPhrase, config)
@@ -44,7 +45,7 @@ const account = new WalletAccountEvmErc4337(
   config    // Same config as wallet manager
 )
 
-// Read-only account (transferMaxFee not needed)
+// Read-only account (fee caps for sending are not needed)
 const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
   '0x...', // Smart contract wallet address
   {
@@ -57,7 +58,7 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
     paymasterToken: {
       address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
     }
-    // Note: transferMaxFee omitted for read-only accounts
+    // Note: transferMaxFee and transactionMaxFee omitted for read-only accounts
   }
 )
 ```
@@ -288,17 +289,45 @@ Enables Native Coins mode, where the user pays fees in the chain's native curren
 ```javascript
 const config = {
   useNativeCoins: true,
-  transferMaxFee: 100000000000000n // Optional: max fee in wei
+  transactionMaxFee: 100000000000000n, // Optional: max send/sign fee in wei
+  transferMaxFee: 100000000000000n // Optional: max transfer fee in wei
+}
+```
+
+### Transaction Max Fee
+
+The `transactionMaxFee` option sets the maximum fee amount for non-sponsored `sendTransaction()` and `signTransaction()` operations. It applies in Paymaster Token and Native Coins modes and is separate from `transferMaxFee`, which only caps token transfer operations. **Optional** parameter.
+
+**Type:** `number | bigint`
+**Required:** No (optional)
+**Unit:** Paymaster token base units in Paymaster Token mode; native token base units in Native Coins mode
+
+**Example:**
+```javascript
+const config = {
+  transactionMaxFee: 100000, // 100,000 paymaster token units
+  transferMaxFee: 100000
+}
+
+try {
+  const result = await account.sendTransaction({
+    to: '0x...',
+    value: 1000000000000000n
+  })
+} catch (error) {
+  if (error.message.includes('Exceeded maximum fee')) {
+    console.error('Transaction cancelled: Fee too high')
+  }
 }
 ```
 
 ### Transfer Max Fee
 
-The `transferMaxFee` option sets the maximum fee amount **in paymaster token units** for transfer operations. This prevents transactions with unexpectedly high fees. **Optional** parameter.
+The `transferMaxFee` option sets the maximum fee amount for transfer operations. In Paymaster Token mode, the cap uses paymaster token base units. In Native Coins mode, the cap uses native token base units. This prevents transactions with unexpectedly high fees. **Optional** parameter.
 
 **Type:** `number | bigint`
 **Required:** No (optional)
-**Unit:** Paymaster token base units
+**Unit:** Paymaster token base units in Paymaster Token mode; native token base units in Native Coins mode
 
 **Example:**
 ```javascript

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
@@ -3,7 +3,7 @@ title: Send Transactions
 description: Send gasless transactions and estimate fees.
 ---
 
-This guide explains how to [send a gasless transaction](#send-a-gasless-transaction), [estimate fees](#estimate-fees), [reuse a recent quote](#reuse-a-recent-quote), and [use a custom paymaster token](#send-with-custom-paymaster-token).
+This guide explains how to [send a gasless transaction](#send-a-gasless-transaction), [estimate fees](#estimate-fees), [cap transaction fees](#cap-transaction-fees), [reuse a recent quote](#reuse-a-recent-quote), and [use a custom paymaster token](#send-with-custom-paymaster-token).
 
 ## Send a Gasless Transaction
 
@@ -34,6 +34,23 @@ const quote = await account.quoteSendTransaction({
 console.log('Estimated fee:', quote.fee)
 ```
 
+## Cap Transaction Fees
+
+Set `transactionMaxFee` to reject non-sponsored `sendTransaction()` and `signTransaction()` operations when the estimated UserOperation fee is above your cap. Use `transferMaxFee` separately for token transfers.
+
+```javascript title="Cap sendTransaction fees"
+const result = await account.sendTransaction({
+  to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  value: 1000000000000000n
+}, {
+  transactionMaxFee: 100000
+})
+```
+
+<Callout type="info">
+`transactionMaxFee` applies to Paymaster Token and Native Coins modes. Sponsored operations return a zero fee to the caller and do not use this cap.
+</Callout>
+
 ## Reuse a Recent Quote
 
 Quotes are cached for up to 2 minutes. If you call `sendTransaction()` with the same transaction during that window, the account checks the current on-chain nonce before reusing the cached UserOperation. If the nonce has moved, it builds a fresh quote before sending.
@@ -50,6 +67,14 @@ console.log('Estimated fee:', quote.fee)
 const result = await account.sendTransaction(tx)
 console.log('Transaction hash:', result.hash)
 ```
+
+## Send Rapid Transactions
+
+When you call `sendTransaction()` or `transfer()` rapidly from the same account instance, the wallet reserves local nonces so concurrent UserOperations use sequential nonces. If submission fails before bundler acceptance, the reserved nonce is released. If the failure is ambiguous, such as a transport error after submission, the wallet keeps the nonce reserved to avoid accidental reuse.
+
+<Callout type="info">
+The wallet reads the on-chain nonce before reserving locally. If that read does not complete within 30 seconds, the operation fails instead of guessing the next nonce.
+</Callout>
 
 ## Send with Custom Paymaster Token
 

--- a/content/docs/sdk/wallet-modules/wallet-evm/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/api-reference.mdx
@@ -22,11 +22,11 @@ Extends `WalletManager` from `@tetherto/wdk-wallet`.
 ### Constructor
 
 ```javascript
-new WalletManagerEvm(seed, config?)
+new WalletManagerEvm(seedOrSigner, config?)
 ```
 
 **Parameters:**
-- `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
+- `seedOrSigner` (`string | Uint8Array | ISigner`): BIP-39 mnemonic seed phrase, seed bytes, or a derivable root signer
 - `config` (object, optional): Configuration object
   - `provider` (`string | Eip1193Provider | Array<string | Eip1193Provider>`, optional): RPC endpoint URL, EIP-1193 provider instance, or ordered failover list
   - `retries` (number, optional): Additional retry attempts when `provider` is an array
@@ -34,12 +34,21 @@ new WalletManagerEvm(seed, config?)
   - `transferMaxFee` (number | bigint, optional): Maximum fee amount for transfer operations (in wei)
   - `transactionMaxFee` (number | bigint, optional): Maximum fee amount for native `sendTransaction()` and provider-backed `signTransaction()` operations (in wei)
 
+The default signer must support derivation. Register non-derivable signers, such as private-key signers, with `addSigner()` and retrieve them by name.
+
 **Example:**
 ```javascript
 const wallet = new WalletManagerEvm(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
   transferMaxFee: 100000000000000, // Maximum ERC-20 transfer fee in wei
   transactionMaxFee: 100000000000000 // Maximum native send/sign fee in wei
+})
+
+import { SeedSignerEvm } from '@tetherto/wdk-wallet-evm/signers'
+
+const signer = new SeedSignerEvm(seedPhrase)
+const signerWallet = new WalletManagerEvm(signer, {
+  provider: 'https://rpc.mevblocker.io/fast'
 })
 ```
 
@@ -49,8 +58,12 @@ const wallet = new WalletManagerEvm(seedPhrase, {
 |--------|-------------|---------|--------|
 | `getRandomSeedPhrase(wordCount?)` | (static) Returns a random BIP-39 seed phrase | `string` | - |
 | `isValidSeedPhrase(seedPhrase)` | (static) Checks if a seed phrase is valid | `boolean` | - |
-| `getAccount(index?)` | Returns a wallet account at the specified index | `Promise<WalletAccountEvm>` | - |
-| `getAccountByPath(path)` | Returns a wallet account at the specified BIP-44 derivation path | `Promise<WalletAccountEvm>` | - |
+| `addSigner(signerName, signer)` | Registers a named signer on the manager | `WalletManagerEvm` | If `signerName` is empty |
+| `getSigner(signerName?)` | Returns the default signer or a named signer | `ISigner` | If the requested signer is unavailable |
+| `getSigners()` | Returns registered named signers | `Record<string, ISigner>` | - |
+| `getAccount(index?, options?)` | Returns a wallet account at the specified index, optionally from a named signer | `Promise<WalletAccountEvm>` | If the requested signer is unavailable or cannot derive |
+| `getAccount(signerName)` | Returns the account associated with a registered signer | `Promise<WalletAccountEvm>` | If the named signer is unavailable |
+| `getAccountByPath(path, options?)` | Returns a wallet account at the specified BIP-44 derivation path, optionally from a named signer | `Promise<WalletAccountEvm>` | If the requested signer is unavailable or cannot derive |
 | `getFeeRates()` | Returns current fee rates for transactions | `Promise<{normal: bigint, fast: bigint}>` | If no provider is set |
 | `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` | - |
 
@@ -91,11 +104,41 @@ const isValid = WalletManagerEvm.isValidSeedPhrase('abandon abandon abandon ...'
 console.log('Valid:', isValid)
 ```
 
+#### `addSigner(signerName, signer)`
+Registers a signer under a name. Use this for external or non-default signers that should be retrieved explicitly.
+
+**Parameters:**
+- `signerName` (string): Name used for lookup
+- `signer` (ISigner): Signer instance
+
+**Returns:** `WalletManagerEvm` - The wallet manager
+
+**Example:**
+```javascript
+import { PrivateKeySignerEvm } from '@tetherto/wdk-wallet-evm/signers'
+
+wallet.addSigner('treasury', new PrivateKeySignerEvm(privateKey))
+```
+
+#### `getSigner(signerName?)`
+Returns the default signer when called with no argument, or a registered named signer.
+
+**Parameters:**
+- `signerName` (string, optional): Name registered with `addSigner()`
+
+**Returns:** `ISigner` - The signer
+
+#### `getSigners()`
+Returns a shallow copy of the named signers registered with `addSigner()`. The default signer is not included.
+
+**Returns:** `Record<string, ISigner>` - Registered named signers
+
 #### `getAccount(index?)`
-Returns a wallet account at the specified index following BIP-44 standard.
+Returns a wallet account at the specified index following BIP-44 standard. Pass `options.signerName` to derive the account from a registered derivable signer.
 
 **Parameters:**
 - `index` (number, optional): The index of the account to get (default: 0)
+- `options.signerName` (string, optional): Registered signer name
 
 **Returns:** `Promise<WalletAccountEvm>` - The wallet account
 
@@ -109,13 +152,30 @@ const account1 = await wallet.getAccount(1)
 
 // Get first account (default)
 const defaultAccount = await wallet.getAccount()
+
+// Derive account 2 from a registered derivable signer
+const signerAccount = await wallet.getAccount(2, { signerName: 'hardware-root' })
+```
+
+#### `getAccount(signerName)`
+Returns the wallet account associated with a registered signer. Non-derivable signers return their single account.
+
+**Parameters:**
+- `signerName` (string): Name registered with `addSigner()`
+
+**Returns:** `Promise<WalletAccountEvm>` - The signer-backed wallet account
+
+**Example:**
+```javascript
+const treasuryAccount = await wallet.getAccount('treasury')
 ```
 
 #### `getAccountByPath(path)`
-Returns a wallet account at the specified BIP-44 derivation path.
+Returns a wallet account at the specified BIP-44 derivation path. Pass `options.signerName` to derive from a registered derivable signer.
 
 **Parameters:**
 - `path` (string): The derivation path (e.g., "0'/0/0")
+- `options.signerName` (string, optional): Registered signer name
 
 **Returns:** `Promise<WalletAccountEvm>` - The wallet account
 
@@ -126,6 +186,10 @@ const account = await wallet.getAccountByPath("0'/0/1")
 
 // Custom path: m/44'/60'/0'/0/5
 const customAccount = await wallet.getAccountByPath("0'/0/5")
+
+const customSignerAccount = await wallet.getAccountByPath("0'/0/5", {
+  signerName: 'hardware-root'
+})
 ```
 
 #### `getFeeRates()`
@@ -168,11 +232,13 @@ Represents an individual wallet account. Extends `WalletAccountReadOnlyEvm` and 
 
 ```javascript
 new WalletAccountEvm(seed, path, config?)
+new WalletAccountEvm(signer, config?)
 ```
 
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
 - `path` (string): BIP-44 derivation path (e.g., "0'/0/0")
+- `signer`: Object implementing the EVM signer shape
 - `config` (object, optional): Configuration object
   - `provider` (`string | Eip1193Provider | Array<string | Eip1193Provider>`, optional): RPC endpoint URL, EIP-1193 provider instance, or ordered failover list
   - `retries` (number, optional): Additional retry attempts when `provider` is an array
@@ -190,7 +256,20 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
   transferMaxFee: 100000000000000,
   transactionMaxFee: 100000000000000
 })
+
+import { PrivateKeySignerEvm } from '@tetherto/wdk-wallet-evm/signers'
+
+const signerAccount = new WalletAccountEvm(
+  new PrivateKeySignerEvm(privateKey),
+  { provider: 'https://rpc.mevblocker.io/fast' }
+)
 ```
+
+### Static Methods
+
+| Method | Description | Returns | Throws |
+|--------|-------------|---------|--------|
+| `fromPrivateKey(privateKey, config?)` | Creates a standalone account from a raw private key | `WalletAccountEvm` | If the private key is invalid |
 
 ### Methods
 
@@ -213,7 +292,26 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 | `getAllowance(token, spender)` | Returns current allowance for a spender | `Promise<bigint>` | If no provider |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<EvmTransactionReceipt \| null>` | If no provider |
 | `toReadOnlyAccount()` | Returns a read-only copy of the account | `Promise<WalletAccountReadOnlyEvm>` | - |
+| `signAuthorization(auth)` | Signs an ERC-7702 authorization tuple | `Promise<Authorization>` | If signing fails |
+| `delegate(delegateAddress)` | Delegates the EOA to a contract through an ERC-7702 type 4 transaction | `Promise<{hash: string, fee: bigint}>` | If no provider |
+| `revokeDelegation()` | Revokes active ERC-7702 delegation by delegating to the zero address | `Promise<{hash: string, fee: bigint}>` | If no provider |
 | `dispose()` | Disposes the wallet account, clearing private keys from memory | `void` | - |
+
+#### `fromPrivateKey(privateKey, config?)` (static)
+Creates a standalone EVM account from a raw private key.
+
+**Parameters:**
+- `privateKey` (`string | Uint8Array`): Raw private key, as a hex string with or without `0x`, or 32 bytes
+- `config` (object, optional): EVM wallet configuration
+
+**Returns:** `WalletAccountEvm` - The wallet account
+
+**Example:**
+```javascript
+const account = WalletAccountEvm.fromPrivateKey(privateKey, {
+  provider: 'https://rpc.mevblocker.io/fast'
+})
+```
 
 #### `getAddress()`
 Returns the account's Ethereum address.
@@ -283,7 +381,7 @@ Signs an EVM transaction and returns the signed raw transaction as a hex string.
 
 **Parameters:**
 - `tx` (EvmTransaction): The transaction object
-  - `to` (string): Recipient address
+  - `to` (string | null, optional): Recipient address; omit or pass `null` for contract creation
   - `value` (number | bigint): Amount in wei
   - `data` (string, optional): Transaction data in hex format
   - `gasLimit` (number | bigint, optional): Maximum gas units
@@ -347,7 +445,7 @@ Sends an EVM transaction and returns the result with hash and fee.
 
 **Parameters:**
 - `tx` (EvmTransaction): The transaction object
-  - `to` (string): Recipient address
+  - `to` (string | null, optional): Recipient address; omit or pass `null` for contract creation
   - `value` (number | bigint): Amount in wei
   - `data` (string, optional): Transaction data in hex format
   - `gasLimit` (number | bigint, optional): Maximum gas units
@@ -583,6 +681,36 @@ const balance = await readOnlyAccount.getBalance()
 // readOnlyAccount.sendTransaction() // Would throw error
 ```
 
+#### `signAuthorization(auth)`
+Signs an ERC-7702 authorization tuple.
+
+**Parameters:**
+- `auth` (AuthorizationRequest): ERC-7702 authorization request
+
+**Returns:** `Promise<Authorization>` - The signed authorization
+
+**Example:**
+```javascript
+const authorization = await account.signAuthorization({
+  chainId: 1,
+  address: delegateContract,
+  nonce: 0
+})
+```
+
+#### `delegate(delegateAddress)`
+Delegates the EOA to a smart contract through an ERC-7702 type 4 transaction.
+
+**Parameters:**
+- `delegateAddress` (string): Contract address to delegate to
+
+**Returns:** `Promise<{hash: string, fee: bigint}>` - Transaction result
+
+#### `revokeDelegation()`
+Revokes active ERC-7702 delegation by delegating to the zero address.
+
+**Returns:** `Promise<{hash: string, fee: bigint}>` - Transaction result
+
 #### `dispose()`
 Disposes the wallet account, erasing the private key from memory.
 
@@ -658,6 +786,7 @@ const readOnlyAccount = new WalletAccountReadOnlyEvm('0x742d35Cc6634C0532925a3b8
 | `quoteTransfer(options)` | Estimates the fee for an ERC20 transfer | `Promise<{fee: bigint}>` | If no provider |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` | - |
 | `verifyTypedData(typedData, signature)` | Verifies a typed data signature (EIP-712) | `Promise<boolean>` | - |
+| `getDelegation()` | Checks active ERC-7702 delegation status | `Promise<DelegationInfo>` | If no provider |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<EvmTransactionReceipt \| null>` | If no provider |
 | `getAllowance(token, spender)` | Returns current allowance for a spender | `Promise<bigint>` | If no provider |
 
@@ -793,6 +922,18 @@ const isValid = await readOnlyAccount.verifyTypedData(typedData, signature)
 console.log('Typed data signature valid:', isValid) // true
 ```
 
+#### `getDelegation()`
+Checks whether the account currently has an active ERC-7702 delegation.
+
+**Returns:** `Promise<DelegationInfo>` - Delegation status and delegate address
+
+**Example:**
+```javascript
+const delegation = await readOnlyAccount.getDelegation()
+console.log('Delegated:', delegation.isDelegated)
+console.log('Delegate:', delegation.delegateAddress)
+```
+
 #### `getTransactionReceipt(hash)`
 Returns a transaction's receipt if it has been mined.
 
@@ -839,7 +980,7 @@ console.log('Allowance:', allowance)
 
 ```typescript
 interface EvmTransaction {
-  to: string;                               // The transaction's recipient address
+  to?: string | null;                       // Recipient address; omit or pass null for contract creation
   value: number | bigint;                    // The amount of ethers to send (in wei)
   data?: string;                             // The transaction's data in hex format (optional)
   gasLimit?: number | bigint;                // Maximum amount of gas this transaction can use (optional)
@@ -899,6 +1040,50 @@ interface KeyPair {
 }
 ```
 
+### EVM signer structural shape
+
+```typescript
+interface EvmSignerLike extends ISigner {
+  readonly isDerivable: boolean;
+  readonly index?: number;
+  readonly path?: string;
+  readonly address?: string;
+  readonly keyPair: KeyPair;
+  derive(relPath: string): Promise<EvmSignerLike>;
+  getAddress(): Promise<string>;
+  sign(message: string): Promise<string>;
+  signTransaction(unsignedTx: UnsignedEvmTransaction): Promise<string>;
+  signTypedData(typedData: TypedData): Promise<string>;
+  signAuthorization(auth: AuthorizationRequest): Promise<Authorization>;
+  dispose(): void;
+}
+```
+
+`SeedSignerEvm` and `PrivateKeySignerEvm` are exported from `@tetherto/wdk-wallet-evm/signers`. `SeedSignerEvm` supports derivation and can be used as a manager default signer. `PrivateKeySignerEvm` represents one private-key account, does not support derivation, and should be registered by name or used directly with `WalletAccountEvm`.
+
+### UnsignedEvmTransaction
+
+```typescript
+interface UnsignedEvmTransaction {
+  chainId: number;
+  nonce: number;
+  from: string;
+  to: string | null;
+  data: string;
+  value: number | bigint;
+  type: number;
+  gasLimit: number | bigint;
+  gasPrice?: number | bigint;
+  maxFeePerGas?: number | bigint;
+  maxPriorityFeePerGas?: number | bigint;
+  accessList?: any[];
+  maxFeePerBlobGas?: number | bigint;
+  blobs?: any[];
+  blobVersionedHashes?: string[];
+  authorizationList?: AuthorizationLike[];
+}
+```
+
 ### TypedData
 
 ```typescript
@@ -939,6 +1124,15 @@ interface EvmWalletConfig {
   chainId?: number;                                                  // Network chain ID. Skips automatic detection when provided.
   transferMaxFee?: number | bigint;                                  // Maximum ERC-20 transfer fee in wei
   transactionMaxFee?: number | bigint;                               // Maximum native send/sign fee in wei
+}
+```
+
+### DelegationInfo
+
+```typescript
+interface DelegationInfo {
+  isDelegated: boolean;              // Whether the account has an active ERC-7702 delegation
+  delegateAddress: string | null;    // Delegate contract address, or null when not delegated
 }
 ```
 

--- a/content/docs/sdk/wallet-modules/wallet-evm/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/configuration.mdx
@@ -33,6 +33,46 @@ const config = {
 const wallet = new WalletManagerEvm(seedPhrase, config)
 ```
 
+## Signer Configuration
+
+`WalletManagerEvm` accepts either a BIP-39 seed phrase/seed bytes or a derivable EVM signer as its first argument. Use the `@tetherto/wdk-wallet-evm/signers` entrypoint when you need explicit signer objects:
+
+```javascript title="Create A Manager From A Seed Signer"
+import WalletManagerEvm from '@tetherto/wdk-wallet-evm'
+import { SeedSignerEvm } from '@tetherto/wdk-wallet-evm/signers'
+
+const signer = new SeedSignerEvm(seedPhrase)
+
+const wallet = new WalletManagerEvm(signer, {
+  provider: 'https://eth.drpc.org'
+})
+```
+
+The manager's default signer must support derivation. Non-derivable signers, such as private-key signers, can be registered by name and used to retrieve signer-backed accounts:
+
+```javascript title="Register A Private-Key Signer"
+import WalletManagerEvm from '@tetherto/wdk-wallet-evm'
+import { PrivateKeySignerEvm } from '@tetherto/wdk-wallet-evm/signers'
+
+const wallet = new WalletManagerEvm(seedPhrase, {
+  provider: 'https://eth.drpc.org'
+})
+
+wallet.addSigner('treasury', new PrivateKeySignerEvm(privateKey))
+
+const treasury = await wallet.getAccount('treasury')
+```
+
+For a standalone account backed by one private key, construct the account directly:
+
+```javascript title="Standalone Private-Key Account"
+import { WalletAccountEvm } from '@tetherto/wdk-wallet-evm'
+
+const account = WalletAccountEvm.fromPrivateKey(privateKey, {
+  provider: 'https://eth.drpc.org'
+})
+```
+
 ## Account Configuration
 
 Both `WalletAccountEvm` and `WalletAccountReadOnlyEvm` share similar configuration options:

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/manage-accounts.mdx
@@ -31,6 +31,31 @@ const customAddress = await customAccount.getAddress()
 console.log('Custom account address:', customAddress)
 ```
 
+## Retrieve Accounts from Named Signers
+
+Register named signers when an account should use signing material outside the manager's default seed. The default manager signer must be derivable; non-derivable private-key signers can be registered by name.
+
+```javascript title="Register A Named Signer"
+import WalletManagerEvm from '@tetherto/wdk-wallet-evm'
+import { PrivateKeySignerEvm } from '@tetherto/wdk-wallet-evm/signers'
+
+const wallet = new WalletManagerEvm(seedPhrase, {
+  provider: 'https://eth.drpc.org'
+})
+
+wallet.addSigner('treasury', new PrivateKeySignerEvm(privateKey))
+
+const treasuryAccount = await wallet.getAccount('treasury')
+console.log('Treasury address:', await treasuryAccount.getAddress())
+```
+
+If a registered signer supports derivation, you can derive accounts from that signer by passing `signerName`:
+
+```javascript title="Derive From A Named Signer"
+const account = await wallet.getAccount(2, { signerName: 'hardware-root' })
+const customAccount = await wallet.getAccountByPath("0'/0/5", { signerName: 'hardware-root' })
+```
+
 ## Iterate Over Multiple Accounts
 
 You can loop through accounts to inspect addresses and balances in bulk.

--- a/content/docs/sdk/wallet-modules/wallet-evm/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/guides/send-transactions.mdx
@@ -5,7 +5,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-This guide explains how to [send EVM transactions with EIP-1559 gas parameters](#send-with-eip-1559-gas-parameters), [send legacy gas transactions](#send-with-legacy-gas-parameters), [sign without broadcasting](#sign-without-broadcasting), [estimate fees](#estimate-transaction-fees), [cap transaction fees](#cap-transaction-fees), and [use dynamic fee rates](#use-dynamic-fee-rates).
+This guide explains how to [send EVM transactions with EIP-1559 gas parameters](#send-with-eip-1559-gas-parameters), [send legacy gas transactions](#send-with-legacy-gas-parameters), [deploy contracts](#deploy-a-contract), [sign without broadcasting](#sign-without-broadcasting), [estimate fees](#estimate-transaction-fees), [cap transaction fees](#cap-transaction-fees), and [use dynamic fee rates](#use-dynamic-fee-rates).
 
 <Callout type="warn">
 **BigInt Usage:** Always use `BigInt` (the `n` suffix) for monetary values to avoid precision loss with large numbers.
@@ -38,6 +38,22 @@ const legacyResult = await account.sendTransaction({
   gasLimit: 21000
 })
 console.log('Transaction hash:', legacyResult.hash)
+```
+
+## Deploy a Contract
+
+For contract-creation transactions, omit `to` or pass `to: null` and provide the deployment bytecode in `data`.
+
+```javascript title="Contract Creation"
+const result = await account.sendTransaction({
+  to: null,
+  value: 0n,
+  data: contractBytecode,
+  maxFeePerGas: 30000000000n,
+  maxPriorityFeePerGas: 2000000000n
+})
+
+console.log('Deployment transaction:', result.hash)
 ```
 
 ## Sign Without Broadcasting

--- a/content/docs/sdk/wallet-modules/wallet-evm/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm/index.mdx
@@ -15,7 +15,9 @@ Use the EVM wallet module for standard Ethereum-compatible accounts where users 
 - **EVM Address Support**: Generate and manage Ethereum-compatible addresses using ethers.js
 - **Message Signing**: Sign and verify messages using EVM cryptography
 - **Offline Transaction Signing**: Sign EVM transactions with `signTransaction()` without broadcasting them
+- **Signer Abstraction**: Use seed-backed or private-key-backed signers from `@tetherto/wdk-wallet-evm/signers`, including named signer account retrieval.
 - **Transaction Management**: Send transactions and get fee estimates with EIP-1559 support
+- **Contract Deployment Transactions**: Send or sign contract-creation transactions by omitting `to` or passing `to: null`.
 - **ERC20 Support**: Query native token and ERC20 token balances using smart contract interactions
 - **Batch Token Balance Queries**: Fetch balances for multiple ERC20 tokens in one call with `getTokenBalances`
 - **TypeScript Support**: Full TypeScript definitions included

--- a/content/docs/sdk/wallet-modules/wallet-tron/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/api-reference.mdx
@@ -37,14 +37,14 @@ new WalletManagerTron(seed, config?)
   - `provider` (`string | TronWeb | Array<string | TronWeb>`, optional): Tron RPC endpoint URL, TronWeb instance, or ordered failover list
   - `retries` (number, optional): Additional failover attempts when `provider` is an array (default: 3)
   - `transferMaxFee` (`number | bigint`, optional): Maximum fee amount for TRC20 transfer operations (in sun)
-  - `transactionMaxFee` (`number | bigint`, optional): Maximum fee amount for native TRX `sendTransaction()` and `signTransaction()` operations (in sun)
+  - `transactionMaxFee` (`number | bigint`, optional): Maximum fee amount for `sendTransaction()` and `signTransaction()` operations (in sun)
 
 **Example:**
 ```javascript
 const wallet = new WalletManagerTron(seedPhrase, {
   provider: 'https://api.trongrid.io', // Tron RPC endpoint
   transferMaxFee: 10000000n, // Maximum TRC20 transfer fee in sun
-  transactionMaxFee: 10000000n // Maximum native TRX send/sign fee in sun
+  transactionMaxFee: 10000000n // Maximum send/sign transaction fee in sun
 })
 
 // Or with TronWeb instance
@@ -158,7 +158,7 @@ new WalletAccountTron(seed, path, config?)
 const account = new WalletAccountTron(seedPhrase, "0'/0/0", {
   provider: 'https://api.trongrid.io',
   transferMaxFee: 10000000n, // Maximum TRC20 transfer fee in sun
-  transactionMaxFee: 10000000n // Maximum native TRX send/sign fee in sun
+  transactionMaxFee: 10000000n // Maximum send/sign transaction fee in sun
 })
 ```
 
@@ -169,8 +169,8 @@ const account = new WalletAccountTron(seedPhrase, "0'/0/0", {
 | `getAddress()` | Returns the account's Tron address | `Promise\<string\>` | - |
 | `sign(message)` | Signs a message using the account's private key | `Promise\<string\>` | - |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
-| `signTransaction(tx)` | Signs a native TRX transaction without broadcasting it | `Promise\<SignedTransaction\>` | If no provider or fee exceeds `transactionMaxFee` |
-| `sendTransaction(tx)` | Sends a Tron transaction | `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` | If no provider |
+| `signTransaction(tx)` | Signs a Tron transaction without broadcasting it | `Promise\<SignedTransaction\>` | If no provider, fee exceeds `transactionMaxFee`, or a pre-built transaction owner does not match the account |
+| `sendTransaction(tx)` | Sends a Tron transaction | `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` | If no provider, fee exceeds `transactionMaxFee`, or a pre-built transaction owner does not match the account |
 | `quoteSendTransaction(tx)` | Estimates the fee for a Tron transaction | `Promise\<{fee: bigint, activationFee: bigint}\>` | If no provider |
 | `transfer(options)` | Transfers TRC20 tokens to another address | `Promise\<{hash: string, fee: bigint}\>` | If no provider or fee exceeds `transferMaxFee` |
 | `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` | If no provider |
@@ -222,18 +222,17 @@ console.log('Signature valid:', isValid)
 ```
 
 ##### `signTransaction(tx)`
-Signs a native TRX transaction and returns the signed transaction object. This method does not broadcast the transaction.
+Signs a Tron transaction and returns the signed transaction object. This method does not broadcast the transaction.
 
 **Parameters:**
-- `tx` (TronTransaction): The transaction object
-  - `to` (string): Recipient Tron address (e.g., 'T...')
-  - `value` (number | bigint): Amount in sun (1 TRX = 1,000,000 sun)
+- `tx` (TronTransaction): Native TRX transfer, smart-contract call descriptor, or pre-built TronWeb transaction
 
 **Returns:** `Promise\<SignedTransaction\>` - Signed Tron transaction object with a `signature` array
 
 **Throws:**
 - Error if no TronWeb provider is configured
 - Error if fee exceeds `transactionMaxFee` when configured
+- Error if a pre-built transaction is owned by a different account
 
 **Example:**
 ```javascript
@@ -246,18 +245,17 @@ console.log('Signed transaction:', signedTransaction)
 ```
 
 ##### `sendTransaction(tx)`
-Sends a TRX transaction and returns the result with hash, fee, and activation fee details.
+Sends a Tron transaction and returns the result with hash, fee, and activation fee details.
 
 **Parameters:**
-- `tx` (TronTransaction): The transaction object
-  - `to` (string): Recipient Tron address (e.g., 'T...')
-  - `value` (number | bigint): Amount in sun (1 TRX = 1,000,000 sun)
+- `tx` (TronTransaction): Native TRX transfer, smart-contract call descriptor, or pre-built TronWeb transaction
 
 **Returns:** `Promise\<{hash: string, fee: bigint, activationFee: bigint}\>` - Transaction hash, total fee in sun, and the portion used for account activation
 
 **Throws:** 
 - Error if no TronWeb provider is configured
 - Error if fee exceeds `transactionMaxFee` when configured
+- Error if a pre-built transaction is owned by a different account
 
 **Example:**
 ```javascript
@@ -271,7 +269,7 @@ console.log('Activation fee:', result.activationFee, 'sun')
 ```
 
 ##### `quoteSendTransaction(tx)`
-Estimates the bandwidth and activation fee cost for a TRX transaction.
+Estimates the cost for a Tron transaction. Quotes include bandwidth for every transaction, energy for smart-contract execution, and activation fee for native transfers to inactive recipients.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object (same as sendTransaction)
@@ -451,7 +449,7 @@ const readOnlyAccount = new WalletAccountReadOnlyTron('TLyqzVGLV1srkB7dToTAEqgDS
 |--------|-------------|---------|--------|
 | `getBalance()` | Returns the native TRX balance (in sun) | `Promise\<bigint\>` | If no provider |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific TRC20 token | `Promise\<bigint\>` | If no provider |
-| `quoteSendTransaction(tx)` | Estimates the fee for a TRX transaction | `Promise\<{fee: bigint, activationFee: bigint}\>` | If no provider |
+| `quoteSendTransaction(tx)` | Estimates the fee for a Tron transaction | `Promise\<{fee: bigint, activationFee: bigint}\>` | If no provider |
 | `quoteTransfer(options)` | Estimates the fee for a TRC20 transfer | `Promise\<{fee: bigint}\>` | If no provider |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise\<TronTransactionReceipt \| null\>` | If no provider |
@@ -486,7 +484,7 @@ console.log('USDT balance:', tokenBalance)
 ```
 
 ##### `quoteSendTransaction(tx)`
-Estimates the bandwidth and activation fee cost for a TRX transaction.
+Estimates the cost for a Tron transaction. Quotes include bandwidth for every transaction, energy for smart-contract execution, and activation fee for native transfers to inactive recipients.
 
 **Parameters:**
 - `tx` (TronTransaction): The transaction object
@@ -540,18 +538,31 @@ interface TronWalletConfig {
   provider?: string | TronWeb | Array<string | TronWeb>; // RPC, TronWeb, or failover list
   retries?: number;                   // Additional failover attempts, default 3
   transferMaxFee?: number | bigint;   // Maximum TRC20 transfer fee in sun
-  transactionMaxFee?: number | bigint; // Maximum native TRX send/sign fee in sun
+  transactionMaxFee?: number | bigint; // Maximum sendTransaction/signTransaction fee in sun
 }
 ```
 
 ### TronTransaction
 
 ```typescript
-interface TronTransaction {
+type TronTransaction = TronTrxTransfer | TronSmartContractCall | Transaction;
+
+interface TronTrxTransfer {
   to: string;                         // Recipient Tron address
   value: number | bigint;             // Amount in sun (1 TRX = 1,000,000 sun)
 }
+
+interface TronSmartContractCall {
+  contractAddress: string;            // Smart contract address to call
+  functionSelector: string;           // Function selector, e.g. 'transfer(address,uint256)'
+  parameters?: ContractFunctionParameter[];
+  options?: TriggerSmartContractOptions;
+}
+
+type Transaction = import('tronweb').Types.Transaction;
 ```
+
+`ContractFunctionParameter` and `TriggerSmartContractOptions` are TronWeb types used by `transactionBuilder.triggerSmartContract()`. Pre-built `Transaction` values are the unsigned transaction objects returned by TronWeb transaction-builder methods.
 
 ### TransferOptions
 

--- a/content/docs/sdk/wallet-modules/wallet-tron/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/configuration.mdx
@@ -18,7 +18,7 @@ const config = {
   ], // Tron RPC endpoints; array enables failover
   retries: 3, // Additional failover attempts when provider is an array
   transferMaxFee: 10000000n, // Maximum TRC20 transfer fee in sun (optional)
-  transactionMaxFee: 10000000n // Maximum native TRX send/sign fee in sun (optional)
+  transactionMaxFee: 10000000n // Maximum sendTransaction/signTransaction fee in sun (optional)
 }
 
 const wallet = new WalletManagerTron(seedPhrase, config)
@@ -32,7 +32,7 @@ import { WalletAccountTron } from '@tetherto/wdk-wallet-tron'
 const accountConfig = {
   provider: 'https://api.trongrid.io',
   transferMaxFee: 10000000n, // Maximum TRC20 transfer fee in sun (optional)
-  transactionMaxFee: 10000000n // Maximum native TRX send/sign fee in sun (optional)
+  transactionMaxFee: 10000000n // Maximum sendTransaction/signTransaction fee in sun (optional)
 }
 
 const account = new WalletAccountTron(seedPhrase, "0'/0/0", accountConfig)
@@ -106,7 +106,7 @@ const config = {
 
 ### Transaction Max Fee
 
-The `transactionMaxFee` option sets the maximum fee amount, in sun, for native TRX `sendTransaction()` and `signTransaction()` operations. This is separate from `transferMaxFee`, which applies to TRC20 transfers.
+The `transactionMaxFee` option sets the maximum fee amount, in sun, for `sendTransaction()` and `signTransaction()` operations. This includes native TRX transfers, smart-contract call descriptors, and pre-built TronWeb transactions. This is separate from `transferMaxFee`, which applies to the dedicated TRC20 `transfer()` API.
 
 **Type:** `number | bigint` (optional)
 **Unit:** Sun (1 TRX = 1,000,000 Sun)
@@ -118,7 +118,7 @@ const config = {
 }
 ```
 
-Native TRX send quotes and results include `activationFee` when the recipient account must be activated.
+Native TRX send quotes and results include `activationFee` when the recipient account must be activated. Smart-contract and pre-built transaction quotes include bandwidth and energy costs where applicable.
 
 <Cards>
 <Card title="Node.js Quickstart" href="/start-building/nodejs-bare-quickstart">

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/handle-errors.mdx
@@ -27,6 +27,8 @@ try {
     console.error('Not enough TRX to complete transaction')
   } else if (error.message.includes('Exceeded maximum fee')) {
     console.error('The transaction fee exceeds transactionMaxFee')
+  } else if (error.message.toLowerCase().includes('transaction owner')) {
+    console.error('The pre-built transaction is owned by a different account')
   } else {
     console.error('Transaction failed:', error.message)
   }
@@ -60,7 +62,9 @@ try {
 
 ### Manage Fee Limits
 
-Set `transactionMaxFee` when creating the wallet to cap native TRX `sendTransaction()` and `signTransaction()` costs. Set `transferMaxFee` separately for TRC20 `transfer()` costs. Native TRX quotes and results include `activationFee` when the recipient account must be activated.
+Set `transactionMaxFee` when creating the wallet to cap `sendTransaction()` and `signTransaction()` costs for native TRX transfers, smart-contract call descriptors, and pre-built TronWeb transactions. Set `transferMaxFee` separately for TRC20 `transfer()` costs. Native TRX quotes and results include `activationFee` when the recipient account must be activated.
+
+For pre-built TronWeb transactions, WDK verifies that the transaction owner address matches the wallet account address before signing or broadcasting.
 
 You can retrieve current network rates using [`wallet.getFeeRates()`](/sdk/wallet-modules/wallet-tron/api-reference):
 

--- a/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/guides/send-transactions.mdx
@@ -1,11 +1,11 @@
 ---
-title: Send TRX
-description: Send native TRX and estimate transaction fees on Tron.
+title: Send TRX and Transactions
+description: Send native TRX, smart-contract calls, and pre-built TronWeb transactions on Tron.
 docType: how-to
 schemaType: TechArticle
 ---
 
-This guide explains how to [send native TRX](#send-native-trx), [estimate transaction fees](#estimate-transaction-fees), [cap transaction fees](#cap-transaction-fees), [sign without broadcasting](#sign-without-broadcasting), and [use dynamic fee rates](#use-dynamic-fee-rates).
+This guide explains how to [send native TRX](#send-native-trx), [send smart-contract calls](#send-smart-contract-calls), [send pre-built TronWeb transactions](#send-pre-built-tronweb-transactions), [estimate transaction fees](#estimate-transaction-fees), [cap transaction fees](#cap-transaction-fees), [sign without broadcasting](#sign-without-broadcasting), and [use dynamic fee rates](#use-dynamic-fee-rates).
 
 <Callout type="info">
 On Tron, values are expressed in sun (1 TRX = 1,000,000 sun).
@@ -25,9 +25,51 @@ console.log('Transaction fee:', result.fee, 'sun')
 console.log('Activation fee:', result.activationFee, 'sun')
 ```
 
+## Send Smart-Contract Calls
+
+`sendTransaction()`, `quoteSendTransaction()`, and `signTransaction()` also accept smart-contract call descriptors. WDK builds a TronWeb `TriggerSmartContract` transaction from the contract address, function selector, parameters, and optional trigger options.
+
+```javascript title="Send A Smart-Contract Call"
+const result = await account.sendTransaction({
+  contractAddress: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  functionSelector: 'transfer(address,uint256)',
+  parameters: [
+    { type: 'address', value: 'TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH' },
+    { type: 'uint256', value: 1000000 }
+  ],
+  options: {
+    feeLimit: 20_000_000
+  }
+})
+
+console.log('Transaction hash:', result.hash)
+console.log('Total fee:', result.fee, 'sun')
+```
+
+Smart-contract quotes include bandwidth plus the net energy cost after the sender's available resources are considered.
+
+## Send Pre-built TronWeb Transactions
+
+Pass a pre-built TronWeb transaction when you need a transaction type that WDK does not model directly, such as staking or voting. This example uses `sendTrx()` for brevity; the same pattern works with other TronWeb transaction-builder methods that return an unsigned transaction owned by the account.
+
+```javascript title="Send A Pre-built TronWeb Transaction"
+const address = await account.getAddress()
+
+const transaction = await tronWeb.transactionBuilder.sendTrx(
+  'TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH',
+  1_000_000,
+  address
+)
+
+const result = await account.sendTransaction(transaction)
+console.log('Transaction hash:', result.hash)
+```
+
+Before signing or sending a pre-built transaction, WDK checks that the transaction owner address matches the wallet account address.
+
 ## Estimate Transaction Fees
 
-You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx). The quote includes `activationFee`, which is non-zero when the recipient account must be activated:
+You can get a fee estimate before sending using [`account.quoteSendTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#quotesendtransactiontx). For native TRX transfers, the quote includes `activationFee`, which is non-zero when the recipient account must be activated:
 
 ```javascript title="Quote Transaction Fee"
 const quote = await account.quoteSendTransaction({
@@ -40,7 +82,7 @@ console.log('Activation fee:', quote.activationFee, 'sun')
 
 ## Cap Transaction Fees
 
-Set [`transactionMaxFee`](/sdk/wallet-modules/wallet-tron/configuration#transaction-max-fee) when you create the wallet to stop native `sendTransaction()` and `signTransaction()` calls if the estimated fee exceeds your limit.
+Set [`transactionMaxFee`](/sdk/wallet-modules/wallet-tron/configuration#transaction-max-fee) when you create the wallet to stop `sendTransaction()` and `signTransaction()` calls if the estimated fee exceeds your limit.
 
 ```javascript title="Cap Native TRX Fees"
 const wallet = new WalletManagerTron(seedPhrase, {
@@ -51,7 +93,7 @@ const wallet = new WalletManagerTron(seedPhrase, {
 
 ## Sign Without Broadcasting
 
-Use [`account.signTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#signtransactiontx) when you need a signed TRX transaction but do not want WDK to broadcast it.
+Use [`account.signTransaction()`](/sdk/wallet-modules/wallet-tron/api-reference#signtransactiontx) when you need a signed Tron transaction but do not want WDK to broadcast it.
 
 ```javascript title="Sign TRX Transaction"
 const signedTransaction = await account.signTransaction({

--- a/content/docs/sdk/wallet-modules/wallet-tron/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-tron/index.mdx
@@ -15,6 +15,7 @@ Use the TRON wallet module for standard TRON accounts where users can handle reg
 - **Tron Address Support:** Generate and manage Tron addresses
 - **Message Signing:** Sign and verify messages using Tron cryptography
 - **Transaction Management**: Send transactions and get fee estimates, including activation fee details for native TRX sends
+- **Arbitrary Transactions**: Quote, sign, and send smart-contract call descriptors or pre-built TronWeb transactions in addition to native TRX transfers
 - **TRC20 Support:** Query native TRX and TRC20 token balances.
 - **TypeScript Support**: Full TypeScript definitions included
 - **Memory Safety**: Secure private key management with automatic memory cleanup

--- a/content/docs/tools/price-rates/api-reference.mdx
+++ b/content/docs/tools/price-rates/api-reference.mdx
@@ -31,11 +31,11 @@ new BitfinexPricingClient(options?)
 
 ##### `getCurrentPrice(base, quote)`
 
-Uses Bitfinex's `/calc/fx/batch` endpoint. If Bitfinex cannot quote the pair directly, the client tries a two-leg USD pivot. Returns `null` when the pair cannot be resolved.
+Uses Bitfinex's `/calc/fx/batch` endpoint. Returns `null` when Bitfinex cannot quote the pair directly. The client does not try a two-leg USD pivot.
 
 ```javascript title="Current Price"
 const price = await client.getCurrentPrice('BTC', 'USD')
-const brl = await client.getCurrentPrice('BTC', 'BRL')
+const unsupported = await client.getCurrentPrice('BTC', 'BRL') // null when unsupported
 ```
 
 ##### `getMultiCurrentPrices(pairs)`
@@ -45,7 +45,8 @@ Returns current prices in the same order as the input pairs. Each unresolved pai
 ```javascript title="Batch Current Prices"
 const prices = await client.getMultiCurrentPrices([
   { from: 'BTC', to: 'USD' },
-  { from: 'ETH', to: 'BRL' }
+  { from: 'ETH', to: 'USD' },
+  { from: 'BTC', to: 'BRL' }
 ])
 ```
 
@@ -153,8 +154,8 @@ Implement this interface to plug your data source into `PricingProvider`.
 
 ## Notes
 
-- Uses Bitfinex Public HTTP API (`/v2/calc/fx/batch`, `/v2/tickers`, and `/v2/candles`) under the hood for the Bitfinex client
-- Current-price lookups can pivot through USD for fiat pairs Bitfinex does not quote directly; historical prices and `getMultiPriceData()` do not use that pivot
+- Uses Bitfinex Public HTTP API (`/v2/calc/fx/batch`, `/v2/tickers`, and `/v2/tickers/hist`) under the hood for the Bitfinex client
+- Bitfinex lookups support only pairs Bitfinex quotes directly. Unsupported current-price and price-data pairs return `null`; unsupported historical pairs return an empty series.
 - Use [`@tetherto/wdk-pricing-coingecko-http`](/sdk/pricing-modules/pricing-coingecko-http/) when you need a CoinGecko-backed `PricingClient`
 - Provider caches last price per pair using in-memory store and TTL
 

--- a/content/docs/tools/price-rates/configuration.mdx
+++ b/content/docs/tools/price-rates/configuration.mdx
@@ -17,13 +17,13 @@ const client = new BitfinexPricingClient()
 
 ### Current Price
 
-Current-price lookups use Bitfinex's FX conversion endpoint. If Bitfinex cannot quote the pair directly, the client tries a two-leg `from -> USD -> to` conversion. If the pair still cannot be resolved, the result is `null`.
+Current-price lookups use Bitfinex's FX conversion endpoint. The client returns a price only when Bitfinex can quote the pair directly. Unsupported pairs return `null`; the client does not try a USD-pivot fallback.
 
 ```javascript title="Get Current Price"
 const price = await client.getCurrentPrice('BTC', 'USD')
-const brlPrice = await client.getCurrentPrice('BTC', 'BRL') // resolved through USD when available
+const unsupported = await client.getCurrentPrice('BTC', 'BRL') // null when Bitfinex has no direct quote
 
-if (price === null) {
+if (unsupported === null) {
   // Show an unavailable-price state in your UI
 }
 ```
@@ -35,7 +35,8 @@ Batch lookups return results in the same order as the input list. Entries that c
 ```javascript title="Get Batch Current Prices"
 const prices = await client.getMultiCurrentPrices([
   { from: 'BTC', to: 'USD' },
-  { from: 'ETH', to: 'BRL' }
+  { from: 'ETH', to: 'USD' },
+  { from: 'BTC', to: 'BRL' } // null when unsupported
 ])
 ```
 
@@ -77,7 +78,7 @@ const provider = new PricingProvider({
 const last = await provider.getLastPrice('BTC', 'USD')
 const prices = await provider.getMultiLastPrices([
   { from: 'BTC', to: 'USD' },
-  { from: 'ETH', to: 'BRL' }
+  { from: 'ETH', to: 'USD' }
 ])
 const hist = await provider.getHistoricalPrice('BTC', 'USD', {
   start: 1709906400000,

--- a/content/docs/tools/price-rates/index.mdx
+++ b/content/docs/tools/price-rates/index.mdx
@@ -12,7 +12,7 @@ Powered by [`@tetherto/wdk-pricing-bitfinex-http`](https://github.com/tetherto/w
 ## Features
 
 - **Current Prices**: Fetch latest price for one pair or many pairs in a batch (e.g., BTC/USD)
-- **Fiat Fallback**: Resolve fiat pairs Bitfinex does not quote directly by pivoting through USD when current FX data is available
+- **Direct Bitfinex Quotes**: Return prices only for pairs Bitfinex can quote directly; unsupported pairs return `null`
 - **Historical Series**: Retrieve historical price series; long histories optionally downscaled to ≤ 100 points
 - **Provider Compatibility**: Works with `@tetherto/wdk-pricing-provider`
 - **CoinGecko Fallback**: Use `@tetherto/wdk-pricing-coingecko-http` when you want a CoinGecko-backed pricing client

--- a/content/docs/tools/react-native-core/api-reference.mdx
+++ b/content/docs/tools/react-native-core/api-reference.mdx
@@ -11,6 +11,7 @@ schemaType: APIReference
 | [`useWdkApp`](#usewdkapp) | Hook | App-level state (discriminated union) |
 | [`useWalletManager`](#usewalletmanager) | Hook | Wallet lifecycle (create, restore, lock, unlock) |
 | [`useAccount`](#useaccount) | Hook | Account operations (send, sign, verify, estimateFee) |
+| [`useProtocol`](#useprotocol) | Hook | Protocol method calls through the active worklet account |
 | [`useAddresses`](#useaddresses) | Hook | Load and query wallet addresses |
 | [`useBalance`](#usebalance) | Hook | Single asset balance with TanStack Query |
 | [`useBalancesForWallet`](#usebalancesforwallet) | Hook | Bulk balance fetch for multiple assets |
@@ -23,6 +24,7 @@ schemaType: APIReference
 | `WdkAppContextValue` | Type | Return type of `useWdkApp` |
 | `UseAccountParams` | Type | Parameters for `useAccount` |
 | `UseAccountReturn` | Type | Return type of `useAccount` |
+| `UseProtocolParams` | Type | Parameters for `useProtocol` |
 | `UseAddressesReturn` | Type | Return type of `useAddresses` |
 | `UseWalletManagerResult` | Type | Return type of `useWalletManager` |
 
@@ -319,6 +321,62 @@ const { extension } = useAccount<{ getTransfers: () => Promise<Transfer[]> }>({
 // Safe to call at any time - waits for wallet initialization internally
 const btcApi = extension()
 const transfers = await btcApi.getTransfers()
+```
+
+---
+
+## useProtocol
+
+Hook to call configured protocol modules through the active WDK worklet account. It returns a typed proxy, so each method you access is forwarded to the protocol registered for the requested account, network, type, and name.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `params.network` | `string` | Network identifier configured in `wdkConfigs` |
+| `params.accountIndex` | `number` | Account index to use for the protocol call |
+| `params.protocolType` | `'bridge' \| 'swap' \| 'lending' \| 'fiat'` | Protocol category |
+| `params.protocolName` | `string` | Registered protocol name |
+
+### Returns
+
+Returns `T`, a proxy for the protocol methods you type with the hook generic. Each method returns a promise from the worklet call.
+
+If no active account is available, protocol method calls log an error and return `undefined`.
+
+### Example
+
+```tsx
+import { useProtocol } from '@tetherto/wdk-react-native-core'
+
+type SwapProtocol = {
+  quoteSwap: (params: {
+    tokenIn: string
+    tokenOut: string
+    tokenInAmount: string
+  }) => Promise<{ tokenOutAmount: string; fee: string }>
+}
+
+function SwapQuoteScreen() {
+  const swap = useProtocol<SwapProtocol>({
+    network: 'ethereum',
+    accountIndex: 0,
+    protocolType: 'swap',
+    protocolName: 'velora',
+  })
+
+  const loadQuote = async () => {
+    const quote = await swap.quoteSwap({
+      tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      tokenInAmount: '1000000',
+    })
+
+    console.log('Quoted output:', quote?.tokenOutAmount)
+  }
+
+  return <Button title="Quote" onPress={loadQuote} />
+}
 ```
 
 ---

--- a/content/docs/tools/react-native-core/index.mdx
+++ b/content/docs/tools/react-native-core/index.mdx
@@ -7,7 +7,7 @@ description: Hooks-based React Native library for building multi-chain wallet ap
 
 ## Features
 
-- **Hooks-based architecture** - `useWdkApp`, `useWalletManager`, `useAccount`, `useBalance`, `useBalancesForWallets`, and more
+- **Hooks-based architecture** - `useWdkApp`, `useWalletManager`, `useAccount`, `useProtocol`, `useBalance`, `useBalancesForWallets`, and more
 - **TanStack Query caching** - automatic balance fetching across one or many account indices, per-token fallback for modules without batch balance support, cache invalidation, and optimistic updates
 - **Zustand state management** - persisted wallet state with MMKV storage
 - **Worklet runtime** - runs WDK in an isolated Bare worklet
@@ -156,6 +156,7 @@ WdkAppProvider
     +-- useWdkApp()         - app state (INITIALIZING, NO_WALLET, LOCKED, READY, ERROR)
     +-- useWalletManager()  - create, restore, lock, unlock, delete wallets
     +-- useAccount()        - address, send, sign, verify, estimateFee
+    +-- useProtocol()       - call bridge, swap, lending, and fiat protocol methods
     +-- useAddresses()      - load and query addresses
     +-- useBalance()            - single balance with TanStack Query
     +-- useBalancesForWallet()  - bulk balance fetch for one account index


### PR DESCRIPTION
## Summary
- Add release documentation for the July 07, July 04, and July 03 WDK package updates, plus the existing July 01 entries.
- Update EVM wallet docs for signer-backed accounts, private-key accounts, contract-creation transactions, and ERC-7702 authorization/delegation helpers.
- Update TRON wallet docs for arbitrary transaction support covering native TRX transfers, smart-contract call descriptors, and pre-built TronWeb transactions.
- Update Bitfinex pricing docs for direct Bitfinex quote behavior after removal of the USD-pivot fallback.
- Keep Worklet Bundler usage pages on the prior workflow because the v1.0.0-beta.4 npm artifact is missing built CLI/API files; the changelog calls out the source changes and artifact caveat.
- Move swap-velora-evm v1.0.0-beta.6 to its actual June 30 release date and retain the React Native Core July 01 update.

## Release references
- https://github.com/tetherto/wdk-pricing-bitfinex-http/releases/tag/v1.0.0-beta.4
- https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.8
- https://github.com/tetherto/wdk-wallet-evm/releases/tag/v1.0.0-beta.15
- https://github.com/tetherto/wdk-wallet-tron/releases/tag/v1.0.0-beta.8
- https://github.com/tetherto/wdk-wallet/releases/tag/v1.0.0-beta.13
- https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.11
- https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.4
- https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.13
- https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/releases/tag/v1.0.0-beta.6
- https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.10
- https://github.com/tetherto/wdk-protocol-swap-velora-evm/releases/tag/v1.0.0-beta.6
- https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.12

## Validation
- `git diff --check`
- `npm ci`
- `npm run check:meta`
- `npm run check:redirects`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `source ~/.nvm/nvm.sh && nvm exec 22.22.2 npm run quality`
- GitHub Docs Quality Gates passed: https://github.com/tetherto/wdk-docs/actions/runs/28869031435/job/85626564177

Notes:
- Local build/quality passes under Node 22.22.2. Node 24/25 hit the existing Next config loader issue with this repo's `NODE_OPTIONS='--import tsx/esm'` setup.
- Existing external 403/redirect and `docType` SEO messages remain warnings, not broken-link or build failures.
