### PR TITLE
Fix MCP SDK tools docs link

### DIFF
--- a/content/docs/ai/mcp-toolkit/configuration.mdx
+++ b/content/docs/ai/mcp-toolkit/configuration.mdx
@@ -201,7 +201,7 @@ server.registerTools([getAddress, getBalance, getCurrentPrice])
 
 ### Custom Tools
 
-Add your own MCP tools alongside the built-in ones using the standard `registerTool()` method (inherited from `McpServer`). See the [MCP SDK tools documentation](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/server.md#tools) for full details.
+Add your own MCP tools alongside the built-in ones using the standard `registerTool()` method (inherited from `McpServer`). See the [MCP SDK tools documentation](https://ts.sdk.modelcontextprotocol.io/v2/servers/tools) for full details.
 
 ```javascript
 server.registerTool(


### PR DESCRIPTION
## Summary
- replace the stale MCP TypeScript SDK tools source URL with the current public tools docs page
- unblock the release PR Docs Quality Gates failure caused by the external 404

## Validation
- git diff --check
- npm run check:links