### PR TITLE
Add Aptos wallet release docs

### DIFF
--- a/content/docs/sdk/all-modules.mdx
+++ b/content/docs/sdk/all-modules.mdx
@@ -30,6 +30,7 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 | [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | TRON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-tron/) |
 | [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | Gas-free transactions on TRON | [Docs](/sdk/wallet-modules/wallet-tron-gasfree/) |
 | [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | Solana blockchain wallet | [Docs](/sdk/wallet-modules/wallet-solana/) |
+| [`@tetherto/wdk-wallet-aptos`](https://github.com/tetherto/wdk-wallet-aptos) | Aptos | Aptos blockchain wallet with native APT and fungible asset support | [Docs](/sdk/wallet-modules/wallet-aptos/) |
 | [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | Spark/Lightning Bitcoin L2 wallet | [Docs](/sdk/wallet-modules/wallet-spark/) |
 
 ## Swidge Interface

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -70,6 +70,7 @@ Standard wallet implementations that use native blockchain tokens for transactio
 | [`@tetherto/wdk-wallet-spark`](https://github.com/tetherto/wdk-wallet-spark) | Spark | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-spark) |
 | [`@tetherto/wdk-wallet-tron`](https://github.com/tetherto/wdk-wallet-tron) | TRON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-tron) |
 | [`@tetherto/wdk-wallet-solana`](https://github.com/tetherto/wdk-wallet-solana) | Solana | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-solana) |
+| [`@tetherto/wdk-wallet-aptos`](https://github.com/tetherto/wdk-wallet-aptos) | Aptos | In review | [Documentation](/sdk/wallet-modules/wallet-aptos) |
 | [`@arkade-os/wdk`](https://github.com/arkade-os/arkade-wdk) | Arkade | ✅ Ready | [README](https://github.com/arkade-os/arkade-wdk#readme) |
 
 ## Account Abstraction Wallet Modules

--- a/content/docs/sdk/wallet-modules/wallet-aptos/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-aptos/api-reference.mdx
@@ -1,0 +1,152 @@
+---
+title: Wallet Aptos API Reference
+description: API reference for @tetherto/wdk-wallet-aptos.
+docType: reference
+schemaType: APIReference
+icon: Code
+---
+
+## Exports
+
+```javascript
+import WalletManagerAptos, {
+  WalletAccountAptos,
+  WalletAccountReadOnlyAptos
+} from '@tetherto/wdk-wallet-aptos'
+```
+
+## WalletManagerAptos
+
+Creates and manages seed-derived Aptos accounts.
+
+```typescript
+new WalletManagerAptos(
+  seed: string | Uint8Array,
+  config?: AptosWalletConfig
+)
+```
+
+### Methods
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `getAccount(index?)` | Returns the account at `m/44'/637'/index'/0'/0'`. | `Promise<WalletAccountAptos>` |
+| `getAccountByPath(path)` | Returns an account at a relative hardened path. | `Promise<WalletAccountAptos>` |
+| `getFeeRates()` | Returns Aptos fee rates in octas per gas unit. | `Promise<FeeRates>` |
+| `dispose()` | Clears managed account secret material. | `void` |
+
+## WalletAccountAptos
+
+Writable Aptos account with signing and transaction submission support.
+
+```typescript
+new WalletAccountAptos(
+  seed: string | Uint8Array,
+  path: string,
+  config?: AptosWalletConfig
+)
+```
+
+### Properties
+
+| Property | Description |
+|----------|-------------|
+| `index` | Index parsed from the derivation path. |
+| `path` | Relative derivation path. |
+| `keyPair` | Public/private key pair view. The private key is unavailable after `dispose()`. |
+
+### Methods
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `getAddress()` | Returns the Aptos account address. | `Promise<string>` |
+| `getBalance()` | Returns the native APT balance in octas. | `Promise<bigint>` |
+| `getTokenBalance(tokenAddress)` | Returns a fungible asset balance by metadata address. | `Promise<bigint>` |
+| `quoteSendTransaction(tx)` | Estimates fee for a native APT transfer. | `Promise<{ fee: bigint }>` |
+| `sendTransaction(tx)` | Signs and submits a native APT transfer. | `Promise<TransactionResult>` |
+| `signTransaction(tx)` | Signs a native APT transfer without broadcasting. | `Promise<SignedTransaction>` |
+| `quoteTransfer(options)` | Estimates fee for a fungible asset transfer. | `Promise<{ fee: bigint }>` |
+| `transfer(options)` | Signs and submits a fungible asset transfer. | `Promise<TransferResult>` |
+| `getTransactionReceipt(hash)` | Looks up a transaction receipt. | `Promise<TransactionReceipt \| null>` |
+| `sign(message)` | Signs a message with the account key. | `Promise<string>` |
+| `verify(message, signature)` | Verifies a message signature. | `Promise<boolean>` |
+| `toReadOnlyAccount()` | Returns a read-only account for the same address. | `Promise<WalletAccountReadOnlyAptos>` |
+| `dispose()` | Clears private key material from memory. | `void` |
+
+## WalletAccountReadOnlyAptos
+
+Read-only account for address-based reads and verification.
+
+```typescript
+new WalletAccountReadOnlyAptos(
+  address: string,
+  config?: AptosWalletConfig
+)
+```
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `getAddress()` | Returns the normalized Aptos address. | `Promise<string>` |
+| `getBalance()` | Returns the native APT balance in octas. | `Promise<bigint>` |
+| `getTokenBalance(tokenAddress)` | Returns a fungible asset balance by metadata address. | `Promise<bigint>` |
+| `quoteSendTransaction(tx)` | Estimates fee for a native APT transfer. | `Promise<{ fee: bigint }>` |
+| `quoteTransfer(options)` | Estimates fee for a fungible asset transfer. | `Promise<{ fee: bigint }>` |
+| `getTransactionReceipt(hash)` | Looks up a transaction receipt. | `Promise<TransactionReceipt \| null>` |
+| `verify(message, signature)` | Verifies a message signature. | `Promise<boolean>` |
+
+## Config Type
+
+```typescript
+type AptosWalletConfig = {
+  provider?: string
+  transferMaxFee?: number | bigint
+}
+```
+
+## Transaction Types
+
+```typescript
+type AptosTransaction = {
+  to: string
+  value: number | bigint
+}
+
+type TransferOptions = {
+  token: string
+  recipient: string
+  amount: number | bigint
+}
+```
+
+`token` is an Aptos fungible asset metadata address.
+
+## Result Types
+
+```typescript
+type TransactionResult = {
+  hash: string
+  fee: bigint
+}
+
+type TransferResult = {
+  hash: string
+  fee: bigint
+}
+```
+
+## Signed Transaction
+
+`signTransaction(tx)` returns a JSON-form signed transaction accepted by the Aptos REST API. It includes sender, sequence number, gas fields, payload, and Ed25519 signature.
+
+<Callout type="warn">
+`signTransaction()` signs native APT transfers only. Use `transfer()` for fungible asset transfers.
+</Callout>
+
+<Cards>
+<Card title="Usage" href="/sdk/wallet-modules/wallet-aptos/usage">
+Create accounts, read balances, transfer funds, and sign messages.
+</Card>
+<Card title="Configuration" href="/sdk/wallet-modules/wallet-aptos/configuration">
+Provider, network, fee, and derivation path options.
+</Card>
+</Cards>

--- a/content/docs/sdk/wallet-modules/wallet-aptos/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-aptos/configuration.mdx
@@ -1,0 +1,102 @@
+---
+title: Wallet Aptos Configuration
+description: Configuration options for @tetherto/wdk-wallet-aptos.
+docType: reference
+schemaType: TechArticle
+icon: Settings
+---
+
+Configure the Aptos wallet module with an Aptos fullnode REST endpoint. A provider is required for balance reads, fee quotes, transaction submission, and receipt polling.
+
+```javascript
+import WalletManagerAptos from '@tetherto/wdk-wallet-aptos'
+
+const wallet = new WalletManagerAptos(seedPhrase, {
+  provider: 'https://fullnode.mainnet.aptoslabs.com/v1',
+  transferMaxFee: 100000n
+})
+```
+
+## Wallet Configuration
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `provider` | `string` | Aptos fullnode REST API URL. Required for chain operations. |
+| `transferMaxFee` | `number \| bigint` | Optional maximum fee in octas for transfer operations. |
+
+## Account Configuration
+
+You can construct accounts directly when you need a specific derivation path.
+
+```javascript
+import { WalletAccountAptos } from '@tetherto/wdk-wallet-aptos'
+
+const account = new WalletAccountAptos(seedPhrase, "0'/0'/0'", {
+  provider: 'https://fullnode.mainnet.aptoslabs.com/v1',
+  transferMaxFee: 100000n
+})
+```
+
+Read-only accounts require only an address and provider configuration.
+
+```javascript
+import { WalletAccountReadOnlyAptos } from '@tetherto/wdk-wallet-aptos'
+
+const readOnlyAccount = new WalletAccountReadOnlyAptos('0x...', {
+  provider: 'https://fullnode.mainnet.aptoslabs.com/v1'
+})
+```
+
+## Network Selection
+
+Network selection is controlled by the fullnode URL.
+
+| Network | Provider URL |
+|---------|--------------|
+| Mainnet | `https://fullnode.mainnet.aptoslabs.com/v1` |
+| Testnet | `https://fullnode.testnet.aptoslabs.com/v1` |
+
+## Derivation Paths
+
+The module uses SLIP-0010 Ed25519 derivation. `getAccount(index)` derives:
+
+```text
+m/44'/637'/index'/0'/0'
+```
+
+Use `getAccountByPath(path)` to provide a relative path after `m/44'/637'/`.
+
+```javascript
+const account = await wallet.getAccountByPath("5'/0'/0'")
+```
+
+<Callout type="warn">
+Every Aptos path segment must be hardened. A path segment without an apostrophe is invalid for this module's Ed25519 derivation.
+</Callout>
+
+## Fee Limit
+
+`transferMaxFee` caps estimated transaction fees before signing and submitting transfer operations.
+
+```javascript
+const wallet = new WalletManagerAptos(seedPhrase, {
+  provider: 'https://fullnode.mainnet.aptoslabs.com/v1',
+  transferMaxFee: 100000n
+})
+```
+
+## Security Notes
+
+- Keep seed phrases and seed bytes outside logs and client-visible error reporting.
+- Use trusted fullnode endpoints for production wallets.
+- Set a fee cap for user-facing transfers.
+- Call `dispose()` on accounts and managers when secret material is no longer needed.
+
+<Cards>
+<Card title="Usage" href="/sdk/wallet-modules/wallet-aptos/usage">
+Create accounts, read balances, send transactions, and transfer fungible assets.
+</Card>
+<Card title="API Reference" href="/sdk/wallet-modules/wallet-aptos/api-reference">
+Detailed class, method, config, and type reference.
+</Card>
+</Cards>

--- a/content/docs/sdk/wallet-modules/wallet-aptos/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-aptos/index.mdx
@@ -1,0 +1,64 @@
+---
+title: Wallet Aptos Overview
+description: Overview of the @tetherto/wdk-wallet-aptos module.
+docType: explanation
+schemaType: TechArticle
+---
+
+The Aptos wallet module manages SLIP-0010 Ed25519 accounts for the Aptos blockchain through the shared WDK wallet interfaces.
+
+Use this module when an app needs Aptos account derivation, APT balances, fungible asset balances, native APT transfers, fungible asset transfers, fee quotes, message signing, and read-only account support.
+
+## Features
+
+- **BIP-39 seed support**: Accepts a mnemonic phrase or seed bytes.
+- **SLIP-0010 Ed25519 derivation**: Uses Aptos coin type `637` and hardened path segments.
+- **Aptos addresses**: Derives 32-byte Aptos addresses from the public key.
+- **Native APT support**: Sends native APT through `0x1::aptos_account::transfer`.
+- **Fungible asset support**: Reads and transfers Aptos fungible assets by metadata address.
+- **Fee estimation**: Simulates transactions to estimate gas before signing and submitting.
+- **Message signing**: Signs and verifies messages with Ed25519 keys.
+- **Read-only accounts**: Reads balances, quotes fees, verifies signatures, and checks receipts without private keys.
+- **Bare runtime compatibility**: Uses the Aptos fullnode REST API over `fetch` instead of the Aptos SDK at runtime.
+
+## Supported Networks
+
+| Network | Chain ID | Fullnode example |
+|---------|----------|------------------|
+| Aptos Mainnet | `1` | `https://fullnode.mainnet.aptoslabs.com/v1` |
+| Aptos Testnet | `2` | `https://fullnode.testnet.aptoslabs.com/v1` |
+
+## Aptos-Specific Behavior
+
+| Area | Behavior |
+|------|----------|
+| Default derivation path | `m/44'/637'/account'/0'/0'` |
+| `getAccount(index)` mapping | Uses `index` as the `account` segment. |
+| Token model | Uses Aptos fungible asset metadata addresses, not coin type tags. |
+| APT units | APT balances and fees are returned in octas. |
+| Token transfers | `transfer()` builds and submits `0x1::primary_fungible_store::transfer`. |
+| Offline signing | `signTransaction()` supports native APT transfers. Use `transfer()` for fungible asset transfers. |
+
+<Callout type="info">
+All Aptos derivation path segments are hardened because the module uses Ed25519 with SLIP-0010 derivation.
+</Callout>
+
+## Next Steps
+
+<Cards>
+<Card title="Configuration" href="/sdk/wallet-modules/wallet-aptos/configuration">
+Configure Aptos fullnode access, derivation paths, and fee limits.
+</Card>
+<Card title="Usage" href="/sdk/wallet-modules/wallet-aptos/usage">
+Install the package, create accounts, read balances, send APT, transfer fungible assets, and sign messages.
+</Card>
+<Card title="API Reference" href="/sdk/wallet-modules/wallet-aptos/api-reference">
+Review manager, account, read-only account, config, transaction, and result types.
+</Card>
+</Cards>
+
+---
+
+## Need Help?
+
+<SupportCards />

--- a/content/docs/sdk/wallet-modules/wallet-aptos/usage.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-aptos/usage.mdx
@@ -1,0 +1,158 @@
+---
+title: Wallet Aptos Usage
+description: Install and use @tetherto/wdk-wallet-aptos for Aptos accounts, balances, transfers, and signing.
+docType: how-to
+schemaType: TechArticle
+icon: BookOpen
+---
+
+## Install
+
+```bash
+npm install @tetherto/wdk-wallet-aptos
+```
+
+## Create a Wallet Manager
+
+```javascript
+import WalletManagerAptos from '@tetherto/wdk-wallet-aptos'
+
+const wallet = new WalletManagerAptos(seedPhrase, {
+  provider: 'https://fullnode.mainnet.aptoslabs.com/v1',
+  transferMaxFee: 100000n
+})
+
+const account = await wallet.getAccount(0)
+const address = await account.getAddress()
+```
+
+## Manage Accounts
+
+```javascript
+const first = await wallet.getAccount(0)
+const second = await wallet.getAccount(1)
+
+const custom = await wallet.getAccountByPath("5'/0'/0'")
+
+console.log(await first.getAddress())
+console.log(await second.getAddress())
+console.log(await custom.getAddress())
+```
+
+`getAccount(index)` maps to `m/44'/637'/index'/0'/0'`.
+
+## Read Balances
+
+```javascript
+const aptBalance = await account.getBalance()
+console.log('APT balance in octas:', aptBalance)
+
+const usdtMetadataAddress =
+  '0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b'
+
+const usdtBalance = await account.getTokenBalance(usdtMetadataAddress)
+console.log('USDT balance:', usdtBalance)
+```
+
+Read-only accounts support the same balance reads without a seed phrase.
+
+```javascript
+import { WalletAccountReadOnlyAptos } from '@tetherto/wdk-wallet-aptos'
+
+const readOnlyAccount = new WalletAccountReadOnlyAptos('0x...', {
+  provider: 'https://fullnode.mainnet.aptoslabs.com/v1'
+})
+
+const balance = await readOnlyAccount.getBalance()
+```
+
+## Send Native APT
+
+```javascript
+const quote = await account.quoteSendTransaction({
+  to: '0x...',
+  value: 100000000n
+})
+
+console.log('Estimated fee in octas:', quote.fee)
+
+const result = await account.sendTransaction({
+  to: '0x...',
+  value: 100000000n
+})
+
+console.log('Transaction hash:', result.hash)
+console.log('Fee in octas:', result.fee)
+```
+
+`sendTransaction()` submits a native APT transfer through `0x1::aptos_account::transfer`.
+
+## Transfer Fungible Assets
+
+Use the fungible asset metadata address as `token`.
+
+```javascript
+const quote = await account.quoteTransfer({
+  token: usdtMetadataAddress,
+  recipient: '0x...',
+  amount: 1000000n
+})
+
+console.log('Estimated fee in octas:', quote.fee)
+
+const result = await account.transfer({
+  token: usdtMetadataAddress,
+  recipient: '0x...',
+  amount: 1000000n
+})
+
+console.log('Transfer hash:', result.hash)
+console.log('Fee in octas:', result.fee)
+```
+
+`transfer()` submits `0x1::primary_fungible_store::transfer` and can auto-create the recipient primary store.
+
+## Sign and Verify Messages
+
+```javascript
+const message = 'Hello, Aptos'
+const signature = await account.sign(message)
+
+const readOnly = await account.toReadOnlyAccount()
+const valid = await readOnly.verify(message, signature)
+
+console.log('Signature valid:', valid)
+```
+
+## Sign Native APT Transfers Offline
+
+`signTransaction()` signs a native APT transfer without broadcasting it.
+
+```javascript
+const signed = await account.signTransaction({
+  to: '0x...',
+  value: 100000000n
+})
+
+console.log('Signed Aptos transaction:', signed)
+```
+
+<Callout type="info">
+Offline signing is for native APT transfers. Fungible asset transfers are built and submitted through `transfer()`.
+</Callout>
+
+## Dispose Secret Material
+
+```javascript
+account.dispose()
+wallet.dispose()
+```
+
+<Cards>
+<Card title="Configuration" href="/sdk/wallet-modules/wallet-aptos/configuration">
+Provider, fee, network, and derivation path configuration.
+</Card>
+<Card title="API Reference" href="/sdk/wallet-modules/wallet-aptos/api-reference">
+Detailed method and type reference.
+</Card>
+</Cards>


### PR DESCRIPTION
## Summary

- Add draft documentation for the Aptos wallet module.
- Document installation, configuration, usage, API surface, and SDK module listings.
- Mark the module as in review pending a non-placeholder package release.

## Release status

`@tetherto/wdk-wallet-aptos` currently resolves to the `0.0.0` npm placeholder. Keep this PR as draft until the package is released.

Source PR checked: `tetherto/wdk-wallet-aptos#1`.

## Validation

- `npm ci`
- `npm run check:meta`
- `npm run check:redirects`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npm run build`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npm run quality`
