### PR TITLE
Fix published package names in docs

### DIFF
--- a/content/docs/resources/concepts.mdx
+++ b/content/docs/resources/concepts.mdx
@@ -14,7 +14,7 @@ Account Abstraction is a blockchain technology that separates the concept of a u
 
 WDK provides Account Abstraction support through specialized wallet modules:
 
-- `@tetherto/wdk-wallet-evm-erc4337` - EVM chains with ERC-4337 standard
+- `@tetherto/wdk-wallet-evm-erc-4337` - EVM chains with ERC-4337 standard
 - `@tetherto/wdk-wallet-ton-gasless` - TON blockchain with gasless transactions
 - `@tetherto/wdk-wallet-tron-gasfree` - TRON blockchain with gas-free transactions
 

--- a/content/docs/sdk/all-modules.mdx
+++ b/content/docs/sdk/all-modules.mdx
@@ -13,7 +13,7 @@ The orchestrator that manages all WDK modules.
 
 | Module | Description | Documentation |
 |--------|-------------|---------------|
-| [`@tetherto/wdk-core`](https://github.com/tetherto/wdk-core) | Central orchestrator for all WDK modules | [Docs](/sdk/core-module/) |
+| [`@tetherto/wdk`](https://github.com/tetherto/wdk) | Central orchestrator for all WDK modules | [Docs](/sdk/core-module/) |
 
 ## Wallet Modules
 
@@ -23,7 +23,7 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 |--------|------------|-------------|---------------|
 | [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | Bitcoin SegWit wallet with BIP-39/BIP-44 support | [Docs](/sdk/wallet-modules/wallet-btc/) |
 | [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | Ethereum and EVM-compatible chains wallet | [Docs](/sdk/wallet-modules/wallet-evm/) |
-| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-erc-4337/) |
+| [`@tetherto/wdk-wallet-evm-erc-4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-erc-4337/) |
 | [`@tetherto/wdk-wallet-evm-7702-gasless`](https://github.com/tetherto/wdk-wallet-evm-7702-gasless) | EVM | EIP-7702 gasless account abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-7702-gasless/) |
 | [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | TON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-ton/) |
 | [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | Gasless transactions on TON | [Docs](/sdk/wallet-modules/wallet-ton-gasless/) |

--- a/content/docs/sdk/wallet-modules/index.mdx
+++ b/content/docs/sdk/wallet-modules/index.mdx
@@ -81,7 +81,7 @@ Wallet implementations that support [Account Abstraction](/resources/concepts#ac
 
 | Module | Blockchain | Status | Documentation |
 |--------|------------|--------|---------------|
-| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-erc-4337) |
+| [`@tetherto/wdk-wallet-evm-erc-4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-erc-4337) |
 | [`@tetherto/wdk-wallet-evm-7702-gasless`](https://github.com/tetherto/wdk-wallet-evm-7702-gasless) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-7702-gasless) |
 | [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-ton-gasless) |
 | [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-tron-gasfree) |

--- a/content/docs/start-building/build-with-ai.mdx
+++ b/content/docs/start-building/build-with-ai.mdx
@@ -65,7 +65,7 @@ Copy the rules content below and save it at the file path for your tool.
 - Core module: `@tetherto/wdk`.
 - Wallet modules follow the pattern: `@tetherto/wdk-wallet-<chain>`.
   - Examples: `@tetherto/wdk-wallet-evm`, `@tetherto/wdk-wallet-btc`, `@tetherto/wdk-wallet-solana`, `@tetherto/wdk-wallet-ton`, `@tetherto/wdk-wallet-tron`, `@tetherto/wdk-wallet-spark`.
-- Specialized wallet modules: `@tetherto/wdk-wallet-evm-erc4337`, `@tetherto/wdk-wallet-ton-gasless`, `@tetherto/wdk-wallet-tron-gasfree`.
+- Specialized wallet modules: `@tetherto/wdk-wallet-evm-erc-4337`, `@tetherto/wdk-wallet-ton-gasless`, `@tetherto/wdk-wallet-tron-gasfree`.
 - Protocol modules follow the pattern: `@tetherto/wdk-protocol-<type>-<name>-<chain>`.
   - Examples: `@tetherto/wdk-protocol-swap-velora-evm`, `@tetherto/wdk-protocol-bridge-usdt0-evm`, `@tetherto/wdk-protocol-lending-aave-evm`.
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -3912,7 +3912,7 @@ Account Abstraction is a blockchain technology that separates the concept of a u
 
 WDK provides Account Abstraction support through specialized wallet modules:
 
-- `@tetherto/wdk-wallet-evm-erc4337` - EVM chains with ERC-4337 standard
+- `@tetherto/wdk-wallet-evm-erc-4337` - EVM chains with ERC-4337 standard
 - `@tetherto/wdk-wallet-ton-gasless` - TON blockchain with gasless transactions
 - `@tetherto/wdk-wallet-tron-gasfree` - TRON blockchain with gas-free transactions
 
@@ -4084,7 +4084,7 @@ The orchestrator that manages all WDK modules.
 
 | Module | Description | Documentation |
 |--------|-------------|---------------|
-| [`@tetherto/wdk-core`](https://github.com/tetherto/wdk-core) | Central orchestrator for all WDK modules | [Docs](/sdk/core-module/) |
+| [`@tetherto/wdk`](https://github.com/tetherto/wdk) | Central orchestrator for all WDK modules | [Docs](/sdk/core-module/) |
 
 ## Wallet Modules
 
@@ -4094,7 +4094,7 @@ Wallet modules provide blockchain-specific wallet functionality for managing add
 |--------|------------|-------------|---------------|
 | [`@tetherto/wdk-wallet-btc`](https://github.com/tetherto/wdk-wallet-btc) | Bitcoin | Bitcoin SegWit wallet with BIP-39/BIP-44 support | [Docs](/sdk/wallet-modules/wallet-btc/) |
 | [`@tetherto/wdk-wallet-evm`](https://github.com/tetherto/wdk-wallet-evm) | EVM | Ethereum and EVM-compatible chains wallet | [Docs](/sdk/wallet-modules/wallet-evm/) |
-| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-erc-4337/) |
+| [`@tetherto/wdk-wallet-evm-erc-4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ERC-4337 Account Abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-erc-4337/) |
 | [`@tetherto/wdk-wallet-evm-7702-gasless`](https://github.com/tetherto/wdk-wallet-evm-7702-gasless) | EVM | EIP-7702 gasless account abstraction for EVM chains | [Docs](/sdk/wallet-modules/wallet-evm-7702-gasless/) |
 | [`@tetherto/wdk-wallet-ton`](https://github.com/tetherto/wdk-wallet-ton) | TON | TON blockchain wallet | [Docs](/sdk/wallet-modules/wallet-ton/) |
 | [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | Gasless transactions on TON | [Docs](/sdk/wallet-modules/wallet-ton-gasless/) |
@@ -5671,7 +5671,7 @@ Community modules should:
 
 ## WDK Core
 URL: https://docs.wdk.tether.io/sdk/core-module
-Description: Overview of the @tetherto/wdk-core module
+Description: Overview of the @tetherto/wdk module
 
 This package serves as the main entry point and **orchestrator for all WDK wallet and protocol modules**, allowing you to register and manage different blockchain wallets through a single, unified interface.
 
@@ -12865,7 +12865,7 @@ Wallet implementations that support [Account Abstraction](/resources/concepts#ac
 
 | Module | Blockchain | Status | Documentation |
 |--------|------------|--------|---------------|
-| [`@tetherto/wdk-wallet-evm-erc4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-erc-4337) |
+| [`@tetherto/wdk-wallet-evm-erc-4337`](https://github.com/tetherto/wdk-wallet-evm-erc-4337) | EVM | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-evm-erc-4337) |
 | [`@tetherto/wdk-wallet-ton-gasless`](https://github.com/tetherto/wdk-wallet-ton-gasless) | TON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-ton-gasless) |
 | [`@tetherto/wdk-wallet-tron-gasfree`](https://github.com/tetherto/wdk-wallet-tron-gasfree) | TRON | ✅ Ready | [Documentation](/sdk/wallet-modules/wallet-tron-gasfree) |
 | `@tetherto/wdk-wallet-solana-jupiterz` | Solana | In progress | - |

--- a/skills/wdk/SKILL.md
+++ b/skills/wdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wdk
-description: Tether Wallet Development Kit (WDK) for building non-custodial multi-chain wallets. Use when working with @tetherto/wdk-core, wallet modules (wdk-wallet-btc, wdk-wallet-evm, wdk-wallet-evm-erc-4337, wdk-wallet-solana, wdk-wallet-spark, wdk-wallet-ton, wdk-wallet-tron, ton-gasless, tron-gasfree), and protocol modules including swidge, swap (wdk-protocol-swap-velora-evm), bridge (wdk-protocol-bridge-usdt0-evm), lending (wdk-protocol-lending-aave-evm), and fiat (wdk-protocol-fiat-moonpay). Covers wallet creation, transactions, token transfers, swidge asset routes, DEX swaps, cross-chain bridges, DeFi lending/borrowing, and fiat on/off ramps.
+description: Tether Wallet Development Kit (WDK) for building non-custodial multi-chain wallets. Use when working with @tetherto/wdk, wallet modules (wdk-wallet-btc, wdk-wallet-evm, wdk-wallet-evm-erc-4337, wdk-wallet-solana, wdk-wallet-spark, wdk-wallet-ton, wdk-wallet-tron, ton-gasless, tron-gasfree), and protocol modules including swidge, swap (wdk-protocol-swap-velora-evm), bridge (wdk-protocol-bridge-usdt0-evm), lending (wdk-protocol-lending-aave-evm), and fiat (wdk-protocol-fiat-moonpay). Covers wallet creation, transactions, token transfers, swidge asset routes, DEX swaps, cross-chain bridges, DeFi lending/borrowing, and fiat on/off ramps.
 ---
 
 # Tether WDK
@@ -63,8 +63,6 @@ When a task targets a specific chain or protocol, read the relevant reference fi
         ├── wdk-protocol-lending-aave-evm  # Aave V3 lending
         └── wdk-protocol-fiat-moonpay      # Fiat on/off ramp
 ```
-
-> **Note:** `@tetherto/wdk-core` appears in the architecture tree but the npm package is `@tetherto/wdk` — import as `import WDK from '@tetherto/wdk'`.
 
 ## npm Packages
 

--- a/src/components/wallet-module-chooser.tsx
+++ b/src/components/wallet-module-chooser.tsx
@@ -82,7 +82,7 @@ const walletModules: WalletModule[] = [
     label: "Smart accounts (ERC-4337)",
     chain: "evm",
     goals: ["gasless"],
-    packageName: "@tetherto/wdk-wallet-evm-erc4337",
+    packageName: "@tetherto/wdk-wallet-evm-erc-4337",
     docsHref: "/sdk/wallet-modules/wallet-evm-erc-4337",
     apiHref: "/sdk/wallet-modules/wallet-evm-erc-4337/api-reference",
     bestFor: "Account abstraction flows that submit UserOperations through a bundler.",


### PR DESCRIPTION
## Summary

- replace the nonexistent `@tetherto/wdk-core` package name with `@tetherto/wdk`
- correct the ERC-4337 package name to `@tetherto/wdk-wallet-evm-erc-4337` across rendered docs, the wallet chooser, the public AI docs bundle, and the WDK skill

## Why

The previous package identifiers return 404 from the public npm registry, which can lead developers and coding agents to copy install commands for packages that do not exist.

## Validation

- `git diff --check`
- `npm run check:meta`
- `npm run check:redirects`
- `LINK_CHECK_EXTERNAL=false npm run check:links`
- `npm run test:llm-md`
- `npm run build` on Node.js 22.22.2
- verified the corrected registry endpoints return 200 and the invalid endpoints return 404
