### PR TITLE
Align CLI sidebar order

### DIFF
--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -368,8 +368,6 @@ export const customTree: Node[] = [
 
   separator('CLI'),
   folder('WDK CLI', '/cli', 'Terminal', [
-    configuration('/cli/configuration'),
-    apiReference('/cli/api-reference'),
     guides([
       page('Get Started', '/cli/guides/get-started', 'Rocket'),
       page('Manage Wallets', '/cli/guides/manage-wallets', 'WalletCards'),
@@ -378,6 +376,8 @@ export const customTree: Node[] = [
       page('Use the MCP Server', '/cli/guides/use-mcp-server', 'Wand'),
       page('Handle Errors', '/cli/guides/handle-errors', 'CircleAlert'),
     ]),
+    configuration('/cli/configuration'),
+    apiReference('/cli/api-reference'),
     group('Reference', 'BookOpen', [
       page('Architecture', '/cli/reference/architecture', 'Network'),
       page('Storage Format', '/cli/reference/storage-format', 'Database'),


### PR DESCRIPTION
## Summary

- move the CLI Guides group before Configuration and API Reference
- keep the supplemental Reference group last

## Why

The CLI was the only documentation family with a Guides group placed after Configuration and API Reference. This aligns it with the existing reader flow used by the other guide-based documentation families.

## Impact

The CLI sidebar now reads Guides, Configuration, API Reference, then Reference. Routes, titles, icons, guide ordering, and page content are unchanged.

## Validation

- `npm run quality` with Node.js 22.22.2
- runtime navigation-tree assertion for the four CLI child groups
- generated production HTML order check
- `git diff --check upstream/develop...HEAD`
