### PR TITLE
Build: update PostCSS and brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@types/react-dom": "^19.1.9",
         "@vahor/next-broken-links": "^0.4.1",
         "glob": "^11.0.3",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.18",
         "remark": "^15.0.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
@@ -5730,9 +5730,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10221,15 +10221,15 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -10819,9 +10819,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -11666,9 +11666,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/react-dom": "^19.1.9",
     "@vahor/next-broken-links": "^0.4.1",
     "glob": "^11.0.3",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.18",
     "remark": "^15.0.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",


### PR DESCRIPTION
## Summary

- Updates `postcss` from `8.5.15` to `8.5.18` and raises the manifest range to `^8.5.18`, covering [#218](https://github.com/tetherto/wdk-docs/pull/218).
- Updates the three affected `brace-expansion` resolutions to `5.0.9`, `2.1.4`, and `1.1.18`, covering [#221](https://github.com/tetherto/wdk-docs/pull/221).
- Regenerates the combined lockfile from current `develop` and preserves the required nested `zod@3.25.76` entry. Both original Dependabot lockfiles removed that entry and fail at `npm ci` before the docs build starts.

This PR supersedes #218 and #221 with one `develop`-based update.

## Validation

- Node 22.22.2 and npm 10.9.7
- Clean `npm ci`: passed
- `npm ls postcss brace-expansion zod --all`: expected versions present, including nested `zod@3.25.76`
- LLM Markdown tests: 12 passed
- Full production-equivalent `npm run quality`: 324 MDX files, 2,685 links, 0 errors or warnings with external requests disabled locally
- Static export: 330 routes, 324 per-page Markdown files, 0 generated broken links
- Historical Sevalla install path (`npm install` followed by `npm run build`): passed
- Served-output smoke test: HTML, `llms.txt`, and per-page Markdown returned 200 with the expected content types; a missing route returned 404
- `git diff --check`: passed

The unmodified GitHub quality gate and a fresh Sevalla preview still need to complete. `brace-expansion@5.0.9` requires Node 20 or Node 22+, and this repository builds on Node 22.
