### PR TITLE
Improve agent-readable documentation output

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,337 +1,338 @@
 # WDK Documentation
 
-Base URL: https://docs.wdk.tether.io
-Raw markdown is available by appending `.md` to any documentation page URL.
+> Complete index of WDK documentation for building wallets and integrating WDK modules.
 
-- Welcome to WDK: https://docs.wdk.tether.io/
-- Agent Skills: https://docs.wdk.tether.io/ai/agent-skills
-- MCP Toolkit: https://docs.wdk.tether.io/ai/mcp-toolkit
-- API Reference: https://docs.wdk.tether.io/ai/mcp-toolkit/api-reference
-- Configuration: https://docs.wdk.tether.io/ai/mcp-toolkit/configuration
-- Get Started: https://docs.wdk.tether.io/ai/mcp-toolkit/get-started
-- LangChain Integration: https://docs.wdk.tether.io/ai/mcp-toolkit/langchain
-- OpenClaw (Community Skill): https://docs.wdk.tether.io/ai/openclaw
-- x402: https://docs.wdk.tether.io/ai/x402
-- WDK CLI: https://docs.wdk.tether.io/cli
-- API Reference: https://docs.wdk.tether.io/cli/api-reference
-- Configuration: https://docs.wdk.tether.io/cli/configuration
-- Custom Networks: https://docs.wdk.tether.io/cli/guides/custom-networks
-- Get Started: https://docs.wdk.tether.io/cli/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/cli/guides/handle-errors
-- Manage Tokens: https://docs.wdk.tether.io/cli/guides/manage-tokens
-- Manage Wallets: https://docs.wdk.tether.io/cli/guides/manage-wallets
-- Use the MCP Server: https://docs.wdk.tether.io/cli/guides/use-mcp-server
-- Architecture: https://docs.wdk.tether.io/cli/reference/architecture
-- Security Model: https://docs.wdk.tether.io/cli/reference/security-model
-- Storage Format: https://docs.wdk.tether.io/cli/reference/storage-format
-- React Native Starter (Alpha): https://docs.wdk.tether.io/examples-and-starters/react-native-starter
-- About WDK: https://docs.wdk.tether.io/overview/about
-- Changelog: https://docs.wdk.tether.io/overview/changelog
-- Partner with WDK: https://docs.wdk.tether.io/overview/partner-program
-- Showcase: https://docs.wdk.tether.io/overview/showcase
-- Get Support: https://docs.wdk.tether.io/overview/support
-- Our Vision: https://docs.wdk.tether.io/overview/vision
-- Concepts & Definitions: https://docs.wdk.tether.io/resources/concepts
-- Bridge Modules Overview: https://docs.wdk.tether.io/sdk/bridge-modules
-- Bridge tokens with USD₮0: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm
-- Bridge USD₮0 EVM API Reference: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/api-reference
-- Bridge USD₮0 EVM Configuration: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/configuration
-- Bridge Cross-Ecosystem: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem
-- Bridge Tokens: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens
-- Bridge with ERC-4337: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337
-- Get Started: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors
-- Bridge USD₮0 EVM Usage: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/usage
-- RGB Lightning wallet: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning
-- RGB Lightning wallet API reference: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/api-reference
-- RGB Lightning wallet configuration: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/configuration
-- Read RGB Lightning balances and history: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/balances-history
-- Get started with RGB Lightning: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/get-started
-- Handle errors and clean up the node: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/handle-errors-cleanup
-- Create and send Lightning payments: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/lightning-payments
-- Use an LSP, Lightning Address, and APay: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/lsp-lightning-address-apay
-- Manage the RGB Lightning node account: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/manage-node-account
-- Connect peers and manage channels: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/peers-channels
-- Receive and send RGB assets: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/rgb-assets
-- Send Bitcoin and manage UTXOs: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/send-btc-utxos
-- Sign and verify Lightning messages: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/sign-verify-messages
-- Back up and recover with VSS: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/vss-backup-recovery
-- RGB Lightning wallet usage: https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/usage
-- Cosmos wallet: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos
-- Cosmos wallet API reference: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/configuration
-- Check balances: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/check-balances
-- Get started: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/get-started
-- Handle errors: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/handle-errors
-- Manage accounts: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/manage-accounts
-- Send transactions: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/send-transactions
-- Sign and verify messages: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/sign-verify-messages
-- Transfer tokens and use IBC: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/usage
-- RGB wallet: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb
-- RGB wallet API reference: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/api-reference
-- RGB wallet configuration: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/configuration
-- Back up, restore, and migrate the RGB wallet: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/backup-restore-migrate
-- Read RGB balances and history: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/balances-history
-- Send Bitcoin and manage RGB UTXOs: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/btc-utxos
-- Get started with the RGB wallet: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/get-started
-- Handle RGB wallet errors: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/handle-errors
-- Issue and receive RGB assets: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/issue-receive-assets
-- Manage the RGB account and storage: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/manage-account-storage
-- Sign and verify messages with the RGB wallet: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/sign-verify-messages
-- Transfer RGB assets: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/transfer-assets
-- RGB wallet usage: https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/usage
-- WDK Core: https://docs.wdk.tether.io/sdk/core-module
-- WDK Core API Reference: https://docs.wdk.tether.io/sdk/core-module/api-reference
-- WDK Core Configuration: https://docs.wdk.tether.io/sdk/core-module/configuration
-- Manage Accounts: https://docs.wdk.tether.io/sdk/core-module/guides/account-management
-- Error Handling: https://docs.wdk.tether.io/sdk/core-module/guides/error-handling
-- Getting Started: https://docs.wdk.tether.io/sdk/core-module/guides/getting-started
-- Configure Middleware: https://docs.wdk.tether.io/sdk/core-module/guides/middleware
-- Integrate Protocols: https://docs.wdk.tether.io/sdk/core-module/guides/protocol-integration
-- Transaction Policies: https://docs.wdk.tether.io/sdk/core-module/guides/transaction-policies
-- Send Transactions: https://docs.wdk.tether.io/sdk/core-module/guides/transactions
-- Register Wallets: https://docs.wdk.tether.io/sdk/core-module/guides/wallet-registration
-- Usage: https://docs.wdk.tether.io/sdk/core-module/usage
-- Fiat Modules Overview: https://docs.wdk.tether.io/sdk/fiat-modules
-- On-ramp and off-ramp with MoonPay: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay
-- Fiat MoonPay API Reference: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/api-reference
-- Fiat MoonPay Configuration: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/configuration
-- Buy and Sell: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell
-- Get Started: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/guides/get-started
-- Manage Transactions: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions
-- Fiat MoonPay Usage: https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/usage
-- Get Started: https://docs.wdk.tether.io/sdk/get-started
-- Lending Modules Overview: https://docs.wdk.tether.io/sdk/lending-modules
-- Lend with Aave: https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm
-- Lending Aave EVM API Reference: https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/api-reference
-- Lending Aave EVM Configuration: https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/configuration
-- Get Started: https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/guides/handle-errors
-- Lending Operations: https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/guides/lending-operations
-- Lending Aave EVM Guides: https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/usage
-- Lend with Morpho: https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm
-- Lending Morpho EVM API Reference: https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/api-reference
-- Lending Morpho EVM Configuration: https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/configuration
-- Get Started: https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/guides/handle-errors
-- Lending Operations: https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/guides/lending-operations
-- Lending Morpho EVM Guides: https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/usage
-- Pricing Modules Overview: https://docs.wdk.tether.io/sdk/pricing-modules
-- Pricing CoinGecko HTTP Overview: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http
-- Pricing CoinGecko HTTP API Reference: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/api-reference
-- Pricing CoinGecko HTTP Configuration: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/configuration
-- Fetch Current Prices: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices
-- Fetch Historical Prices: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices
-- Get Started: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors
-- Pricing CoinGecko HTTP Guides: https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/usage
-- Swap Modules Overview: https://docs.wdk.tether.io/sdk/swap-modules
-- Swap tokens with Velora: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm
-- API Reference: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/configuration
-- Execute Swaps: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/execute-swaps
-- Get Started: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/get-started
-- Get Swap Quotes: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes
-- Handle Errors: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/handle-errors
-- Swap velora EVM Guides: https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/usage
-- Swap and Bridge Modules Overview: https://docs.wdk.tether.io/sdk/swidge-modules
-- 0x Swidge Overview: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x
-- 0x Swidge API Reference: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x/api-reference
-- 0x Swidge Configuration: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x/configuration
-- 0x Swidge Usage: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x/usage
-- LI.FI Swidge Overview: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi
-- LI.FI Swidge API Reference: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi/api-reference
-- LI.FI Swidge Configuration: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi/configuration
-- LI.FI Swidge Usage: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi/usage
-- Route with Orchestra: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra
-- Orchestra API Reference: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/api-reference
-- Orchestra Configuration: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/configuration
-- Get Started with Orchestra: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/get-started
-- Handle Orchestra Errors: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/handle-errors
-- Quote and Execute Orchestra Routes: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/quote-and-execute
-- Orchestra State and Recovery: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/state-and-recovery
-- Orchestra Usage: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/usage
-- Rhino.fi Swidge Overview: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi
-- Rhino.fi Swidge API Reference: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi/api-reference
-- Rhino.fi Swidge Configuration: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi/configuration
-- Rhino.fi Swidge Usage: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi/usage
-- Symbiosis Swidge Overview: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis
-- Symbiosis Swidge API Reference: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/api-reference
-- Symbiosis Swidge Configuration: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/configuration
-- Bridge from Bitcoin with Symbiosis: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/bridge-from-bitcoin
-- Get Started with Symbiosis Swidge: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/get-started
-- Handle Symbiosis Errors: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/handle-errors
-- Quote and Execute Symbiosis Routes: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/quote-and-execute
-- Track Symbiosis Settlement: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/track-settlement
-- Symbiosis Swidge Usage: https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/usage
-- Wallet Modules Overview: https://docs.wdk.tether.io/sdk/wallet-modules
-- Wallet Aptos Overview: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos
-- Wallet Aptos API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos/api-reference
-- Wallet Aptos Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos/configuration
-- Wallet Aptos Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos/usage
-- Bitcoin wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc
-- Wallet BTC API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/get-started
-- Transaction History: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/get-transaction-history
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/manage-accounts
-- Send Transactions: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/sign-verify-messages
-- Wallet BTC Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/usage
-- Standard EVM wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm
-- EIP-7702 accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless
-- Wallet EVM 7702 Gasless API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts
-- Send Transactions: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/sign-verify-messages
-- Transfer Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens
-- Wallet EVM 7702 Gasless Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/usage
-- Smart accounts (ERC-4337): https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337
-- Wallet EVM ERC-4337 API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts
-- Send Transactions: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages
-- Transfer Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens
-- Wallet EVM ERC-4337 Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/usage
-- Wallet EVM API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/check-balances
-- Error Handling: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/error-handling
-- Getting Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/getting-started
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/manage-accounts
-- Send Transactions: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/sign-verify-messages
-- Transfer ERC-20 Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/usage
-- Solana wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana
-- Gasless Solana wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless
-- API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/manage-accounts
-- Send Transactions: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/sign-verify-messages
-- Transfer SPL Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/usage
-- Wallet Solana API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/api-reference
-- Wallet Solana Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/configuration
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/account-management
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/check-balances
-- Error Handling: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/error-handling
-- Getting Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/getting-started
-- Send SOL: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/sign-verify-messages
-- Transfer SPL Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/usage
-- Lightning (Spark) wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark
-- Wallet Spark API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/api-reference
-- Wallet Spark Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/check-balances
-- Deposits and Withdrawals: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/deposits-and-withdrawals
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/handle-errors
-- Lightning Payments: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/lightning-payments
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/manage-accounts
-- Send and Transfer: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/send-and-transfer
-- Wallet Spark Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/usage
-- Standard TON wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton
-- Gasless TON wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless
-- API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts
-- Native Sends Unsupported: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages
-- Transfer Jetton Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/usage
-- API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/manage-accounts
-- Send TON: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/sign-verify-messages
-- Transfer Jetton Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/usage
-- Standard TRON wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron
-- Gasfree TRON wallet: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree
-- API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/manage-accounts
-- Native TRX Transactions: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/sign-verify-messages
-- Transfer TRC20 Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/usage
-- API Reference: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/api-reference
-- Configuration: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/configuration
-- Check Balances: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/check-balances
-- Get Started: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/get-started
-- Handle Errors: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/handle-errors
-- Manage Accounts: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/manage-accounts
-- Send TRX and Transactions: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/send-transactions
-- Sign and Verify Messages: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/sign-verify-messages
-- Transfer TRC20 Tokens: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/transfer-tokens
-- Usage: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/usage
-- Which wallet module do I need?: https://docs.wdk.tether.io/sdk/wallet-modules/which-wallet-module
-- Build with AI: https://docs.wdk.tether.io/start-building/build-with-ai
-- Node.js & Bare Runtime Quickstart: https://docs.wdk.tether.io/start-building/nodejs-bare-quickstart
-- React Native Quickstart: https://docs.wdk.tether.io/start-building/react-native-quickstart
-- Asset Registry: https://docs.wdk.tether.io/tools/asset-registry
-- Asset Registry API Reference: https://docs.wdk.tether.io/tools/asset-registry/api-reference
-- Asset Registry Configuration: https://docs.wdk.tether.io/tools/asset-registry/configuration
-- Create WDK Module: https://docs.wdk.tether.io/tools/create-wdk-module
-- Failover Provider: https://docs.wdk.tether.io/tools/failover-provider
-- Failover Provider API Reference: https://docs.wdk.tether.io/tools/failover-provider/api-reference
-- Failover Provider Configuration: https://docs.wdk.tether.io/tools/failover-provider/configuration
-- Indexer API: https://docs.wdk.tether.io/tools/indexer-api
-- API Reference: https://docs.wdk.tether.io/tools/indexer-api/api-reference
-- Get Started: https://docs.wdk.tether.io/tools/indexer-api/get-started
-- P2P Address Book: https://docs.wdk.tether.io/tools/p2p-address-book
-- P2P Address Book API Reference: https://docs.wdk.tether.io/tools/p2p-address-book/api-reference
-- P2P Address Book Get Started: https://docs.wdk.tether.io/tools/p2p-address-book/get-started
-- P2P Address Book Production and Privacy: https://docs.wdk.tether.io/tools/p2p-address-book/production-and-privacy
-- P2P Address Book Sync and Recovery: https://docs.wdk.tether.io/tools/p2p-address-book/sync-and-recovery
-- Pear Worklet WDK: https://docs.wdk.tether.io/tools/pear-wrk-wdk
-- Pear Worklet WDK API Reference: https://docs.wdk.tether.io/tools/pear-wrk-wdk/api-reference
-- Pear Worklet WDK Configuration: https://docs.wdk.tether.io/tools/pear-wrk-wdk/configuration
-- Price Rates: https://docs.wdk.tether.io/tools/price-rates
-- API Reference: https://docs.wdk.tether.io/tools/price-rates/api-reference
-- Configuration: https://docs.wdk.tether.io/tools/price-rates/configuration
-- React Native Core: https://docs.wdk.tether.io/tools/react-native-core
-- API Reference: https://docs.wdk.tether.io/tools/react-native-core/api-reference
-- React Native Secure Storage: https://docs.wdk.tether.io/tools/react-native-secure-storage
-- React Native Secure Storage API Reference: https://docs.wdk.tether.io/tools/react-native-secure-storage/api-reference
-- React Native Secure Storage Configuration: https://docs.wdk.tether.io/tools/react-native-secure-storage/configuration
-- Secret Manager: https://docs.wdk.tether.io/tools/secret-manager
-- API Reference: https://docs.wdk.tether.io/tools/secret-manager/api-reference
-- Configuration: https://docs.wdk.tether.io/tools/secret-manager/configuration
-- WDK Utils: https://docs.wdk.tether.io/tools/wdk-utils
-- WDK Utils API Reference: https://docs.wdk.tether.io/tools/wdk-utils/api-reference
-- WDK Utils Configuration: https://docs.wdk.tether.io/tools/wdk-utils/configuration
-- Shamir Secret Sharing: https://docs.wdk.tether.io/tools/wdk-utils/guides/shamir-secret-sharing
-- Worklet Bundler: https://docs.wdk.tether.io/tools/worklet-bundler
-- Worklet Bundler API Reference: https://docs.wdk.tether.io/tools/worklet-bundler/api-reference
-- Worklet Bundler Configuration: https://docs.wdk.tether.io/tools/worklet-bundler/configuration
-- React Native UI Kit: https://docs.wdk.tether.io/ui-kits/react-native-ui-kit
-- Components List: https://docs.wdk.tether.io/ui-kits/react-native-ui-kit/api-reference
-- Get Started: https://docs.wdk.tether.io/ui-kits/react-native-ui-kit/get-started
-- Theming: https://docs.wdk.tether.io/ui-kits/react-native-ui-kit/theming
+## Documentation
+
+- [Welcome to WDK](https://docs.wdk.tether.io/index.md)
+- [Agent Skills](https://docs.wdk.tether.io/ai/agent-skills.md)
+- [MCP Toolkit](https://docs.wdk.tether.io/ai/mcp-toolkit.md)
+- [API Reference](https://docs.wdk.tether.io/ai/mcp-toolkit/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/ai/mcp-toolkit/configuration.md)
+- [Get Started](https://docs.wdk.tether.io/ai/mcp-toolkit/get-started.md)
+- [LangChain Integration](https://docs.wdk.tether.io/ai/mcp-toolkit/langchain.md)
+- [OpenClaw (Community Skill)](https://docs.wdk.tether.io/ai/openclaw.md)
+- [x402](https://docs.wdk.tether.io/ai/x402.md)
+- [WDK CLI](https://docs.wdk.tether.io/cli.md)
+- [API Reference](https://docs.wdk.tether.io/cli/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/cli/configuration.md)
+- [Custom Networks](https://docs.wdk.tether.io/cli/guides/custom-networks.md)
+- [Get Started](https://docs.wdk.tether.io/cli/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/cli/guides/handle-errors.md)
+- [Manage Tokens](https://docs.wdk.tether.io/cli/guides/manage-tokens.md)
+- [Manage Wallets](https://docs.wdk.tether.io/cli/guides/manage-wallets.md)
+- [Use the MCP Server](https://docs.wdk.tether.io/cli/guides/use-mcp-server.md)
+- [Architecture](https://docs.wdk.tether.io/cli/reference/architecture.md)
+- [Security Model](https://docs.wdk.tether.io/cli/reference/security-model.md)
+- [Storage Format](https://docs.wdk.tether.io/cli/reference/storage-format.md)
+- [React Native Starter (Alpha)](https://docs.wdk.tether.io/examples-and-starters/react-native-starter.md)
+- [About WDK](https://docs.wdk.tether.io/overview/about.md)
+- [Changelog](https://docs.wdk.tether.io/overview/changelog.md)
+- [Partner with WDK](https://docs.wdk.tether.io/overview/partner-program.md)
+- [Showcase](https://docs.wdk.tether.io/overview/showcase.md)
+- [Get Support](https://docs.wdk.tether.io/overview/support.md)
+- [Our Vision](https://docs.wdk.tether.io/overview/vision.md)
+- [Concepts & Definitions](https://docs.wdk.tether.io/resources/concepts.md)
+- [Bridge Modules Overview](https://docs.wdk.tether.io/sdk/bridge-modules.md)
+- [Bridge tokens with USD₮0](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm.md)
+- [Bridge USD₮0 EVM API Reference](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/api-reference.md)
+- [Bridge USD₮0 EVM Configuration](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/configuration.md)
+- [Bridge Cross-Ecosystem](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.md)
+- [Bridge Tokens](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens.md)
+- [Bridge with ERC-4337](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors.md)
+- [Bridge USD₮0 EVM Usage](https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/usage.md)
+- [RGB Lightning wallet](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning.md)
+- [RGB Lightning wallet API reference](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/api-reference.md)
+- [RGB Lightning wallet configuration](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/configuration.md)
+- [Read RGB Lightning balances and history](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/balances-history.md)
+- [Get started with RGB Lightning](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/get-started.md)
+- [Handle errors and clean up the node](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/handle-errors-cleanup.md)
+- [Create and send Lightning payments](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/lightning-payments.md)
+- [Use an LSP, Lightning Address, and APay](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/lsp-lightning-address-apay.md)
+- [Manage the RGB Lightning node account](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/manage-node-account.md)
+- [Connect peers and manage channels](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/peers-channels.md)
+- [Receive and send RGB assets](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/rgb-assets.md)
+- [Send Bitcoin and manage UTXOs](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/send-btc-utxos.md)
+- [Sign and verify Lightning messages](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/sign-verify-messages.md)
+- [Back up and recover with VSS](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/guides/vss-backup-recovery.md)
+- [RGB Lightning wallet usage](https://docs.wdk.tether.io/sdk/community-modules/wdk-rgb-lightning/usage.md)
+- [Cosmos wallet](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos.md)
+- [Cosmos wallet API reference](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/configuration.md)
+- [Check balances](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/check-balances.md)
+- [Get started](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/get-started.md)
+- [Handle errors](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/handle-errors.md)
+- [Manage accounts](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/manage-accounts.md)
+- [Send transactions](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/send-transactions.md)
+- [Sign and verify messages](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/sign-verify-messages.md)
+- [Transfer tokens and use IBC](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-cosmos/usage.md)
+- [RGB wallet](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb.md)
+- [RGB wallet API reference](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/api-reference.md)
+- [RGB wallet configuration](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/configuration.md)
+- [Back up, restore, and migrate the RGB wallet](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/backup-restore-migrate.md)
+- [Read RGB balances and history](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/balances-history.md)
+- [Send Bitcoin and manage RGB UTXOs](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/btc-utxos.md)
+- [Get started with the RGB wallet](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/get-started.md)
+- [Handle RGB wallet errors](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/handle-errors.md)
+- [Issue and receive RGB assets](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/issue-receive-assets.md)
+- [Manage the RGB account and storage](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/manage-account-storage.md)
+- [Sign and verify messages with the RGB wallet](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/sign-verify-messages.md)
+- [Transfer RGB assets](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/guides/transfer-assets.md)
+- [RGB wallet usage](https://docs.wdk.tether.io/sdk/community-modules/wdk-wallet-rgb/usage.md)
+- [WDK Core](https://docs.wdk.tether.io/sdk/core-module.md)
+- [WDK Core API Reference](https://docs.wdk.tether.io/sdk/core-module/api-reference.md)
+- [WDK Core Configuration](https://docs.wdk.tether.io/sdk/core-module/configuration.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/core-module/guides/account-management.md)
+- [Error Handling](https://docs.wdk.tether.io/sdk/core-module/guides/error-handling.md)
+- [Getting Started](https://docs.wdk.tether.io/sdk/core-module/guides/getting-started.md)
+- [Configure Middleware](https://docs.wdk.tether.io/sdk/core-module/guides/middleware.md)
+- [Integrate Protocols](https://docs.wdk.tether.io/sdk/core-module/guides/protocol-integration.md)
+- [Transaction Policies](https://docs.wdk.tether.io/sdk/core-module/guides/transaction-policies.md)
+- [Send Transactions](https://docs.wdk.tether.io/sdk/core-module/guides/transactions.md)
+- [Register Wallets](https://docs.wdk.tether.io/sdk/core-module/guides/wallet-registration.md)
+- [Usage](https://docs.wdk.tether.io/sdk/core-module/usage.md)
+- [Fiat Modules Overview](https://docs.wdk.tether.io/sdk/fiat-modules.md)
+- [On-ramp and off-ramp with MoonPay](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay.md)
+- [Fiat MoonPay API Reference](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/api-reference.md)
+- [Fiat MoonPay Configuration](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/configuration.md)
+- [Buy and Sell](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/guides/buy-and-sell.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/guides/get-started.md)
+- [Manage Transactions](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/guides/manage-transactions.md)
+- [Fiat MoonPay Usage](https://docs.wdk.tether.io/sdk/fiat-modules/fiat-moonpay/usage.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/get-started.md)
+- [Lending Modules Overview](https://docs.wdk.tether.io/sdk/lending-modules.md)
+- [Lend with Aave](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm.md)
+- [Lending Aave EVM API Reference](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/api-reference.md)
+- [Lending Aave EVM Configuration](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/configuration.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/guides/handle-errors.md)
+- [Lending Operations](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/guides/lending-operations.md)
+- [Lending Aave EVM Guides](https://docs.wdk.tether.io/sdk/lending-modules/lending-aave-evm/usage.md)
+- [Lend with Morpho](https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm.md)
+- [Lending Morpho EVM API Reference](https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/api-reference.md)
+- [Lending Morpho EVM Configuration](https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/configuration.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/guides/handle-errors.md)
+- [Lending Operations](https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/guides/lending-operations.md)
+- [Lending Morpho EVM Guides](https://docs.wdk.tether.io/sdk/lending-modules/lending-morpho-evm/usage.md)
+- [Pricing Modules Overview](https://docs.wdk.tether.io/sdk/pricing-modules.md)
+- [Pricing CoinGecko HTTP Overview](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http.md)
+- [Pricing CoinGecko HTTP API Reference](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/api-reference.md)
+- [Pricing CoinGecko HTTP Configuration](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/configuration.md)
+- [Fetch Current Prices](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-current-prices.md)
+- [Fetch Historical Prices](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/fetch-historical-prices.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/guides/handle-errors.md)
+- [Pricing CoinGecko HTTP Guides](https://docs.wdk.tether.io/sdk/pricing-modules/pricing-coingecko-http/usage.md)
+- [Swap Modules Overview](https://docs.wdk.tether.io/sdk/swap-modules.md)
+- [Swap tokens with Velora](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm.md)
+- [API Reference](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/configuration.md)
+- [Execute Swaps](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/execute-swaps.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/get-started.md)
+- [Get Swap Quotes](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/guides/handle-errors.md)
+- [Swap velora EVM Guides](https://docs.wdk.tether.io/sdk/swap-modules/swap-velora-evm/usage.md)
+- [Swap and Bridge Modules Overview](https://docs.wdk.tether.io/sdk/swidge-modules.md)
+- [0x Swidge Overview](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x.md)
+- [0x Swidge API Reference](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x/api-reference.md)
+- [0x Swidge Configuration](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x/configuration.md)
+- [0x Swidge Usage](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-0x/usage.md)
+- [LI.FI Swidge Overview](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi.md)
+- [LI.FI Swidge API Reference](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi/api-reference.md)
+- [LI.FI Swidge Configuration](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi/configuration.md)
+- [LI.FI Swidge Usage](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-lifi/usage.md)
+- [Route with Orchestra](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra.md)
+- [Orchestra API Reference](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/api-reference.md)
+- [Orchestra Configuration](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/configuration.md)
+- [Get Started with Orchestra](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/get-started.md)
+- [Handle Orchestra Errors](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/handle-errors.md)
+- [Quote and Execute Orchestra Routes](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/quote-and-execute.md)
+- [Orchestra State and Recovery](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/guides/state-and-recovery.md)
+- [Orchestra Usage](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-orchestra/usage.md)
+- [Rhino.fi Swidge Overview](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi.md)
+- [Rhino.fi Swidge API Reference](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi/api-reference.md)
+- [Rhino.fi Swidge Configuration](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi/configuration.md)
+- [Rhino.fi Swidge Usage](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-rhinofi/usage.md)
+- [Symbiosis Swidge Overview](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis.md)
+- [Symbiosis Swidge API Reference](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/api-reference.md)
+- [Symbiosis Swidge Configuration](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/configuration.md)
+- [Bridge from Bitcoin with Symbiosis](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/bridge-from-bitcoin.md)
+- [Get Started with Symbiosis Swidge](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/get-started.md)
+- [Handle Symbiosis Errors](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/handle-errors.md)
+- [Quote and Execute Symbiosis Routes](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/quote-and-execute.md)
+- [Track Symbiosis Settlement](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/guides/track-settlement.md)
+- [Symbiosis Swidge Usage](https://docs.wdk.tether.io/sdk/swidge-modules/swidge-symbiosis/usage.md)
+- [Wallet Modules Overview](https://docs.wdk.tether.io/sdk/wallet-modules.md)
+- [Wallet Aptos Overview](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos.md)
+- [Wallet Aptos API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos/api-reference.md)
+- [Wallet Aptos Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos/configuration.md)
+- [Wallet Aptos Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-aptos/usage.md)
+- [Bitcoin wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc.md)
+- [Wallet BTC API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/get-started.md)
+- [Transaction History](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/get-transaction-history.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/manage-accounts.md)
+- [Send Transactions](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/guides/sign-verify-messages.md)
+- [Wallet BTC Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-btc/usage.md)
+- [Standard EVM wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm.md)
+- [EIP-7702 accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless.md)
+- [Wallet EVM 7702 Gasless API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts.md)
+- [Send Transactions](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/sign-verify-messages.md)
+- [Transfer Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens.md)
+- [Wallet EVM 7702 Gasless Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-7702-gasless/usage.md)
+- [Smart accounts (ERC-4337)](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337.md)
+- [Wallet EVM ERC-4337 API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts.md)
+- [Send Transactions](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages.md)
+- [Transfer Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.md)
+- [Wallet EVM ERC-4337 Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/usage.md)
+- [Wallet EVM API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/check-balances.md)
+- [Error Handling](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/error-handling.md)
+- [Getting Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/getting-started.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/manage-accounts.md)
+- [Send Transactions](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/sign-verify-messages.md)
+- [Transfer ERC-20 Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm/usage.md)
+- [Solana wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana.md)
+- [Gasless Solana wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless.md)
+- [API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/manage-accounts.md)
+- [Send Transactions](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/sign-verify-messages.md)
+- [Transfer SPL Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana-gasless/usage.md)
+- [Wallet Solana API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/api-reference.md)
+- [Wallet Solana Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/configuration.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/account-management.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/check-balances.md)
+- [Error Handling](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/error-handling.md)
+- [Getting Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/getting-started.md)
+- [Send SOL](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/sign-verify-messages.md)
+- [Transfer SPL Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-solana/usage.md)
+- [Lightning (Spark) wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark.md)
+- [Wallet Spark API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/api-reference.md)
+- [Wallet Spark Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/check-balances.md)
+- [Deposits and Withdrawals](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/deposits-and-withdrawals.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/handle-errors.md)
+- [Lightning Payments](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/lightning-payments.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/manage-accounts.md)
+- [Send and Transfer](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/guides/send-and-transfer.md)
+- [Wallet Spark Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-spark/usage.md)
+- [Standard TON wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton.md)
+- [Gasless TON wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless.md)
+- [API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/manage-accounts.md)
+- [Native Sends Unsupported](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/sign-verify-messages.md)
+- [Transfer Jetton Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton-gasless/usage.md)
+- [API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/manage-accounts.md)
+- [Send TON](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/sign-verify-messages.md)
+- [Transfer Jetton Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-ton/usage.md)
+- [Standard TRON wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron.md)
+- [Gasfree TRON wallet](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree.md)
+- [API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/manage-accounts.md)
+- [Native TRX Transactions](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/sign-verify-messages.md)
+- [Transfer TRC20 Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron-gasfree/usage.md)
+- [API Reference](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/configuration.md)
+- [Check Balances](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/check-balances.md)
+- [Get Started](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/get-started.md)
+- [Handle Errors](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/handle-errors.md)
+- [Manage Accounts](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/manage-accounts.md)
+- [Send TRX and Transactions](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/send-transactions.md)
+- [Sign and Verify Messages](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/sign-verify-messages.md)
+- [Transfer TRC20 Tokens](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/guides/transfer-tokens.md)
+- [Usage](https://docs.wdk.tether.io/sdk/wallet-modules/wallet-tron/usage.md)
+- [Which wallet module do I need?](https://docs.wdk.tether.io/sdk/wallet-modules/which-wallet-module.md)
+- [Build with AI](https://docs.wdk.tether.io/start-building/build-with-ai.md)
+- [Node.js & Bare Runtime Quickstart](https://docs.wdk.tether.io/start-building/nodejs-bare-quickstart.md)
+- [React Native Quickstart](https://docs.wdk.tether.io/start-building/react-native-quickstart.md)
+- [Asset Registry](https://docs.wdk.tether.io/tools/asset-registry.md)
+- [Asset Registry API Reference](https://docs.wdk.tether.io/tools/asset-registry/api-reference.md)
+- [Asset Registry Configuration](https://docs.wdk.tether.io/tools/asset-registry/configuration.md)
+- [Create WDK Module](https://docs.wdk.tether.io/tools/create-wdk-module.md)
+- [Failover Provider](https://docs.wdk.tether.io/tools/failover-provider.md)
+- [Failover Provider API Reference](https://docs.wdk.tether.io/tools/failover-provider/api-reference.md)
+- [Failover Provider Configuration](https://docs.wdk.tether.io/tools/failover-provider/configuration.md)
+- [Indexer API](https://docs.wdk.tether.io/tools/indexer-api.md)
+- [API Reference](https://docs.wdk.tether.io/tools/indexer-api/api-reference.md)
+- [Get Started](https://docs.wdk.tether.io/tools/indexer-api/get-started.md)
+- [P2P Address Book](https://docs.wdk.tether.io/tools/p2p-address-book.md)
+- [P2P Address Book API Reference](https://docs.wdk.tether.io/tools/p2p-address-book/api-reference.md)
+- [P2P Address Book Get Started](https://docs.wdk.tether.io/tools/p2p-address-book/get-started.md)
+- [P2P Address Book Production and Privacy](https://docs.wdk.tether.io/tools/p2p-address-book/production-and-privacy.md)
+- [P2P Address Book Sync and Recovery](https://docs.wdk.tether.io/tools/p2p-address-book/sync-and-recovery.md)
+- [Pear Worklet WDK](https://docs.wdk.tether.io/tools/pear-wrk-wdk.md)
+- [Pear Worklet WDK API Reference](https://docs.wdk.tether.io/tools/pear-wrk-wdk/api-reference.md)
+- [Pear Worklet WDK Configuration](https://docs.wdk.tether.io/tools/pear-wrk-wdk/configuration.md)
+- [Price Rates](https://docs.wdk.tether.io/tools/price-rates.md)
+- [API Reference](https://docs.wdk.tether.io/tools/price-rates/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/tools/price-rates/configuration.md)
+- [React Native Core](https://docs.wdk.tether.io/tools/react-native-core.md)
+- [API Reference](https://docs.wdk.tether.io/tools/react-native-core/api-reference.md)
+- [React Native Secure Storage](https://docs.wdk.tether.io/tools/react-native-secure-storage.md)
+- [React Native Secure Storage API Reference](https://docs.wdk.tether.io/tools/react-native-secure-storage/api-reference.md)
+- [React Native Secure Storage Configuration](https://docs.wdk.tether.io/tools/react-native-secure-storage/configuration.md)
+- [Secret Manager](https://docs.wdk.tether.io/tools/secret-manager.md)
+- [API Reference](https://docs.wdk.tether.io/tools/secret-manager/api-reference.md)
+- [Configuration](https://docs.wdk.tether.io/tools/secret-manager/configuration.md)
+- [WDK Utils](https://docs.wdk.tether.io/tools/wdk-utils.md)
+- [WDK Utils API Reference](https://docs.wdk.tether.io/tools/wdk-utils/api-reference.md)
+- [WDK Utils Configuration](https://docs.wdk.tether.io/tools/wdk-utils/configuration.md)
+- [Shamir Secret Sharing](https://docs.wdk.tether.io/tools/wdk-utils/guides/shamir-secret-sharing.md)
+- [Worklet Bundler](https://docs.wdk.tether.io/tools/worklet-bundler.md)
+- [Worklet Bundler API Reference](https://docs.wdk.tether.io/tools/worklet-bundler/api-reference.md)
+- [Worklet Bundler Configuration](https://docs.wdk.tether.io/tools/worklet-bundler/configuration.md)
+- [React Native UI Kit](https://docs.wdk.tether.io/ui-kits/react-native-ui-kit.md)
+- [Components List](https://docs.wdk.tether.io/ui-kits/react-native-ui-kit/api-reference.md)
+- [Get Started](https://docs.wdk.tether.io/ui-kits/react-native-ui-kit/get-started.md)
+- [Theming](https://docs.wdk.tether.io/ui-kits/react-native-ui-kit/theming.md)

--- a/scripts/check-llm-md-output.mjs
+++ b/scripts/check-llm-md-output.mjs
@@ -8,9 +8,12 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
 const DEFAULT_DIST_DIR = path.join(REPO_ROOT, 'dist');
 const DEFAULT_REQUIRED_PATHS = ['index.md', 'sdk/get-started.md'];
+const DEFAULT_PUBLIC_LLMS_PATH = path.join(REPO_ROOT, 'public', 'llms.txt');
 const DEFAULT_CATALOG_SOURCE_PATH = path.join(REPO_ROOT, 'content', 'feeds', 'all-modules.md');
 const DEFAULT_PUBLIC_LLMS_FULL_PATH = path.join(REPO_ROOT, 'public', 'llms-full.txt');
 const DEFAULT_DOCS_ROOT = path.join(REPO_ROOT, 'content', 'docs');
+const DOCS_ORIGIN = 'https://docs.wdk.tether.io';
+const LLMS_MAX_CHARACTERS = 50_000;
 const LLMS_SECTION_SEPARATOR = '\n\n***\n\n';
 const LLMS_SECTION_TERMINATOR = '\n\n***\n';
 const HTML_OR_NEXT_ERROR_PATTERN = /<!doctype html|<html\b|404: This page could not be found|self\.__next_f|BAILOUT_TO_CLIENT_SIDE_RENDERING/i;
@@ -93,6 +96,167 @@ function countOccurrences(value, search) {
   }
 
   return count;
+}
+
+function summarizePaths(paths, limit = 10) {
+  const visible = paths.slice(0, limit).join(', ');
+  const remaining = paths.length - limit;
+  return remaining > 0 ? `${visible}, and ${remaining} more` : visible;
+}
+
+export async function validateLlmsTxt({
+  llmsPath = DEFAULT_PUBLIC_LLMS_PATH,
+  distDir,
+} = {}) {
+  const errors = [];
+  let llms;
+
+  try {
+    llms = await fs.readFile(llmsPath, 'utf8');
+  } catch {
+    return [`Missing llms.txt artifact: ${llmsPath}`];
+  }
+
+  if (llms.length > LLMS_MAX_CHARACTERS) {
+    errors.push(`llms.txt exceeds ${LLMS_MAX_CHARACTERS} characters; found ${llms.length}`);
+  }
+  const byteLength = Buffer.byteLength(llms, 'utf8');
+  if (byteLength > LLMS_MAX_CHARACTERS) {
+    errors.push(`llms.txt exceeds ${LLMS_MAX_CHARACTERS} UTF-8 bytes; found ${byteLength}`);
+  }
+
+  const lines = llms.split(/\r?\n/);
+  const h1Lines = lines.filter((line) => line.startsWith('# '));
+  if (lines[0] !== '# WDK Documentation' || h1Lines.length !== 1) {
+    errors.push('llms.txt must start with exactly one `# WDK Documentation` heading');
+  }
+
+  const summaryIndex = lines.findIndex((line) => /^> \S/.test(line));
+  const documentationHeadings = lines.filter((line) => line === '## Documentation');
+  const documentationIndex = lines.indexOf('## Documentation');
+  if (summaryIndex < 1 || documentationHeadings.length !== 1 || summaryIndex > documentationIndex) {
+    errors.push('llms.txt must include a blockquote summary before the `## Documentation` section');
+  }
+
+  const linkPattern = /^- \[([^\[\]]+)]\((https:\/\/docs\.wdk\.tether\.io\/[^)\s]+\.md)\)$/;
+  const linkLines = documentationIndex < 0
+    ? []
+    : lines.slice(documentationIndex + 1).filter((line) => line.trim().length > 0);
+  const linkedPaths = [];
+
+  for (const line of linkLines) {
+    const match = line.match(linkPattern);
+    if (!match) {
+      errors.push(`Invalid llms.txt documentation entry: ${line}`);
+      continue;
+    }
+
+    const [, label, href] = match;
+    if (label.trim().length === 0) {
+      errors.push(`llms.txt entry has an empty label: ${line}`);
+    }
+
+    const url = new URL(href);
+    if (url.origin !== DOCS_ORIGIN || url.search || url.hash) {
+      errors.push(`llms.txt entry must use a canonical ${DOCS_ORIGIN} URL without a query or fragment: ${href}`);
+      continue;
+    }
+
+    linkedPaths.push(url.pathname);
+  }
+
+  if (linkLines.length === 0) {
+    errors.push('llms.txt must include at least one documentation link');
+  }
+
+  const uniquePaths = new Set(linkedPaths);
+  if (uniquePaths.size !== linkedPaths.length) {
+    errors.push('llms.txt documentation URLs must be unique');
+  }
+
+  if (distDir) {
+    let markdownFiles;
+    let htmlIndexFiles;
+    try {
+      [markdownFiles, htmlIndexFiles] = await Promise.all([
+        collectMarkdownFiles(distDir),
+        collectIndexHtmlFiles(distDir),
+      ]);
+    } catch {
+      errors.push(`Missing generated documentation directory: ${distDir}`);
+      return errors;
+    }
+
+    const expectedRelativePaths = htmlIndexFiles
+      .filter((relativePath) => !IGNORED_HTML_INDEX_PATHS.has(relativePath))
+      .map(markdownPathForHtmlIndex);
+    const expectedPaths = expectedRelativePaths.map((relativePath) => `/${relativePath}`);
+    const expectedSet = new Set(expectedPaths);
+    const missingPaths = expectedPaths.filter((route) => !uniquePaths.has(route));
+    const unexpectedPaths = [...uniquePaths].filter((route) => !expectedSet.has(route));
+    const markdownFileSet = new Set(markdownFiles);
+    const missingMarkdownFiles = expectedRelativePaths.filter((relativePath) => !markdownFileSet.has(relativePath));
+    const orphanMarkdownFiles = markdownFiles.filter((relativePath) => !expectedSet.has(`/${relativePath}`));
+
+    if (missingPaths.length > 0) {
+      errors.push(`llms.txt is missing ${missingPaths.length} exported documentation route(s): ${summarizePaths(missingPaths)}`);
+    }
+    if (unexpectedPaths.length > 0) {
+      errors.push(`llms.txt contains ${unexpectedPaths.length} unknown Markdown route(s): ${summarizePaths(unexpectedPaths)}`);
+    }
+    if (missingMarkdownFiles.length > 0) {
+      errors.push(`Exported HTML is missing ${missingMarkdownFiles.length} generated Markdown file(s): ${summarizePaths(missingMarkdownFiles)}`);
+    }
+    if (orphanMarkdownFiles.length > 0) {
+      errors.push(`Generated Markdown has ${orphanMarkdownFiles.length} route(s) without exported HTML: ${summarizePaths(orphanMarkdownFiles)}`);
+    }
+  }
+
+  return errors;
+}
+
+export async function validateDocsHtmlSourceOrder({ distDir = DEFAULT_DIST_DIR } = {}) {
+  const errors = [];
+
+  if (!await exists(distDir)) {
+    return [`Missing dist directory: ${distDir}`];
+  }
+
+  const htmlIndexFiles = (await collectIndexHtmlFiles(distDir))
+    .filter((relativePath) => !IGNORED_HTML_INDEX_PATHS.has(relativePath));
+  if (htmlIndexFiles.length === 0) {
+    return ['No exported documentation HTML pages found'];
+  }
+
+  for (const relativeHtmlPath of htmlIndexFiles) {
+    const htmlPath = path.join(distDir, relativeHtmlPath);
+    const html = await fs.readFile(htmlPath, 'utf8');
+    const articleCount = countOccurrences(html, 'id="nd-page"');
+    const sidebarCount = countOccurrences(html, 'id="nd-sidebar"');
+    const sidebarPlaceholderCount = countOccurrences(html, 'data-sidebar-placeholder');
+
+    if (articleCount !== 1) {
+      errors.push(`${relativeHtmlPath} must contain exactly one docs article; found ${articleCount}`);
+    }
+    if (sidebarCount !== 1 || sidebarPlaceholderCount !== 1) {
+      errors.push(`${relativeHtmlPath} must contain exactly one docs sidebar; found ${sidebarCount} sidebar(s) and ${sidebarPlaceholderCount} placeholder(s)`);
+    }
+
+    const articleIndex = html.indexOf('id="nd-page"');
+    const sidebarIndex = html.indexOf('id="nd-sidebar"');
+    const sidebarPlaceholderIndex = html.indexOf('data-sidebar-placeholder');
+    if (
+      articleIndex >= 0
+      && (
+        (sidebarIndex >= 0 && articleIndex > sidebarIndex)
+        || (sidebarPlaceholderIndex >= 0 && articleIndex > sidebarPlaceholderIndex)
+      )
+    ) {
+      errors.push(`${relativeHtmlPath} serializes repeated navigation before the docs article`);
+    }
+  }
+
+  return errors;
 }
 
 function internalDocRoutes(markdown) {
@@ -245,6 +409,8 @@ export async function validateFileSystemOutput({
       if (normalizeBody(html) === normalizeBody(content)) {
         errors.push(`${relativePath} duplicates HTML output at ${htmlPathForMarkdown(relativePath)}`);
       }
+    } else {
+      errors.push(`Generated Markdown file has no exported HTML page: ${relativePath}`);
     }
   }
 
@@ -333,7 +499,12 @@ function parseArgs(argv) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const errors = [
+    ...await validateLlmsTxt({
+      llmsPath: path.join(options.distDir, 'llms.txt'),
+      distDir: options.distDir,
+    }),
     ...await validateFileSystemOutput(options),
+    ...await validateDocsHtmlSourceOrder(options),
     ...await validateAllModulesFeed({ distPath: path.join(options.distDir, 'llms-full.txt') }),
     ...await validateHttpOutput(options),
   ];

--- a/scripts/test/check-llm-md-output.test.mjs
+++ b/scripts/test/check-llm-md-output.test.mjs
@@ -6,8 +6,10 @@ import path from 'node:path';
 
 import {
   validateAllModulesFeed,
+  validateDocsHtmlSourceOrder,
   validateFileSystemOutput,
   validateHttpOutput,
+  validateLlmsTxt,
 } from '../check-llm-md-output.mjs';
 
 async function createDistFixture(files) {
@@ -21,6 +23,211 @@ async function createDistFixture(files) {
 
   return distDir;
 }
+
+function htmlPathForMarkdown(relativePath) {
+  if (relativePath === 'index.md') return 'index.html';
+  return `${relativePath.slice(0, -'.md'.length)}/index.html`;
+}
+
+async function createLlmsFixture({ llms, markdownFiles, htmlFiles = markdownFiles }) {
+  const root = await mkdtemp(path.join(tmpdir(), 'wdk-llms-txt-'));
+  const llmsPath = path.join(root, 'llms.txt');
+  const distDir = path.join(root, 'dist');
+
+  await mkdir(distDir, { recursive: true });
+  await writeFile(llmsPath, llms, 'utf8');
+
+  for (const relativePath of markdownFiles) {
+    const target = path.join(distDir, relativePath);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, '# Fixture\n', 'utf8');
+  }
+
+  for (const relativePath of htmlFiles) {
+    const target = path.join(distDir, htmlPathForMarkdown(relativePath));
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, '<!DOCTYPE html><article id="nd-page">Fixture</article>', 'utf8');
+  }
+
+  return { llmsPath, distDir };
+}
+
+const validLlmsLines = [
+    '# WDK Documentation',
+    '',
+    '> Complete WDK documentation index.',
+    '',
+    '## Documentation',
+    '',
+    '- [Welcome to WDK](https://docs.wdk.tether.io/index.md)',
+    '- [Core](https://docs.wdk.tether.io/sdk/core-module.md)',
+    '- [Get Started](https://docs.wdk.tether.io/sdk/get-started.md)',
+    '',
+];
+const fixtureMarkdownFiles = ['index.md', 'sdk/core-module.md', 'sdk/get-started.md'];
+
+test('accepts a structured llms.txt with exact exported HTML and Markdown coverage', async () => {
+  const llms = validLlmsLines.join('\n');
+  const fixture = await createLlmsFixture({
+    llms,
+    markdownFiles: fixtureMarkdownFiles,
+  });
+
+  const errors = await validateLlmsTxt(fixture);
+
+  assert.deepEqual(errors, []);
+});
+
+const invalidLlmsCases = [
+  {
+    name: 'a missing H1',
+    mutate: (lines) => lines.with(0, 'WDK Documentation'),
+    expected: 'must start with exactly one',
+  },
+  {
+    name: 'a missing blockquote summary',
+    mutate: (lines) => lines.filter((line) => !line.startsWith('> ')),
+    expected: 'blockquote summary',
+  },
+  {
+    name: 'a missing Documentation H2',
+    mutate: (lines) => lines.filter((line) => line !== '## Documentation'),
+    expected: 'blockquote summary',
+  },
+  {
+    name: 'a legacy bare URL entry',
+    mutate: (lines) => lines.with(6, '- Welcome to WDK: https://docs.wdk.tether.io/'),
+    expected: 'Invalid llms.txt documentation entry',
+  },
+  {
+    name: 'a same-origin HTML target',
+    mutate: (lines) => lines.with(6, '- [Welcome to WDK](https://docs.wdk.tether.io/)'),
+    expected: 'Invalid llms.txt documentation entry',
+  },
+  {
+    name: 'a foreign-origin Markdown target',
+    mutate: (lines) => lines.with(6, '- [Welcome to WDK](https://example.com/index.md)'),
+    expected: 'Invalid llms.txt documentation entry',
+  },
+  {
+    name: 'multiple Markdown links in one entry',
+    mutate: (lines) => lines.with(
+      6,
+      '- [Injected](https://example.com/off-origin.md) [Welcome](https://docs.wdk.tether.io/index.md)',
+    ),
+    expected: 'Invalid llms.txt documentation entry',
+  },
+  {
+    name: 'a query-bearing Markdown target',
+    mutate: (lines) => lines.with(6, '- [Welcome to WDK](https://docs.wdk.tether.io/index.md?raw=1)'),
+    expected: 'Invalid llms.txt documentation entry',
+  },
+  {
+    name: 'a duplicate route',
+    mutate: (lines) => [...lines.slice(0, -1), lines[6], ''],
+    expected: 'must be unique',
+  },
+  {
+    name: 'an oversized artifact',
+    mutate: (lines) => lines.with(2, `> ${'x'.repeat(50_001)}`),
+    expected: 'exceeds 50000 characters',
+  },
+  {
+    name: 'a missing exported route',
+    mutate: (lines) => lines.filter((line) => !line.includes('/sdk/get-started.md')),
+    expected: 'missing 1 exported documentation route',
+  },
+  {
+    name: 'an extra retired route',
+    mutate: (lines) => [...lines.slice(0, -1), '- [Retired](https://docs.wdk.tether.io/sdk/all-modules.md)', ''],
+    expected: 'unknown Markdown route',
+  },
+  {
+    name: 'the invalid root /.md route',
+    mutate: (lines) => lines.with(6, '- [Welcome to WDK](https://docs.wdk.tether.io/.md)'),
+    expected: 'Invalid llms.txt documentation entry',
+  },
+];
+
+for (const { name, mutate, expected } of invalidLlmsCases) {
+  test(`rejects llms.txt with ${name}`, async () => {
+    const fixture = await createLlmsFixture({
+      llms: mutate(validLlmsLines).join('\n'),
+      markdownFiles: fixtureMarkdownFiles,
+    });
+
+    const errors = await validateLlmsTxt(fixture);
+
+    assert(errors.some((error) => error.includes(expected)), errors.join('\n'));
+  });
+}
+
+test('rejects generated Markdown without matching exported HTML', async () => {
+  const fixture = await createLlmsFixture({
+    llms: validLlmsLines.join('\n'),
+    markdownFiles: [...fixtureMarkdownFiles, 'sdk/all-modules.md'],
+    htmlFiles: fixtureMarkdownFiles,
+  });
+
+  const errors = await validateLlmsTxt(fixture);
+
+  assert(errors.some((error) => error.includes('without exported HTML')));
+});
+
+test('accepts docs HTML that serializes the article before one sidebar', async () => {
+  const distDir = await createDistFixture({
+    'index.md': '# Welcome to WDK (/)',
+    'index.html': '<div id="nd-page">Article</div><div data-sidebar-placeholder><aside id="nd-sidebar">Navigation</aside></div>',
+  });
+
+  const errors = await validateDocsHtmlSourceOrder({ distDir });
+
+  assert.deepEqual(errors, []);
+});
+
+test('rejects docs HTML with navigation first or duplicated sidebars', async () => {
+  const distDir = await createDistFixture({
+    'nested/page/index.html': '<div data-sidebar-placeholder><aside id="nd-sidebar">Navigation</aside></div><div id="nd-page">Article</div><aside id="nd-sidebar">Duplicate</aside>',
+  });
+
+  const errors = await validateDocsHtmlSourceOrder({ distDir });
+
+  assert(errors.some((error) => error.includes('exactly one docs sidebar')));
+  assert(errors.some((error) => error.includes('repeated navigation before the docs article')));
+});
+
+for (const [name, html, expected] of [
+  ['missing article', '<div data-sidebar-placeholder><aside id="nd-sidebar">Navigation</aside></div>', 'exactly one docs article; found 0'],
+  ['duplicate article', '<article id="nd-page"></article><article id="nd-page"></article><div data-sidebar-placeholder><aside id="nd-sidebar"></aside></div>', 'exactly one docs article; found 2'],
+  ['missing sidebar', '<article id="nd-page"></article><div data-sidebar-placeholder></div>', 'found 0 sidebar(s)'],
+  ['missing placeholder', '<article id="nd-page"></article><aside id="nd-sidebar"></aside>', '0 placeholder(s)'],
+]) {
+  test(`rejects docs HTML with a ${name}`, async () => {
+    const distDir = await createDistFixture({ 'nested/page/index.html': html });
+
+    const errors = await validateDocsHtmlSourceOrder({ distDir });
+
+    assert(errors.some((error) => error.includes(expected)), errors.join('\n'));
+  });
+}
+
+test('ignores framework not-found HTML in the source-order gate', async () => {
+  const distDir = await createDistFixture({
+    'index.html': '<article id="nd-page"></article><div data-sidebar-placeholder><aside id="nd-sidebar"></aside></div>',
+    '404/index.html': '<h1>Not found</h1>',
+    '_not-found/index.html': '<h1>Not found</h1>',
+  });
+
+  const errors = await validateDocsHtmlSourceOrder({ distDir });
+
+  assert.deepEqual(errors, []);
+});
+
+test('keeps the repository llms.txt artifact valid', async () => {
+  const errors = await validateLlmsTxt();
+
+  assert.deepEqual(errors, []);
+});
 
 test('accepts markdown output for required files without the manifest', async () => {
   const distDir = await createDistFixture({

--- a/src/app/(docs)/layout.tsx
+++ b/src/app/(docs)/layout.tsx
@@ -3,6 +3,7 @@ import { baseOptions } from '@/lib/layout.shared';
 import { customTree } from '@/lib/custom-tree';
 import type { LinkItemType } from 'fumadocs-ui/layouts/shared';
 import { FaGithub, FaDiscord } from 'react-icons/fa6';
+import { ContentFirstSidebar } from '@/components/content-first-sidebar';
 
 export default function Layout({ children }: LayoutProps<'/'>) {
 
@@ -28,6 +29,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <DocsLayout
       {...baseOptions()}
+      sidebar={{ enabled: false }}
       tree={{
           name: 'docs',
           children: customTree
@@ -35,6 +37,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
       links={linkItems}
       >
       {children}
+      <ContentFirstSidebar />
     </DocsLayout>
   );
 }

--- a/src/components/content-first-sidebar.tsx
+++ b/src/components/content-first-sidebar.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Sidebar, useSidebar } from 'fumadocs-ui/layouts/docs/slots/sidebar';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function focusableElements(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => (
+      element.tabIndex >= 0
+      && element.getClientRects().length > 0
+      && !element.closest('[hidden],[aria-hidden="true"],[inert]')
+    ));
+}
+
+function activateDrawer(setOpen: (open: boolean) => void) {
+  const drawer = document.getElementById('nd-sidebar-mobile');
+  const layout = drawer?.parentElement;
+  const overlay = drawer?.previousElementSibling;
+  if (
+    !drawer
+    || !layout
+    || drawer.dataset.state !== 'open'
+    || !(overlay instanceof HTMLElement)
+    || overlay.dataset.state !== 'open'
+  ) {
+    return;
+  }
+
+  const activeElement = document.activeElement;
+  const trigger = activeElement instanceof HTMLElement && activeElement.matches('button[aria-label="Open Sidebar"]')
+    ? activeElement
+    : document.querySelector<HTMLElement>('header button[aria-label="Open Sidebar"]');
+
+  const previousTriggerExpanded = trigger ? trigger.getAttribute('aria-expanded') : null;
+  const previousTriggerControls = trigger ? trigger.getAttribute('aria-controls') : null;
+  trigger?.setAttribute('aria-expanded', 'true');
+  trigger?.setAttribute('aria-controls', drawer.id);
+
+  const previousRole = drawer.getAttribute('role');
+  const previousModal = drawer.getAttribute('aria-modal');
+  const previousLabel = drawer.getAttribute('aria-label');
+  const previousTabIndex = drawer.getAttribute('tabindex');
+  drawer.setAttribute('role', 'dialog');
+  drawer.setAttribute('aria-modal', 'true');
+  drawer.setAttribute('aria-label', 'Documentation navigation');
+  drawer.setAttribute('tabindex', '-1');
+
+  const closeButton = drawer.querySelector<HTMLElement>('button[aria-label="Open Sidebar"]');
+  const previousCloseLabel = closeButton ? closeButton.getAttribute('aria-label') : null;
+  closeButton?.setAttribute('aria-label', 'Close Sidebar');
+
+  drawer.focus({ preventScroll: true });
+
+  const inertedElements = Array.from(layout.children)
+    .filter((element): element is HTMLElement => (
+      element instanceof HTMLElement
+      && element !== drawer
+      && element !== overlay
+      && !element.inert
+    ));
+  for (const element of inertedElements) element.inert = true;
+
+  const previousBodyOverflow = document.body.style.overflow;
+  const previousRootOverflow = document.documentElement.style.overflow;
+  document.body.style.overflow = 'hidden';
+  document.documentElement.style.overflow = 'hidden';
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || event.isComposing) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (event.key !== 'Tab') return;
+
+    const focusable = focusableElements(drawer);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      drawer.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const current = document.activeElement;
+    if (event.shiftKey && (current === drawer || current === first || !drawer.contains(current))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && (current === drawer || current === last || !drawer.contains(current))) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+  document.addEventListener('keydown', handleKeyDown);
+
+  return () => {
+    document.removeEventListener('keydown', handleKeyDown);
+    for (const element of inertedElements) element.inert = false;
+    document.body.style.overflow = previousBodyOverflow;
+    document.documentElement.style.overflow = previousRootOverflow;
+
+    if (previousRole === null) drawer.removeAttribute('role');
+    else drawer.setAttribute('role', previousRole);
+    if (previousModal === null) drawer.removeAttribute('aria-modal');
+    else drawer.setAttribute('aria-modal', previousModal);
+    if (previousLabel === null) drawer.removeAttribute('aria-label');
+    else drawer.setAttribute('aria-label', previousLabel);
+    if (previousTabIndex === null) drawer.removeAttribute('tabindex');
+    else drawer.setAttribute('tabindex', previousTabIndex);
+    if (closeButton) {
+      if (previousCloseLabel === null) closeButton.removeAttribute('aria-label');
+      else closeButton.setAttribute('aria-label', previousCloseLabel);
+    }
+    if (trigger) {
+      if (previousTriggerExpanded === null) trigger.removeAttribute('aria-expanded');
+      else trigger.setAttribute('aria-expanded', previousTriggerExpanded);
+      if (previousTriggerControls === null) trigger.removeAttribute('aria-controls');
+      else trigger.setAttribute('aria-controls', previousTriggerControls);
+    }
+
+    if (window.matchMedia('(width < 768px)').matches && trigger?.isConnected) trigger.focus();
+  };
+}
+
+export function ContentFirstSidebar() {
+  const { mode, open, setOpen } = useSidebar();
+
+  useEffect(() => {
+    if (mode === 'full' && open) setOpen(false);
+  }, [mode, open, setOpen]);
+
+  useEffect(() => {
+    if (mode !== 'drawer' || !open) return;
+
+    let cleanup: (() => void) | undefined;
+    let frame = 0;
+    let attempts = 0;
+    const initialize = () => {
+      cleanup = activateDrawer(setOpen);
+      if (cleanup) return;
+      if (attempts < 2) {
+        attempts += 1;
+        frame = window.requestAnimationFrame(initialize);
+      } else {
+        setOpen(false);
+      }
+    };
+    initialize();
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      cleanup?.();
+    };
+  }, [mode, open, setOpen]);
+
+  return <Sidebar />;
+}


### PR DESCRIPTION
## Summary

- update `llms.txt` to the proposed structure with 332 direct Markdown links
- serialize each docs article before repeated navigation while preserving the desktop layout and accessible mobile drawer behavior
- enforce exact HTML/Markdown/`llms.txt` route parity, article-first source order, and malformed-artifact regressions in the production build

## Validation

- Node 22.22.2 / npm 10.9.7: `npm run quality`
  - 43 artifact/source-order tests and 2 routing tests passed
  - 338 static routes and 332 per-page Markdown files generated
  - 0 broken internal, anchor, external, or output links
- production export served on localhost
  - `npm run check:llm-md -- --base-url http://127.0.0.1:8080`
  - GET/HEAD, MIME, body-hash, missing-route, and retired-route checks passed
  - hydrated Chrome checks passed on five desktop pages and at 390×844 and 320×568, including focus trapping, inert background, all close paths, resize cleanup, and client routing
- AFDocs 0.18.7 and 0.19.0, deterministic full 332-page corpus
  - 332/332 links resolve as Markdown
  - 332/332 pages support `.md` URLs
  - content starts within the first 10% on all pages (median 3%)
  - localhost sitemap coverage was skipped by AFDocs; route parity is enforced independently by the build gate

## Notes

- the mobile focus wrapper depends on the DOM contract of the pinned Fumadocs version; its browser matrix should be rerun with future Fumadocs upgrades
- preview should recheck uppercase-path and encoded-dot behavior because the macOS localhost filesystem/server normalizes those probes
