### PR TITLE
Document September 2-11 WDK releases and update dependencies

### DIFF
--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,23 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### September 08, 2026
+
+**What's New**
+- **wallet-evm-erc-4337** ([v1.0.0-beta.19](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.19)): Monitor a known Safe address with `WalletAccountReadOnlyEvmErc4337.fromSafeAddress()` without its owner address or a seed phrase. Address validation now reports malformed owner inputs with `ValueError`.
+- **wdk-utils** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.12)): Add `validateTonAddress()` and `ton` dispatch for raw and checksum-validated user-friendly TON addresses. Require percent-encoded non-ASCII query text in BIP-21 and EIP-681 parsers, and fix key derivation with custom scrypt parameters above the default memory budget.
+
+**Changes**
+- **wdk-core** ([v1.0.0-beta.17](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.17)): [Breaking] Govern public account and protocol methods outside an explicit exclusion set, replacing the fixed operation list. Add method-name rules, `DEFAULT_POLICY_EXCLUSIONS`, constructor `policyExclusions`, and `getPolicyExclusions()`. Previously ungoverned calls can now require an `ALLOW` rule; rules naming excluded methods are rejected.
+- **lending-aave-evm** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.7)): Accept shared writable and read-only wallet-account interfaces and use callable account methods instead of concrete ERC-4337 class checks. Pass one transaction object to the account while preserving per-call configuration forwarding. Supply and repayment continue to require a separate token approval to the Pool.
+- **swap-velora-evm** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-protocol-swap-velora-evm/releases/tag/v1.0.0-beta.8)): Forward one swap transaction and the per-call configuration to compatible accounts. Apply per-call `swapMaxFee` to standard EVM accounts as well as ERC-4337 accounts, in the account's quoted fee units. A fee equal to or above the cap is rejected. Input-token approval remains caller-owned.
+- **worklet-bundler** ([v1.0.0-beta.13](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.13)): Publish a maintenance release with an updated CLI version. The bundled runtime and public declarations are unchanged apart from the CLI's reported version.
+
+**Fixes**
+- **react-native-core** ([v1.0.0-beta.19](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.19)): Load Zod's compiler through a side-effect import for Metro and update Zod to `^4.5.4`. Public schemas and peer requirements are unchanged. The npm artifact still omits its declared default `dist` entrypoints; use the React Native source condition.
+
+---
+
 ### September 03, 2026
 
 **What's New**
@@ -36,7 +53,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 **Fixes**
 - **wallet-evm-erc-4337** ([v1.0.0-beta.17](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.17)): Allow a quoted or submitted fee equal to the configured maximum, classify AA50 prefund failures as insufficient-balance transaction errors, and add typed validation for configuration, providers, fee caps, and nonce ranges. The published per-call declarations still omit the runtime-supported `parallel` and `nonceKey` fields.
-- **lending-aave-evm** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.6)): Forward each operation's optional second `config` argument to the account's quote or send method. ERC-4337 accounts consume the gas-payment override; standard EVM accounts accept and silently ignore it.
+- **lending-aave-evm** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.6)): Forward each operation's optional `config` argument to the account's quote or send method. ERC-4337 accounts consume the gas-payment override; standard EVM accounts accept and silently ignore it.
 - **worklet-bundler** ([v1.0.0-beta.11](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.11)): Include `@tetherto/pear-wrk-wdk` in dependency validation and `generate --install` for both transports. When `bare-pack` reports an unresolved package subpath, the CLI now suggests the installable package root with the detected npm, Yarn, or pnpm command; the package-root normalization helper is internal to the CLI bundle and is not a public export.
 
 **Changes**

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,25 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### September 03, 2026
+
+**What's New**
+- **worklet-bundler** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.12)): Generate generic modules, method allowlists, and module suspend/resume handlers for JSON-RPC. Add `options.handleLeakCheck` for opt-in HRPC handle diagnostics; use Pear Worklet beta.13 for these runtime features.
+- **wallet-evm-7702-gasless** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm-7702-gasless/releases/tag/v1.0.0-beta.5)): Add configurable EntryPoint v0.8/v0.9 with matching delegation implementations, and check configured `chainId` on the first UserOperation chain lookup.
+
+**Fixes**
+- **bridge-usdt0-evm** ([v1.0.0-beta.9](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/releases/tag/v1.0.0-beta.9)): Accept shared WDK account interfaces and allow EVM-compatible accounts with a callable `sendTransaction()` to execute `bridge()`. ERC-4337 helper selection and approval batching still depend on the bridge package's concrete account classes.
+- **wallet-evm-erc-4337** ([v1.0.0-beta.18](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.18)): Validate the provider against configured `chainId` on the first chain lookup before building UserOperations for signing.
+
+---
+
+### September 02, 2026
+
+**Changes**
+- **pear-wrk-wdk** ([v1.0.0-beta.13](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.13)): [Breaking] Remove the `callMethod()` default-value fallback; missing methods now fail with `BAD_REQUEST`. Add generic-module calls and events over JSON-RPC, opt-in suspend handle diagnostics, and narrower logging of request and mnemonic data.
+
+---
+
 ### August 30, 2026
 
 **What's New**

--- a/content/docs/overview/changelog.mdx
+++ b/content/docs/overview/changelog.mdx
@@ -10,6 +10,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### September 11, 2026
+
+**Changes**
+- **pear-wrk-wdk** ([v1.0.0-beta.14](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.14)): [Breaking] Remove `CallMethodOptions.transformResult`; transform responses in the host. Zero the retained seed buffer on full disposal and seed replacement; targeted disposal and config-only reinitialization retain it. Add named-field log redaction, default unknown log levels to `ERROR`, and omit native parser details from invalid-JSON field errors. Normalize generic-module void results to `null`, fix HRPC module-event forwarding, and update optional `bare-walk-handles` to `^2.1.0`.
+
+---
+
 ### September 08, 2026
 
 **What's New**

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/api-reference.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/api-reference.mdx
@@ -24,7 +24,7 @@ new Usdt0ProtocolEvm(account, config?)
 ```
 
 **Parameters:**
-- `account` (WalletAccountEvm | WalletAccountEvmErc4337 | WalletAccountReadOnlyEvm | WalletAccountReadOnlyEvmErc4337): The wallet account to use for bridge operations
+- `account` (`IWalletAccount` or `IWalletAccountReadOnly` from `@tetherto/wdk-wallet`): The wallet account to use for bridge operations. See [account requirements](#account-requirements).
 - `config` (BridgeProtocolConfig, optional): Configuration object
   - `bridgeMaxFee` (number | bigint, optional): Rejects `bridge()` when the implementation's combined fee value is at or above this cap
 
@@ -41,6 +41,18 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
   bridgeMaxFee: 1000000000000000n // Standard Ethereum account: source native base units
 })
 ```
+
+### Account requirements
+
+The constructor accepts the shared `IWalletAccount` and `IWalletAccountReadOnly` interfaces in `1.0.0-beta.9`. For execution, `bridge()` checks whether the account has a callable `sendTransaction()` method instead of requiring a `WalletAccountEvm` instance.
+
+The account must still implement EVM-compatible `getAddress()` and `quoteSendTransaction()` operations. Both bridge methods require an RPC URL or EIP-1193 provider in the wallet configuration. The constructor reads `account._config.provider`, an internal field absent from the shared interfaces. Implementing the interface alone does not establish runtime compatibility; an account without `_config` fails construction.
+
+Read-only accounts can use `quoteBridge()`, subject to the same provider, route, balance, and allowance requirements. They cannot execute `bridge()` without `sendTransaction()`.
+
+<Callout type="warn">
+ERC-4337 helper selection and approval batching still depend on the concrete classes resolved by the bridge package: `WalletAccountReadOnlyEvmErc4337` for helper construction and quotes, and `WalletAccountEvmErc4337` for execution. A custom account or an account from a separate copy of the ERC-4337 package does not receive that path solely because it implements `sendTransaction()`. The bridge release depends on ERC-4337 wallet `1.0.0-beta.11`; verify package deduplication and runtime class identity when combining wallet versions. See [Bridge with ERC-4337](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337#prerequisites).
+</Callout>
 
 ### Methods
 
@@ -70,7 +82,7 @@ With a standard EVM account, approve the source-chain bridge spender before call
 **Returns:** `Promise<BridgeResult>` - Bridge operation result
 
 **Throws:**
-- Error if account is read-only
+- Error if the account has no callable `sendTransaction()` method
 - Error if no provider is configured
 - Error if the combined fee value is equal to or greater than `bridgeMaxFee`
 
@@ -88,7 +100,7 @@ await standardAccount.approve({
 const result = await standardBridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...', // Recipient address
-  token: '0x...', // ₮ contract address
+  token: '0x...', // USDt contract address
   amount: 1000000n,
   oftContractAddress: '0x...' // Same address used as approval spender
 })
@@ -116,7 +128,7 @@ console.log('Bridge fee:', result2.bridgeFee)
 ```
 
 #### `quoteBridge(options, config?)`
-Estimates the cost of a bridge operation without executing it.
+Estimates the cost of a bridge operation without executing it. Read-only accounts are accepted, and this method does not enforce `bridgeMaxFee`.
 
 For standard EVM accounts, some providers estimate the same bridge transaction that `bridge()` sends. If that estimate fails because token allowance is missing, approve the source-chain bridge spender before calling `quoteBridge()`. ERC-4337 quotes include the bundled approval transaction. For `WalletAccountReadOnlyEvmErc4337`, `quoteBridge()` uses the same ordered batch as `bridge()`: on Ethereum mainnet for the resolved USD₮ token at `0xdAC17F958D2ee523a2206206994597C13D831ec7`, an existing non-zero allowance and non-zero `approveAmount` produce `approve(spender, 0)`, `approve(spender, approveAmount)`, then the helper bridge call; otherwise the batch is the approval followed by the helper call.
 
@@ -239,13 +251,14 @@ type Erc4337BridgeConfig = Erc4337QuoteConfig & {
 
 | Account flow | `fee` | `bridgeFee` |
 |---|---|---|
-| Standard EVM | Source-chain native base units | Source-chain native base units |
+| `WalletAccountEvm` | Source-chain native base units | Source-chain native base units |
+| Other compatible accounts using the single-transaction path | Account-specific `quoteSendTransaction()` fee units | Source-chain native base units |
 | ERC-4337 with native gas | Source-chain native base units | Bridged-token base units |
 | ERC-4337 with token-paid gas | Paymaster-token base units | Bridged-token base units |
 | ERC-4337 with sponsored gas | `0` | Bridged-token base units |
 
 <Callout type="warn">
-In `1.0.0-beta.7`, the ERC-4337 path numerically adds `fee + bridgeFee` when checking `bridgeMaxFee`, even when the fields have different denominations. Do not interpret that sum as a total monetary cost. Set an ERC-4337 cap only after confirming that the selected account payment mode produces compatible units. The equality boundary is rejected.
+In `1.0.0-beta.9`, `bridge()` numerically adds `fee + bridgeFee` when checking `bridgeMaxFee`, even when the fields have different denominations. This affects ERC-4337 helper flows and any compatible account whose quoted fee is not in source-chain native base units. Do not interpret that sum as a total monetary cost. Set a cap only after confirming that the selected account payment mode produces compatible units. The equality boundary is rejected.
 </Callout>
 
 `Erc4337QuoteConfig` is a partial operation-level override of the wallet's token-paid, sponsored, or native-gas configuration. Sponsored gas uses `isSponsored: true` and can include `sponsorshipPolicyId`; native gas uses `useNativeCoins: true`. See the [ERC-4337 wallet configuration](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) for the complete account requirements.

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/configuration.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/configuration.mdx
@@ -27,7 +27,9 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 
 ## Account Configuration
 
-The bridge protocol uses the wallet account's configuration for blockchain access:
+The constructor accepts `IWalletAccount` or `IWalletAccountReadOnly` from `@tetherto/wdk-wallet`. Execution requires EVM transaction support and a callable `sendTransaction()` method; read-only accounts can quote. See [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) for custom accounts and ERC-4337 class identity.
+
+The bridge protocol reads the provider from the wallet account's internal configuration for blockchain access:
 
 ```javascript
 import { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
@@ -64,10 +66,10 @@ The `bridgeMaxFee` option rejects `bridge()` when the implementation's `fee + br
 
 **Type:** `number | bigint` (optional)
 
-For a standard EVM account, both fields use the source chain's native base unit. For example, Ethereum and Arbitrum report the values in wei.
+For `WalletAccountEvm`, both fields use the source chain's native base unit, such as wei on Ethereum and Arbitrum. Other compatible accounts retain their own `quoteSendTransaction()` fee denomination, while the single-transaction path still returns `bridgeFee` in source native base units. Confirm the units match before setting a cap.
 
 <Callout type="warn">
-For an ERC-4337 helper flow, `bridgeFee` is in bridged-token base units. The account's `fee` uses native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. In `1.0.0-beta.7`, the protocol numerically adds these values when enforcing `bridgeMaxFee`. Do not treat that sum as one currency or set a cap until your payment mode uses compatible units.
+For an ERC-4337 helper flow, `bridgeFee` is in bridged-token base units. The account's `fee` uses native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. In `1.0.0-beta.9`, the protocol numerically adds these values when enforcing `bridgeMaxFee`. Do not treat that sum as one currency or set a cap until your payment mode uses compatible units.
 </Callout>
 
 **Examples:**
@@ -102,7 +104,7 @@ try {
 
 ### Provider
 
-The `provider` option comes from the wallet account configuration and specifies how to connect to the blockchain.
+The `provider` option comes from the wallet account configuration and specifies how to connect to the blockchain. Both `bridge()` and `quoteBridge()` require it. The constructor reads `account._config.provider`; `_config` is not part of the shared account interfaces, so accepting an interface in TypeScript does not guarantee runtime compatibility.
 
 **Type:** `string | Eip1193Provider`
 
@@ -125,7 +127,7 @@ Pass either an RPC URL string or a genuine EIP-1193 provider. An ethers `JsonRpc
 
 ## ERC-4337 Configuration
 
-When using ERC-4337 accounts, you can override configuration options during bridge operations:
+When using ERC-4337 accounts recognized by the bridge package's concrete class checks, you can override configuration options during bridge operations. Review the [class identity requirement](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) before combining package versions:
 
 ```javascript
 // Bridge with ERC-4337 account

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem.mdx
@@ -3,7 +3,7 @@ title: Bridge Cross-Ecosystem
 description: Send USD₮0 from EVM toward Solana, TON, or TRON recipients.
 ---
 
-This guide covers [prerequisites](#prerequisites) and how to [bridge to Solana](#bridge-to-solana), [bridge to TON](#bridge-to-ton), and [bridge to TRON](#bridge-to-tron) using [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config). The same [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#usdt0protocolevm) instance you use for EVM destinations applies; only `targetChain` and `recipient` formats change.
+This guide covers [prerequisites](#prerequisites), how to [verify the route](#verify-the-route), and how to [bridge to Solana](#bridge-to-solana), [bridge to TON](#bridge-to-ton), and [bridge to TRON](#bridge-to-tron) using [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config). The same [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#usdt0protocolevm) instance you use for EVM destinations applies; only `targetChain` and `recipient` formats change.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ The examples below use a standard EVM account. For `USDT_BRIDGE_SPENDER_ADDRESS`
 
 ## Verify the route
 
-For Solana, TON, and TRON targets, beta.7 does not auto-resolve the source chain's ordinary USD₮0 OFT. Its bundled auto-resolution candidates are:
+For Solana, TON, and TRON targets, the protocol does not auto-resolve the source chain's ordinary USD₮0 OFT. Its bundled auto-resolution candidates are:
 
 | Source token contract family | EVM source chains with a bundled candidate |
 |---|---|

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337.mdx
@@ -10,6 +10,7 @@ This guide covers [prerequisites](#prerequisites), how to [create an ERC-4337 ac
 * `@tetherto/wdk-wallet-evm-erc-4337` installed alongside [@tetherto/wdk-protocol-bridge-usdt0-evm](https://www.npmjs.com/package/@tetherto/wdk-protocol-bridge-usdt0-evm).
 * Bundler and paymaster endpoints for your chain (example uses Arbitrum public URLs from the API reference).
 * An ERC-4337 source chain with a configured transaction-value helper: Ethereum, Arbitrum, Plasma, or Polygon.
+* An account recognized as the same ERC-4337 class instance used by the bridge package. In `1.0.0-beta.9`, the bridge depends on ERC-4337 wallet `1.0.0-beta.11` and still uses concrete class checks for its helper and batching flow. Separate package copies, including those introduced by differing versions, can miss this path. Verify deduplication and runtime class identity before using this guide. The new `sendTransaction()` capability check alone does not enable batching. See [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements).
 
 ## Create a WalletAccountEvmErc4337 account
 
@@ -72,7 +73,7 @@ The bundled approval sequence and helper call produce one UserOperation hash. Fo
 </Callout>
 
 <Callout type="warn">
-In `1.0.0-beta.7`, `bridgeFee` for this helper flow is in bridged-token base units. The account's `fee` is in native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. The protocol numerically adds those values when enforcing `bridgeMaxFee`. Do not interpret the sum as one currency or set an ERC-4337 cap until your integration has confirmed compatible units for its payment mode.
+In `1.0.0-beta.9`, `bridgeFee` for this helper flow is in bridged-token base units. The account's `fee` is in native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. The protocol numerically adds those values when enforcing `bridgeMaxFee`. Do not interpret the sum as one currency or set an ERC-4337 cap until your integration has confirmed compatible units for its payment mode.
 </Callout>
 
 <Callout type="warn">

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started.mdx
@@ -3,7 +3,7 @@ title: Get Started
 description: Install the bridge package, wire WalletAccountEvm, and review supported chains.
 ---
 
-This guide shows how to [install the package](#install-the-package), [create an EVM account](#create-an-evm-account), [instantiate the bridge protocol](#instantiate-the-bridge-protocol), and review [supported chains](#supported-chains).
+This guide shows how to [install the package](#install-the-package), [create an EVM account](#create-an-evm-account), [instantiate the bridge protocol](#instantiate-the-bridge-protocol), [use a read-only account](#use-a-read-only-account-optional), and review [supported chains](#supported-chains).
 
 ## Install the package
 
@@ -15,7 +15,7 @@ This guide shows how to [install the package](#install-the-package), [create an 
 You can add the published package to your project from npm: [@tetherto/wdk-protocol-bridge-usdt0-evm](https://www.npmjs.com/package/@tetherto/wdk-protocol-bridge-usdt0-evm).
 
 ```bash title="Install @tetherto/wdk-protocol-bridge-usdt0-evm"
-npm install @tetherto/wdk-protocol-bridge-usdt0-evm
+npm install @tetherto/wdk-protocol-bridge-usdt0-evm @tetherto/wdk-wallet-evm
 ```
 
 ## Create an EVM account
@@ -51,8 +51,23 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 For standard EVM accounts, `fee` and `bridgeFee` are source-chain native base units. ERC-4337 fee units depend on the account's gas-payment mode while `bridgeFee` is returned in bridged-token base units. Read [Fee units and `bridgeMaxFee`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#fee-units-and-bridgemaxfee) before setting a cap for an ERC-4337 flow.
 
 <Callout type="info">
-The account must not be read-only. Read-only accounts cannot call [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference).
+The constructor also accepts the shared WDK account interfaces. [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) requires a callable `sendTransaction()` method and EVM transaction support. Read [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) before supplying a custom account or combining ERC-4337 package versions.
 </Callout>
+
+## Use a read-only account (optional)
+
+For quotes without signing, create a [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm) for the source address and pass it to [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#constructor):
+
+```javascript title="Create a read-only bridge"
+import { WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
+
+const readOnlyAccount = new WalletAccountReadOnlyEvm(await account.getAddress(), {
+  provider: 'https://eth.drpc.org'
+})
+const readOnlyBridge = new Usdt0ProtocolEvm(readOnlyAccount)
+```
+
+You can now call [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) with your route options. The source address needs any allowance and balance required by the route's gas estimate; a read-only account cannot grant that allowance. Calling [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) on this instance rejects before sending a transaction.
 
 ## Supported chains
 

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/guides/handle-errors.mdx
@@ -7,7 +7,7 @@ This guide describes [errors thrown by the bridge](#errors-from-the-bridge-proto
 
 ## Errors from the bridge protocol
 
-Calls to [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) and [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) throw when the account is read-only, no provider is configured, the route is invalid, the combined fee value is at or above [`bridgeMaxFee`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeprotocolconfig), or the destination matches the source chain. The [API reference](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#error-handling) lists representative `error.message` substrings.
+Both [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) and [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) require a provider and valid route options. Only execution rejects an account without a callable `sendTransaction()` method and enforces [`bridgeMaxFee`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeprotocolconfig). Read-only accounts can quote; a quote does not enforce the cap. For auto-resolved routes, the source and destination must differ. The [API reference](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#error-handling) lists representative `error.message` substrings.
 
 ## Catch and branch on error messages
 

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/index.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/index.mdx
@@ -13,7 +13,7 @@ Use the USD₮0 bridge module to move USD₮0 and XAU₮0 across supported chain
 - **LayerZero Integration**: Uses LayerZero protocol for secure cross-chain transfers
 - **Expanded Multi-Chain Support**: Discover 25 configured EVM and non-EVM network keys
 - **Non-EVM Destinations**: Bridge toward Solana, TON, and TRON when the source token has a compatible route contract
-- **Account Abstraction**: Works with both standard EVM wallets and ERC-4337 smart accounts
+- **Account Compatibility**: Accepts the shared WDK account interfaces; execution requires a callable `sendTransaction()` method and EVM transaction support. See [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) for ERC-4337 batching limits.
 - **Fee Management**: Built-in fee calculation and bridge cost estimation
 - **Token Support**: Supports USD₮0 and XAU₮0 ecosystem tokens
 - **Route Overrides**: Custom OFT contract addresses and destination endpoint IDs
@@ -62,7 +62,7 @@ All source chains above, plus:
 
 ### Non-EVM route candidates
 
-For auto-resolved routes toward Solana, TON, or TRON, beta.7 skips the source chain's ordinary `oftContract`. The bundled configuration can instead consider these source contracts:
+For auto-resolved routes toward Solana, TON, or TRON, the protocol skips the source chain's ordinary `oftContract`. The bundled configuration can instead consider these source contracts:
 
 | Source token contract family | EVM source chains with a bundled candidate |
 |---|---|
@@ -84,7 +84,7 @@ Standard EVM accounts can use every supported EVM source route with a matching t
 </Callout>
 
 <Callout type="warn">
-ERC-4337 `fee` and `bridgeFee` values can use different denominations in `1.0.0-beta.7`. Review the [fee-unit limitation](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#fee-units-and-bridgemaxfee) before configuring `bridgeMaxFee`.
+ERC-4337 `fee` and `bridgeFee` values can use different denominations in `1.0.0-beta.9`. Review the [fee-unit limitation](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#fee-units-and-bridgemaxfee) before configuring `bridgeMaxFee`.
 </Callout>
 
 ## Next Steps

--- a/content/docs/sdk/bridge-modules/bridge-usdt0-evm/usage.mdx
+++ b/content/docs/sdk/bridge-modules/bridge-usdt0-evm/usage.mdx
@@ -13,7 +13,7 @@ The [@tetherto/wdk-protocol-bridge-usdt0-evm](https://www.npmjs.com/package/@tet
 
 <Cards>
 <Card title="Get Started" href="/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started">
-Install the package, attach WalletAccountEvm, and review supported chains.
+Install the package, attach a signing or read-only EVM account, and review supported chains.
 </Card>
 <Card title="Bridge Tokens" href="/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens">
 EVM-to-EVM bridges, quotes, fee caps, and optional OFT or endpoint overrides.

--- a/content/docs/sdk/core-module/api-reference.mdx
+++ b/content/docs/sdk/core-module/api-reference.mdx
@@ -28,9 +28,9 @@ new WDK(seed, options?)
 
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
-- `options` (`WdkOptions`, optional): Instance settings. `maxConditionTimeoutMs` is a finite positive number that caps every policy condition timeout on this WDK instance and defaults to `30000` milliseconds.
+- `options` (`WdkOptions`, optional): Instance settings. `maxConditionTimeoutMs` is a finite positive number that caps every policy condition timeout on this WDK instance and defaults to `30000` milliseconds. `policyExclusions?: string[]` appends non-empty method names to the default policy exclusions.
 
-**Throws:** `Error` if the seed is invalid. Throws `PolicyConfigurationError` if `options` fails the published options schema, such as an array or primitive value, or if `maxConditionTimeoutMs` is not a finite positive number.
+**Throws:** `Error` if the seed is invalid. Throws `PolicyConfigurationError` if `options` fails the published options schema, such as an array or primitive value, if `maxConditionTimeoutMs` is not a finite positive number, or if `policyExclusions` is not an array of non-empty strings.
 
 **Example:**
 ```javascript title="Initialize WDK"
@@ -56,13 +56,14 @@ const policyWdk = new WDK(seedBytes, {
 | `registerWallet(blockchain, wallet, config)` | Registers a new wallet manager for a blockchain | `WDK` | If a wallet is already registered for that blockchain |
 | `registerProtocol(blockchain, label, protocol, config)` | Registers a protocol globally for a blockchain | `WDK` | - |
 | `registerMiddleware(blockchain, middleware)` | Registers middleware for account decoration | `WDK` | - |
-| `registerPolicy(policies, options?)` | Registers local transaction policies for wallet account and protocol write methods | `WDK` | If policy configuration is invalid |
+| `getPolicyExclusions()` | Returns the resolved method names that bypass policy evaluation | `readonly string[]` | - |
+| `registerPolicy(policies, options?)` | Registers local transaction policies for governed wallet account and protocol methods | `WDK` | If policy configuration is invalid |
 | `getAccount(blockchain, index?)` | Returns a wallet account for a blockchain and index | `Promise<WdkAccount>` | If wallet not registered |
 | `getAccountByPath(blockchain, path)` | Returns a wallet account for a blockchain and derivation path | `Promise<WdkAccount>` | If wallet not registered |
 | `getFeeRates(blockchain)` | Returns current fee rates for a registered blockchain | `Promise<FeeRates>` | If wallet not registered |
 | `dispose(blockchains?)` | Disposes all registered wallets, or only the named blockchains, and clears keys and account state managed by WDK | `void` | - |
 
-##### `registerWallet(blockchain, wallet, config)`
+#### `registerWallet(blockchain, wallet, config)`
 Registers a new wallet manager for a specific blockchain.
 
 **Type Parameters:**
@@ -102,7 +103,7 @@ const wdk2 = new WDK(seedPhrase)
   .registerWallet('ton', WalletManagerTon, tonWalletConfig)
 ```
 
-##### `registerProtocol(blockchain, label, protocol, config)`
+#### `registerProtocol(blockchain, label, protocol, config)`
 Registers a protocol globally for all accounts of a specific blockchain.
 
 For swidge or Smart Deposit Address (SDA) integrations, pass a concrete provider class that extends the corresponding base class from `@tetherto/wdk-wallet/protocols`.
@@ -145,7 +146,7 @@ const wdk2 = new WDK(seedPhrase)
   .registerProtocol('ethereum', 'velora', veloraProtocolEvm, veloraProtocolConfig)
 ```
 
-##### `registerMiddleware(blockchain, middleware)`
+#### `registerMiddleware(blockchain, middleware)`
 Registers middleware for account decoration and enhanced functionality.
 
 **Parameters:**
@@ -179,10 +180,25 @@ const wdk2 = new WDK(seedPhrase)
   })
 ```
 
-##### `registerPolicy(policies, options?)`
+#### `getPolicyExclusions()`
+
+Returns a frozen array containing [`DEFAULT_POLICY_EXCLUSIONS`](#default-policy-exclusions) followed by any additional `policyExclusions` passed to the constructor, with duplicate names removed. Names match globally across accounts and protocols on this instance; they are not scoped by wallet or protocol label.
+
+**Parameters:** None.
+
+**Returns:** `readonly string[]`. The returned array cannot be mutated, and it is not a setter for the engine's exclusions. Defaults remain present even when the constructor receives an empty array.
+
+You can check whether a named method bypasses policy evaluation:
+
+```javascript title="Inspect Policy Exclusions"
+const excludedMethods = wdk.getPolicyExclusions()
+console.log(excludedMethods.includes('getBalance')) // true
+```
+
+#### `registerPolicy(policies, options?)`
 Registers one or more local transaction policies on the WDK instance.
 
-Policies are evaluated before wrapped account and protocol write methods execute. Matching `DENY` rules and governed-account default-deny outcomes throw `PolicyViolationError`; matching `ALLOW` rules permit the call only when no higher-priority `DENY` rule applies. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
+Policies are evaluated before governed account and protocol methods execute. In beta.17, the proxy discovers public string-named methods on the account or protocol and its prototype chain, then wraps those absent from the resolved exclusion set. This replaces the earlier fixed write-method list; see [coverage and limits](/sdk/core-module/guides/transaction-policies#supported-operations). Matching `DENY` rules and governed-account default-deny outcomes throw `PolicyViolationError`; matching `ALLOW` rules permit the call only when no higher-priority `DENY` rule applies. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
 
 Evaluation order:
 
@@ -204,7 +220,7 @@ Distinct policy IDs keep their original per-registration timeouts. A repeated ID
 
 **Returns:** `WDK` - The WDK instance (supports method chaining)
 
-**Throws:** `PolicyConfigurationError` if a policy or option fails validation, if an account-scoped policy omits its account binding, or if a policy references a wallet identifier that has not been registered. Governed write calls also throw `PolicyConfigurationError` when WDK cannot snapshot a method argument safely.
+**Throws:** `PolicyConfigurationError` if a policy or option fails validation, if an account-scoped policy omits its account binding, if a policy references a wallet identifier that has not been registered, or if a rule names an excluded method. Governed calls also throw `PolicyConfigurationError` when WDK cannot snapshot a method argument safely.
 
 **Example:**
 ```typescript title="Register A Send Policy"
@@ -264,13 +280,11 @@ try {
 }
 ```
 
-Supported `PolicyOperation` values are `sendTransaction`, `signTransaction`, `transfer`, `approve`, `sign`, `signTypedData`, `signAuthorization`, `delegate`, `revokeDelegation`, `swap`, `bridge`, `supply`, `withdraw`, `borrow`, `repay`, `buy`, `sell`, `swidge`, `createDepositAddress`, `renewDepositAddress`, `recoverDepositAddress`, `disableDepositAddress`, and `*`.
+`PolicyOperation` is a string. A rule accepts one non-empty method name, a non-empty array of names, or `*` for all governed methods. Use the method's exact spelling: an unknown name registers but never matches a different method. Explicitly naming an excluded method fails registration; a wildcard does not include excluded methods.
 
-Use `sign` for message-style signing in this release. `signMessage` and `signHash` are not valid policy operation names.
+Governed methods return Promises, including methods whose underlying implementation is synchronous. Pass plain data arguments; object arguments are cloned before evaluation and execution, which can change class-instance semantics. See [argument handling and runtime caveats](/sdk/core-module/guides/transaction-policies#runtime-caveats) before governing callback-based or custom methods.
 
-Policy-enforced calls snapshot method arguments before evaluation and forward the same approved values to the wallet method. Pass structured-cloneable values such as primitives, plain objects, arrays, `bigint`, and typed arrays. Non-cloneable governed arguments fail closed with `PolicyConfigurationError`.
-
-##### `getAccount(blockchain, index?)`
+#### `getAccount(blockchain, index?)`
 Returns a wallet account for a specific blockchain and index using BIP-44 derivation.
 
 **Parameters:**
@@ -300,7 +314,7 @@ try {
 }
 ```
 
-##### `getAccountByPath(blockchain, path)`
+#### `getAccountByPath(blockchain, path)`
 Returns a wallet account for a specific blockchain and BIP-44 derivation path.
 
 **Parameters:**
@@ -320,7 +334,7 @@ const account = await wdk.getAccountByPath('ethereum', "0'/0/1")
 const customAccount = await wdk.getAccountByPath('ton', "1'/2/3")
 ```
 
-##### `getFeeRates(blockchain)`
+#### `getFeeRates(blockchain)`
 Returns current fee rates for a registered blockchain.
 
 **Parameters:**
@@ -336,7 +350,7 @@ const feeRates = await wdk.getFeeRates('ethereum')
 console.log('Fee rates:', feeRates)
 ```
 
-##### `dispose(blockchains?)`
+#### `dispose(blockchains?)`
 Disposes all registered wallets when called without arguments, or only the wallets for the named blockchains when you pass a string array.
 
 This clears keys and account state managed by WDK, including private keys held by registered wallets. It does not mutate or zero the seed value passed to `new WDK(seed)`. See [Seed Lifecycle](/sdk/core-module/guides/error-handling#seed-lifecycle) for the recommended cleanup pattern.
@@ -360,7 +374,7 @@ wdk.dispose(['ethereum'])
 | `getRandomSeedPhrase(wordCount?)` | Returns a random BIP-39 seed phrase (12 or 24 words) | `string` |
 | `isValidSeed(seed)` | Checks if a seed phrase or seed bytes value is valid | `boolean` |
 
-##### `getRandomSeedPhrase(wordCount?)`
+#### `getRandomSeedPhrase(wordCount?)`
 Returns a random BIP-39 seed phrase. Supports both 12-word (128-bit entropy) and 24-word (256-bit entropy) seed phrases.
 
 **Parameters:**
@@ -381,7 +395,7 @@ await presentSeedPhraseForSecureBackup(seedPhrase24)
 
 `presentSeedPhraseForSecureBackup()` represents an application-owned, non-logging backup flow. Never send a generated seed phrase to console output, telemetry, crash reports, or a remote service.
 
-##### `isValidSeed(seed)`
+#### `isValidSeed(seed)`
 Checks if a seed phrase or seed bytes value is valid.
 
 **Parameters:**
@@ -397,6 +411,20 @@ console.log('Seed phrase valid:', isValid) // true
 const isInvalid = WDK.isValidSeed('invalid seed phrase')
 console.log('Seed phrase valid:', isInvalid) // false
 ```
+
+### Default Policy Exclusions
+
+A root export with type `readonly string[]`. This frozen array lists method names that bypass policy evaluation by default, including `getBalance`, `quoteSendTransaction`, `dispose`, and `toReadOnlyAccount`.
+
+You can inspect the defaults without creating a wallet:
+
+```javascript title="Inspect Default Policy Exclusions"
+import { DEFAULT_POLICY_EXCLUSIONS } from '@tetherto/wdk'
+
+console.log(DEFAULT_POLICY_EXCLUSIONS.includes('getBalance')) // true
+```
+
+The list matches exact names, not prefixes: a new `get*` or `quote*` method is not automatically excluded. Use [`getPolicyExclusions()`](#getpolicyexclusions) to include the instance's custom additions. See [configuration](/sdk/core-module/configuration#policy-method-exclusions) before adding exclusions.
 
 ## IWalletAccount
 
@@ -963,35 +991,13 @@ type MiddlewareFunction = <A extends IWalletAccount>(
 ```typescript title="Types: Policy Engine"
 interface WdkOptions {
   maxConditionTimeoutMs?: number
+  policyExclusions?: string[]
 }
 
 type PolicyAction = 'ALLOW' | 'DENY'
 type PolicyScope = 'project' | 'account'
 
-type PolicyOperation =
-  | 'sendTransaction'
-  | 'signTransaction'
-  | 'transfer'
-  | 'approve'
-  | 'sign'
-  | 'signTypedData'
-  | 'signAuthorization'
-  | 'delegate'
-  | 'revokeDelegation'
-  | 'swap'
-  | 'bridge'
-  | 'supply'
-  | 'withdraw'
-  | 'borrow'
-  | 'repay'
-  | 'buy'
-  | 'sell'
-  | 'swidge'
-  | 'createDepositAddress'
-  | 'renewDepositAddress'
-  | 'recoverDepositAddress'
-  | 'disableDepositAddress'
-  | '*'
+type PolicyOperation = string
 
 type PolicyCondition = (context: PolicyContext) => boolean | Promise<boolean>
 

--- a/content/docs/sdk/core-module/configuration.mdx
+++ b/content/docs/sdk/core-module/configuration.mdx
@@ -16,7 +16,7 @@ import WDK from '@tetherto/wdk'
 const wdk = new WDK(seedPhrase)
 ```
 
-The WDK Manager requires a seed phrase or seed bytes. Its optional second argument sets instance-level policy limits; wallet and protocol configuration remains registration-based.
+The WDK Manager requires a seed phrase or seed bytes. Its optional second argument sets instance-level policy limits and method exclusions; wallet and protocol configuration remains registration-based.
 
 ### Policy Condition Timeout Ceiling
 
@@ -27,6 +27,28 @@ const wdk = new WDK(seedPhrase, {
 ```
 
 `maxConditionTimeoutMs` is the maximum time any one policy condition can receive through `registerPolicy(..., { conditionTimeoutMs })`. It defaults to `30000` milliseconds and must be a finite positive number. A policy that requests a larger timeout is capped to this ceiling rather than rejected. Each `registerPolicy()` call applies its requested timeout only to the policies registered by that call.
+
+### Policy Method Exclusions
+
+Starting in `@tetherto/wdk` v1.0.0-beta.17, `policyExclusions` optionally adds method names that bypass policy evaluation on this WDK instance. It accepts an array of non-empty strings. The resolved set always includes [`DEFAULT_POLICY_EXCLUSIONS`](/sdk/core-module/api-reference#default-policy-exclusions); passing `[]` does not remove the defaults.
+
+An exclusion applies to the exact method name across every governed account and protocol on the instance. Review the method's behavior on each applicable module before excluding it. To permit a write while retaining evaluation and simulation, register an `ALLOW` rule instead.
+
+You can opt out of evaluating Spark's local balance synchronization using the constructor option:
+
+```javascript title="Configure A Method Exclusion"
+import WDK from '@tetherto/wdk'
+
+const wdk = new WDK(seedPhrase, {
+  policyExclusions: ['syncWalletBalance']
+})
+```
+
+This configuration bypasses evaluation for `syncWalletBalance`, which is governed by default. It does not grant permission to other Spark methods. Wallet and policy registration still happen separately.
+
+Inspect the resolved names with [`getPolicyExclusions()`](/sdk/core-module/api-reference#getpolicyexclusions). Duplicate names appear once, and the returned array is frozen. Names that no installed account exposes are accepted without an existence check. Exclusions are fixed when the WDK instance is created; mutating the input array later does not change them.
+
+`registerPolicy()` rejects a rule that explicitly names an excluded method, including a name inside an operation array. Remove the ineffective rule, or omit that method from your custom exclusions when creating the instance. Default exclusions cannot be removed. See [Transaction Policies](/sdk/core-module/guides/transaction-policies#supported-operations) for migration guidance.
 
 ## Wallet Registration Configuration
 

--- a/content/docs/sdk/core-module/guides/transaction-policies.mdx
+++ b/content/docs/sdk/core-module/guides/transaction-policies.mdx
@@ -5,7 +5,9 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-Local transaction policies let a WDK app evaluate rules before account or protocol write methods execute. Use them for local approval limits, account-level exceptions, preflight checks, or UI flows that need a dry-run verdict before calling a wallet method.
+Use local transaction policies to evaluate account and protocol calls before execution. This guide covers [registering policies](#register-policies), [method coverage and migration](#supported-operations), and [simulating calls](#simulate-before-execution).
+
+Use `@tetherto/wdk` v1.0.0-beta.17 or later for method exclusions and coverage beyond the earlier fixed operation list. The examples assume you have loaded an app-owned `seedPhrase` and registered the relevant wallet modules.
 
 <Callout type="warn">
 Transaction policies are local pre-execution controls. They do not enforce rules on-chain, replace smart-contract permissions, or validate live token metadata, balances, prices, or contract state.
@@ -13,15 +15,15 @@ Transaction policies are local pre-execution controls. They do not enforce rules
 
 ## Policy Structure
 
-A transaction policy is a named local configuration object registered with `wdk.registerPolicy()`. Each policy chooses where it applies, then evaluates its ordered `rules` array before a governed account or protocol write method runs.
+A transaction policy is a named local configuration object registered with `wdk.registerPolicy()`. Each policy chooses where it applies, then evaluates its ordered `rules` array before a governed account or protocol method runs.
 
 | Concept | What you configure |
 | --- | --- |
 | Scope | `scope: 'project'` for project or wallet-level rules, or `scope: 'account'` for selected account indices or derivation paths |
 | Wallet | Optional `wallet` bindings for project policies, required `wallet` bindings for account policies |
-| Rules | Ordered `rules` array evaluated before a governed account or protocol write method runs |
+| Rules | Ordered `rules` array evaluated before a governed account or protocol method runs |
 | Action | `ALLOW` to permit a matching governed call, or `DENY` to block it with `PolicyViolationError` |
-| Operation | The wallet or protocol write operation a rule addresses, such as `sendTransaction`, `transfer`, `swap`, or `*` |
+| Operation | The wallet or protocol method a rule addresses, such as `sendTransaction`, `transfer`, `swap`, or `*` |
 | Conditions | Functions that receive `PolicyContext` and return truthy when the rule should match |
 
 Use `scope: 'project'` for rules that apply across all wallets or selected wallet identifiers. Use `scope: 'account'` with `wallet` and `accounts` for rules that apply only to specific account indices or derivation paths.
@@ -34,9 +36,17 @@ WDK does not manage durable policy state for you. Conditions can inspect the cur
 
 ## Register Policies
 
-Register wallets before policies. `wdk.registerPolicy()` validates wallet bindings synchronously and throws `PolicyConfigurationError` if a policy references a wallet identifier that has not been registered.
+Register wallets before policies. [`wdk.registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options) validates wallet bindings synchronously and throws `PolicyConfigurationError` if a policy references a wallet identifier that has not been registered.
 
-The example below allows normal operations, then denies ETH sends above a local approval limit. The wildcard `ALLOW` rule is intentional: once a policy governs an account, wrapped write operations are default-denied unless a matching `ALLOW` permits them.
+The example allows all governed operations, then denies ETH sends above a local approval limit. Its wildcard `ALLOW` deliberately permits other methods, including newly discovered methods after an upgrade. Use explicit method names instead when your app needs a narrow permission set.
+
+To register and exercise the send limit:
+
+1. Register the Ethereum wallet with its reviewed configuration.
+2. Register the rules through [`wdk.registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options).
+3. Attempt the over-limit send and handle its policy denial.
+
+You can enforce this local limit before [`sendTransaction()`](/sdk/core-module/api-reference#iwalletaccount) reaches the wallet:
 
 ```typescript title="Register A Local Send Limit"
 import WDK, { PolicyViolationError } from '@tetherto/wdk'
@@ -103,7 +113,7 @@ Account entries can be non-negative account indices or derivation-path strings. 
 WDK evaluates policies in this order:
 
 1. If no registered policy applies to the account, WDK returns the original account. No policy proxy or `simulate` mirror is added.
-2. If at least one policy applies, the account is governed. WDK wraps every supported write or signing operation that exists on that account, plus registered protocol write methods.
+2. If at least one policy applies, the account is governed. WDK wraps its discovered public methods and registered protocol methods unless their names are in the exclusion set. See [Supported Operations](#supported-operations) for the discovery boundary.
 3. If no rule addresses the attempted operation, WDK blocks the call with `PolicyViolationError` and `reason: 'no-applicable-rule'`.
 4. Account-scoped policies run before project-scoped policies. Within each scope, policies and rules run in registration order.
 5. A matching account-scoped `DENY` blocks immediately. A matching account-scoped `ALLOW` is recorded unless it has `override_broader_scope: true`.
@@ -174,7 +184,7 @@ In the example above, the treasury account can send up to `0.01 ETH` because the
 
 ## Supported Operations
 
-Use these operation names in `PolicyRule.operation`:
+In beta.17, `PolicyRule.operation` accepts any non-empty method-name string, an array of names, or `*`. The following are examples, not a closed list:
 
 | Operation | Method family |
 | --- | --- |
@@ -193,9 +203,29 @@ Use these operation names in `PolicyRule.operation`:
 | `buy`, `sell` | Fiat protocol writes |
 | `swidge` | Combined swap and bridge route execution |
 | `createDepositAddress`, `renewDepositAddress`, `recoverDepositAddress`, `disableDepositAddress` | Smart Deposit Address writes |
-| `*` | Wildcard rule for all wrapped write operations |
+| `*` | Wildcard rule for all governed methods |
 
-Use `sign` for message-style signing in this release. `signMessage` and `signHash` are not valid `PolicyOperation` values.
+Use the exact method name implemented by your wallet or protocol. For example, a rule for `payLightningInvoice` can now govern that Spark method. [`waitForTransaction()`](/sdk/core-module/api-reference#waitfortransactionhash-options) is also governed by default, so transaction polling needs a matching `ALLOW` rule on a governed account. A name that matches nothing still registers, but cannot allow the real call; a typo can leave that call denied. `signMessage` and `signHash` are accepted strings, but only affect methods with those names.
+
+Coverage comes from public string-named methods declared directly on the object or inherited from its class. The proxy skips names in [`getPolicyExclusions()`](/sdk/core-module/api-reference#getpolicyexclusions), `constructor`, protected members, symbol-named methods, and `Object.prototype` methods. Accessor-only properties are not intercepted; defining a getter does not add a governed method. An unfamiliar method is governed even when its name starts with `get` or `quote`. Governed methods return Promises; always `await` them even when the original method is synchronous.
+
+### Migrate From The Fixed Operation List
+
+Default-deny evaluation already existed before beta.17. This release expands which methods reach it. A call that previously bypassed evaluation can now fail with `reason: 'no-applicable-rule'`.
+
+1. Compare the methods your app calls with the resolved exclusions from [`getPolicyExclusions()`](/sdk/core-module/api-reference#getpolicyexclusions).
+2. Register an explicit `ALLOW` rule for each additional operation your app intends to permit, then verify its simulation and denial cases.
+3. For a method that should bypass evaluation, review its behavior across every applicable wallet and protocol before adding a [constructor exclusion](/sdk/core-module/configuration#policy-method-exclusions). Exclusions apply globally by name and also remove policy simulation for that method.
+
+You can inspect the resolved exclusions on an existing WDK instance:
+
+```javascript title="Inspect Method Coverage"
+const exclusions = wdk.getPolicyExclusions()
+console.log(exclusions.includes('getBalance')) // true by default
+console.log(exclusions.includes('payLightningInvoice')) // false by default
+```
+
+Default exclusions cannot be removed. [`registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options) rejects rules naming an excluded method because those rules could never run. Adding a wildcard `ALLOW` permits every governed method and is not a substitute for reviewing the expanded method surface.
 
 ## Common Policy Patterns
 
@@ -332,9 +362,9 @@ Conditions receive a frozen `PolicyContext`:
 | `operation` | The operation being evaluated |
 | `wallet` | The wallet identifier bound to the account |
 | `account` | Read-only account view exposed by the wallet module |
-| `args` | Frozen array containing a snapshot of every argument passed to the wrapped method, in signature order |
+| `args` | Frozen array of arguments in signature order; object values are cloned for evaluation |
 
-For governed write calls, WDK snapshots the method arguments once before policy evaluation. Conditions see that snapshot, and WDK forwards the same approved values to the underlying wallet method. This prevents a caller from mutating a transaction object while an asynchronous policy condition is running.
+For governed calls, WDK clones object arguments before policy evaluation, then gives conditions a separate clone of that snapshot. The wallet receives the original snapshot, so later mutations to the caller's transaction object or the condition's copy do not change the forwarded values. The context and `args` array are frozen shallowly; nested objects are not frozen. Keep conditions free of mutations because conditions share their evaluation context.
 
 <Callout type="warn">
 `PolicyContext.params` was removed in `@tetherto/wdk` v1.0.0-beta.16. Replace `params` with `args[0]`. For multi-argument methods, use the actual signature position and check optional arguments before reading their fields. For example, a `swidge(options, config?)` condition reads `options` from `args[0]` and `config` from `args[1]`.
@@ -346,7 +376,7 @@ Set `maxConditionTimeoutMs` in the WDK constructor to cap every per-policy timeo
 
 ## Simulate Before Execution
 
-When a policy applies to an account, WDK adds runtime `simulate` mirrors for wrapped account and protocol write methods. Simulation returns the policy verdict and does not call the underlying wallet or protocol method.
+When a policy applies to an account, WDK adds runtime `simulate` mirrors for governed account and protocol methods, including methods outside the earlier fixed operation list. Simulation returns the policy verdict and does not call the underlying wallet or protocol method.
 
 You can dry-run a governed account method through the runtime `simulate` mirror:
 
@@ -369,18 +399,19 @@ In this beta, `simulate` is added at runtime but is not typed on the account ret
 
 ## Handle Errors
 
-`PolicyConfigurationError` means WDK rejected the policy setup or could not safely evaluate a governed call. Common causes include invalid scopes, actions, operation names, condition functions, timeout options, missing account bindings, wallet identifiers that have not been registered, or governed method arguments that are not structured-cloneable.
+`PolicyConfigurationError` means WDK rejected the policy setup or could not safely evaluate a governed call. Common causes include invalid scopes, actions, empty or non-string operation names, rules naming excluded methods, invalid condition functions or timeout options, missing account bindings, unknown wallet identifiers, or object arguments that cannot be cloned.
 
-`PolicyViolationError` means an enforced write call was blocked by a matching `DENY` rule or by default-deny when no `ALLOW` rule matched. Catch it around the write call and surface the `reason` to the user or approval workflow.
+`PolicyViolationError` means a governed call was blocked by a matching `DENY` rule or by default-deny when no `ALLOW` rule matched. Catch it around the write call and surface the `reason` to the user or approval workflow.
 
 ## Runtime Caveats
 
 - Policies wrap the WDK account/protocol proxy surface. On governed proxies, `keyPair` and string members beginning with `_` are absent from direct property access, membership checks, own-property descriptors, and own-key enumeration. The proxy also refuses `Object.preventExtensions()` and `Object.freeze()` with `TypeError` so those hiding rules remain valid.
 - This is not a complete sandbox. Prototype inspection, separately retained raw account or protocol references, and nested calls made inside a module remain outside the proxy interception path.
-- Quote and read methods are not wrapped. Policies apply to write methods such as sends, signs, swaps, bridges, lending writes, fiat writes, swidge execution, and SDA address creation, renewal, recovery, or disablement.
+- The default exclusions contain specific read, quote, and lifecycle method names. A read or quote method absent from that list is governed until you explicitly exclude it; a `get` or `quote` prefix does not change coverage.
 - Policy conditions receive local method arguments. WDK does not decode calldata, fetch prices, validate token metadata, or calculate fiat value unless your condition function does that work.
 - Wallet accounts must expose a read-only account view when a policy applies, otherwise `getAccount()` fails with `PolicyConfigurationError`.
-- Governed write-call arguments must be structured-cloneable, such as primitives, plain objects, arrays, `bigint`, and typed arrays. Functions, live class instances, and other non-cloneable values fail closed with `PolicyConfigurationError` instead of being forwarded unsafely.
+- Pass plain data to governed methods. An object that cannot be structured-cloned, such as a plain object containing a callback, fails with `PolicyConfigurationError`. Class instances can become plain objects and lose their methods. A top-level function argument passes through unchanged in this release, so do not treat the snapshot as isolation for callback-driven state or side effects.
+- Method discovery is not a live monitor of account changes. Add module methods before obtaining a governed account; do not rely on mutating an account or its prototype after wrapping to update policy coverage.
 - Engine-managed state hooks are not active in this beta. The schema accepts `state` and `onSuccess`, but WDK does not pass `state` into conditions, update it after execution, persist it, or call `onSuccess`. Conditions can still use app-owned state through closures or external stores; keep that state outside `rule.state`, and have your app own durability, concurrency, and rollback behavior.
 
 ## Next Steps

--- a/content/docs/sdk/lending-modules/lending-aave-evm/api-reference.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/api-reference.mdx
@@ -19,11 +19,16 @@ new AaveProtocolEvm(account)
 ```
 
 Parameters:
-- `account`: `WalletAccountEvm | WalletAccountReadOnlyEvm | WalletAccountEvmErc4337 | WalletAccountReadOnlyEvmErc4337`
+- `account`: `IWalletAccount | IWalletAccountReadOnly` from `@tetherto/wdk-wallet`
+
+Since beta.7, write methods check for a callable `sendTransaction()` rather than a concrete account class. The implementation still reads `account._config.provider`; supply an EVM-compatible JSON-RPC URL or EIP-1193 provider for a supported Aave deployment. Shared interfaces alone do not make another chain's account compatible. The selected operation also needs its account methods, such as `getAddress()`, `getTokenBalance()`, and `quoteSendTransaction()`.
+
+Before supplying or repaying, grant the Aave Pool enough token allowance through the account's approval API and wait for approval confirmation. The lending module does not approve or reset allowances automatically. Use the Pool and token addresses for the same chain. The examples below use 1 USD₮ on Ethereum, whose contract is `0xdAC17F958D2ee523a2206206994597C13D831ec7` with 6 decimals.
 
 Example:
 
 ```javascript
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 const aave = new AaveProtocolEvm(account)
 ```
 
@@ -31,7 +36,7 @@ const aave = new AaveProtocolEvm(account)
 
 | Method | Description | Returns |
 |--------|-------------|---------|
-| `supply(options, config?)` | Add tokens to the pool | `Promise<{hash: string, fee: bigint, approveHash?: string, resetAllowanceHash?: string}>` |
+| `supply(options, config?)` | Add tokens to the pool | `Promise<{hash: string, fee: bigint}>` |
 | `quoteSupply(options, config?)` | Estimate cost to add tokens | `Promise<{fee: bigint}>` |
 | `withdraw(options, config?)` | Remove tokens from the pool | `Promise<{hash: string, fee: bigint}>` |
 | `quoteWithdraw(options, config?)` | Estimate cost to withdraw | `Promise<{fee: bigint}>` |
@@ -47,9 +52,9 @@ const aave = new AaveProtocolEvm(account)
 
 When `AaveProtocolEvm` is initialized with an ERC‑4337 smart account, the optional `config` argument on mutating and quote methods accepts the same gas-payment override families documented in [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference): paymaster token, sponsorship policy, and native coins.
 
-Standard (non‑ERC‑4337) accounts silently ignore this optional ERC‑4337 configuration and use their normal EVM transaction path.
+The protocol forwards `config` to the account's send or quote method. Standard WDK EVM accounts ignore ERC-4337 gas-payment fields; compatible wrappers determine their own handling. Fees retain the account's denomination, which can be native wei, paymaster-token base units, or zero for sponsorship.
 
-### `supply(options, config?)`
+#### `supply(options, config?)`
 Add tokens to the pool.
 
 Options:
@@ -58,26 +63,26 @@ Options:
 - `onBehalfOf` (`string`, optional)
 
 Returns:
-- May include `approveHash` and `resetAllowanceHash` for standard accounts (e.g., USD₮ allowance reset on Ethereum mainnet)
+- The account's transaction result, including `hash` and `fee`. The protocol does not add approval transaction hashes.
 
 Example:
 
 ```javascript
-const res = await aave.supply({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const res = await aave.supply({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `quoteSupply(options, config?)`
+#### `quoteSupply(options, config?)`
 Estimate fee to add tokens.
 
 ```javascript
-const q = await aave.quoteSupply({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteSupply({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `withdraw(options, config?)`
+#### `withdraw(options, config?)`
 Remove tokens from the pool.
 
 Options:
@@ -86,21 +91,21 @@ Options:
 - `to` (`string`, optional)
 
 ```javascript
-const tx = await aave.withdraw({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const tx = await aave.withdraw({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `quoteWithdraw(options, config?)`
+#### `quoteWithdraw(options, config?)`
 Estimate fee to withdraw tokens.
 
 ```javascript
-const q = await aave.quoteWithdraw({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteWithdraw({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `borrow(options, config?)`
+#### `borrow(options, config?)`
 Borrow tokens.
 
 Options:
@@ -109,21 +114,21 @@ Options:
 - `onBehalfOf` (`string`, optional)
 
 ```javascript
-const tx = await aave.borrow({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const tx = await aave.borrow({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `quoteBorrow(options, config?)`
+#### `quoteBorrow(options, config?)`
 Estimate fee to borrow tokens.
 
 ```javascript
-const q = await aave.quoteBorrow({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteBorrow({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `repay(options, config?)`
+#### `repay(options, config?)`
 Repay borrowed tokens.
 
 Options:
@@ -132,33 +137,33 @@ Options:
 - `onBehalfOf` (`string`, optional)
 
 ```javascript
-const tx = await aave.repay({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const tx = await aave.repay({ token: USDT, amount: 1000000n })
 ```
 
 Returns:
-- For standard accounts, may include `approveHash` / `resetAllowanceHash` when applicable.
+- The account's transaction result, including `hash` and `fee`. Required approvals are separate operations.
 
 ---
 
-### `quoteRepay(options, config?)`
+#### `quoteRepay(options, config?)`
 Estimate fee to repay borrowed tokens.
 
 ```javascript
-const q = await aave.quoteRepay({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteRepay({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `setUseReserveAsCollateral(token, use, config?)`
+#### `setUseReserveAsCollateral(token, use, config?)`
 Toggle token as collateral for the user.
 
 ```javascript
-const tx = await aave.setUseReserveAsCollateral('TOKEN_ADDRESS', true)
+const tx = await aave.setUseReserveAsCollateral(USDT, true)
 ```
 
 ---
 
-### `setUserEMode(categoryId, config?)`
+#### `setUserEMode(categoryId, config?)`
 Set user eMode category.
 
 ```javascript
@@ -167,7 +172,7 @@ const tx = await aave.setUserEMode(1)
 
 ---
 
-### `getAccountData(account?)`
+#### `getAccountData(account?)`
 Read account stats like total collateral, debt, and health.
 
 ```javascript

--- a/content/docs/sdk/lending-modules/lending-aave-evm/configuration.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/configuration.mdx
@@ -25,7 +25,9 @@ const aave = new AaveProtocolEvm(account)
 
 ## Account Configuration
 
-The service uses the wallet account configuration to connect to the target network and sign transactions.
+The constructor accepts `IWalletAccount` or `IWalletAccountReadOnly`. The implementation reads `account._config.provider` and expects an EVM-compatible JSON-RPC URL or EIP-1193 provider. Compatible account wrappers must expose this configuration plus the methods required by the chosen operation. Every write checks for a callable `sendTransaction()`; quotes call `quoteSendTransaction()` without requiring write capability. The wider interfaces do not add support for non-EVM chains.
+
+For accounts governed by WDK transaction policies, use [`wdk.registerProtocol()`](/sdk/core-module/api-reference#registerprotocolblockchain-label-protocol-config) and the account's protocol getter. Do not pass the governed account proxy directly to this constructor: that proxy hides `_config`.
 
 ```javascript
 import { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
@@ -36,7 +38,7 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 })
 
 // Read-only account (quotes, reads)
-const readOnly = new WalletAccountReadOnlyEvm('0xYourAddress', {
+const readOnly = new WalletAccountReadOnlyEvm(await account.getAddress(), {
   provider: 'https://ethereum-rpc.publicnode.com'
 })
 
@@ -45,7 +47,7 @@ const aave = new AaveProtocolEvm(account)
 
 ## ERC‑4337 (Account Abstraction)
 
-When using ERC‑4337 smart accounts, every mutating method and quote helper accepts an optional `config` override. In `v1.0.0-beta.6`, that override matches the three gas-payment families exposed by [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins. Standard (non‑ERC‑4337) accounts silently ignore this optional ERC‑4337 configuration.
+Every mutating method and quote helper forwards its optional `config` argument to the account. The declared gas-payment families match [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins. Standard WDK EVM accounts ignore these wallet fields. Fees keep the account's denomination; a token-paymaster quote is not a native-wei quote.
 
 Use the fields that match the gas-payment mode you want for that call. For the full field-level definitions, see the [`@tetherto/wdk-wallet-evm-erc-4337` configuration docs](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) and [`Config Override`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) reference.
 
@@ -96,20 +98,22 @@ const arb = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 ## Operation Options
 
-Each operation accepts a simple options object:
+Each operation accepts an options object. Before supplying or repaying, confirm the account's token allowance to the [Aave Pool for the selected network](https://github.com/bgd-labs/aave-address-book) and send any required approval separately. The lending module does not add approval or allowance-reset transactions. To change an existing nonzero Ethereum USD₮ allowance to another nonzero amount, first approve zero and wait for confirmation, then approve the new amount and wait again. These examples use 1 USD₮ on Ethereum (6 decimals):
 
 ```javascript
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDt on Ethereum
+
 // Supply
-await aave.supply({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.supply({ token: USDT, amount: 1000000n })
 
 // Withdraw
-await aave.withdraw({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.withdraw({ token: USDT, amount: 1000000n })
 
 // Borrow
-await aave.borrow({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.borrow({ token: USDT, amount: 1000000n })
 
 // Repay
-await aave.repay({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.repay({ token: USDT, amount: 1000000n })
 ```
 
 ### Common Parameters

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/handle-errors.mdx
@@ -31,7 +31,7 @@ try {
     token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
     amount: 1000000n
   })
-  console.log('Borrow fee (wei):', q.fee)
+  console.log('Borrow fee (account units):', q.fee)
 } catch (e) {
   console.error('Quote failed:', e.message)
 }

--- a/content/docs/sdk/lending-modules/lending-aave-evm/guides/lending-operations.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/guides/lending-operations.mdx
@@ -7,6 +7,8 @@ This guide walks through [supply](#supply), [withdraw](#withdraw), [borrow](#bor
 
 ## Supply
 
+Before supplying, confirm sufficient token allowance to the Aave Pool for your chain. Send any required approval through the wallet account and wait for confirmation. The lending module does not approve or reset allowances automatically.
+
 You can deposit reserves into the pool using [`supply()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Supply USDt"
@@ -40,6 +42,8 @@ console.log('Borrow tx hash:', tx.hash)
 
 ## Repay
 
+Repayment also requires sufficient token allowance to the Aave Pool. Complete any approval before calling `repay()`; it is a separate transaction from repayment.
+
 You can pay down debt using [`repay()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Repay USDt"
@@ -51,13 +55,15 @@ console.log('Repay tx hash:', tx.hash)
 
 ## Quotes before sending
 
+Quote fees use the wallet account's fee denomination: native wei for standard EVM/native-coin fees, paymaster-token base units for token-paid fees, or zero for sponsored quotes. Supply and repayment quotes assume any required approval is already in place; they do not include a separate approval's cost.
+
 You can estimate the supply fee with [`quoteSupply()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Quote supply fee"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const supplyQuote = await aave.quoteSupply({ token: USDT, amount: 1000000n })
-console.log('Supply fee (wei):', supplyQuote.fee)
+console.log('Supply fee (account units):', supplyQuote.fee)
 ```
 
 You can estimate the withdraw fee with [`quoteWithdraw()`](/sdk/lending-modules/lending-aave-evm/api-reference):
@@ -66,7 +72,7 @@ You can estimate the withdraw fee with [`quoteWithdraw()`](/sdk/lending-modules/
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const withdrawQuote = await aave.quoteWithdraw({ token: USDT, amount: 1000000n })
-console.log('Withdraw fee (wei):', withdrawQuote.fee)
+console.log('Withdraw fee (account units):', withdrawQuote.fee)
 ```
 
 You can estimate the borrow fee with [`quoteBorrow()`](/sdk/lending-modules/lending-aave-evm/api-reference):
@@ -75,7 +81,7 @@ You can estimate the borrow fee with [`quoteBorrow()`](/sdk/lending-modules/lend
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const borrowQuote = await aave.quoteBorrow({ token: USDT, amount: 1000000n })
-console.log('Borrow fee (wei):', borrowQuote.fee)
+console.log('Borrow fee (account units):', borrowQuote.fee)
 ```
 
 You can estimate the repay fee with [`quoteRepay()`](/sdk/lending-modules/lending-aave-evm/api-reference):
@@ -84,7 +90,7 @@ You can estimate the repay fee with [`quoteRepay()`](/sdk/lending-modules/lendin
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const repayQuote = await aave.quoteRepay({ token: USDT, amount: 1000000n })
-console.log('Repay fee (wei):', repayQuote.fee)
+console.log('Repay fee (account units):', repayQuote.fee)
 ```
 
 <Callout type="warn">
@@ -93,7 +99,7 @@ Health factor and collateralization limits still apply. A quote does not guarant
 
 ## ERC-4337 smart accounts
 
-You can run the same methods through [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and pass a second `config` argument to override per-call gas payment settings. In `v1.0.0-beta.6`, the lending methods accept the same override families as the wallet module: paymaster token, sponsorship policy, and native coins. Standard (non‑ERC‑4337) accounts silently ignore this optional configuration. See the [ERC-4337 config override](/sdk/lending-modules/lending-aave-evm/api-reference) section for the full field list.
+You can run the same methods through [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and pass the optional `config` argument to override per-call gas payment settings. The lending methods accept the same override families as the wallet module: paymaster token, sponsorship policy, and native coins. Standard WDK EVM accounts ignore these wallet fields; compatible wrappers determine their own handling. See the [ERC-4337 config override](/sdk/lending-modules/lending-aave-evm/api-reference) section for the full field list.
 
 ```javascript title="Supply with paymaster"
 import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -105,7 +111,10 @@ const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   bundlerUrl: process.env.BUNDLER_URL,
   paymasterUrl: process.env.PAYMASTER_URL,
   paymasterAddress: process.env.PAYMASTER_ADDRESS,
-  safeModulesVersion: '0.3.0'
+  safeModulesVersion: '0.3.0',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  }
 })
 
 const aaveAA = new AaveProtocolEvm(aa)

--- a/content/docs/sdk/lending-modules/lending-aave-evm/index.mdx
+++ b/content/docs/sdk/lending-modules/lending-aave-evm/index.mdx
@@ -26,6 +26,8 @@ Works on supported Aave V3 EVM networks, including Ethereum, Arbitrum, Optimism,
 - **ERC‑4337 Smart Accounts**: `@tetherto/wdk-wallet-evm-erc-4337`
 - **Read‑Only Accounts**: For quoting and reading account data without sending transactions
 
+Beta.7 accepts the shared wallet interfaces and checks for a callable `sendTransaction()` before each write. The account must still expose the EVM provider and account methods the selected operation needs. See [account configuration](/sdk/lending-modules/lending-aave-evm/configuration#account-configuration) for wrapper requirements. Supply and repayment require a separate token approval to the Aave Pool.
+
 ## Key Components
 
 - **Aave V3 Integration**: Supply, withdraw, borrow, repay primitives

--- a/content/docs/sdk/lending-modules/lending-morpho-evm/api-reference.mdx
+++ b/content/docs/sdk/lending-modules/lending-morpho-evm/api-reference.mdx
@@ -34,11 +34,12 @@ Example:
 ```javascript
 const morpho = new MorphoProtocolEvm(account, {
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })
 ```
+
+This example configures a borrow market. The vault examples below also require an operator-selected Ethereum mainnet USD₮ vault configured with `earnVaultAddress` and `chainId: 1`; see [Explicit Targets](/sdk/lending-modules/lending-morpho-evm/configuration#explicit-targets).
 
 ### Methods
 

--- a/content/docs/sdk/lending-modules/lending-morpho-evm/configuration.mdx
+++ b/content/docs/sdk/lending-modules/lending-morpho-evm/configuration.mdx
@@ -42,7 +42,6 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 const morpho = new MorphoProtocolEvm(account, {
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })
@@ -63,7 +62,7 @@ The wallet account must include a provider. Read-only accounts can read position
 
 ## Presets
 
-Built-in presets target Ethereum mainnet USD₮ earn and borrow flows.
+Built-in presets target Ethereum mainnet. The `xaut` borrow preset selects a market with XAU₮ collateral.
 
 The package exports frozen preset maps. Use them as the complete registry for the installed package rather than copying a static list into your integration:
 
@@ -77,12 +76,11 @@ console.log(Object.keys(MORPHO_VAULT_PRESETS))
 console.log(Object.keys(MORPHO_MARKET_PRESETS))
 ```
 
-Selected Tether-family presets from version `1.0.5` are shown below. See the package's [released preset source](https://github.com/morpho-org/sdks/blob/15c622bbdfb841d5cd65d1d1ff080ecd1649437a/packages/wdk-protocol-lending-morpho-evm/src/morpho-presets.ts) for the pinned registry.
+The XAU₮ collateral preset from version `1.0.5` is shown below. See the package's [released preset source](https://github.com/morpho-org/sdks/blob/15c622bbdfb841d5cd65d1d1ff080ecd1649437a/packages/wdk-protocol-lending-morpho-evm/src/morpho-presets.ts) for the pinned registry.
 
 ```javascript title="Use built-in presets"
 const morpho = new MorphoProtocolEvm(account, {
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })
@@ -90,17 +88,21 @@ const morpho = new MorphoProtocolEvm(account, {
 
 | Operation | Preset | Chain ID | Target ID | Target |
 |-----------|--------|----------|-----------|--------|
-| Earn | `sky-money-usdt-savings` | `1` | `0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11` | sky.money USD₮ Savings |
 | Borrow | `xaut` | `1` | `0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877` | XAU₮ collateral, 77% LLTV |
 
 ## Explicit Targets
 
-Use explicit targets when you want to configure a vault address or market directly instead of selecting it by preset name.
+Use explicit targets when you want to configure a vault address or market directly instead of selecting it by preset name. Before using a vault, verify its underlying asset, share token, collateral exposure, and chain against the deployment data. For the USD₮ vault examples, set `MORPHO_EARN_VAULT_ADDRESS` to an operator-selected Ethereum mainnet Morpho Vault V2 address whose underlying asset is USD₮.
 
 ```javascript title="Use explicit Morpho targets"
+const earnVaultAddress = process.env.MORPHO_EARN_VAULT_ADDRESS
+if (!earnVaultAddress) {
+  throw new Error('Set MORPHO_EARN_VAULT_ADDRESS to your verified vault address')
+}
+
 const morpho = new MorphoProtocolEvm(account, {
   chainId: 1,
-  earnVaultAddress: '0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11',
+  earnVaultAddress,
   borrowMarketId: '0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2'
 })
 ```

--- a/content/docs/sdk/lending-modules/lending-morpho-evm/guides/get-started.mdx
+++ b/content/docs/sdk/lending-modules/lending-morpho-evm/guides/get-started.mdx
@@ -29,6 +29,8 @@ If you use ERC-4337 smart accounts, also install `@tetherto/wdk-wallet-evm-erc-4
 
 ## Create the lending client
 
+For the vault examples, set `MORPHO_EARN_VAULT_ADDRESS` to an operator-selected Ethereum mainnet Morpho Vault V2 address whose underlying asset is USD₮. Verify the vault’s underlying asset, share token, collateral exposure, and chain before configuring it; see [Explicit Targets](/sdk/lending-modules/lending-morpho-evm/configuration#explicit-targets).
+
 You can attach Morpho actions to an EVM account from [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) with [`new MorphoProtocolEvm(account, options)`](/sdk/lending-modules/lending-morpho-evm/api-reference):
 
 ```javascript title="Create MorphoProtocolEvm"
@@ -39,9 +41,15 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
   provider: 'https://ethereum-rpc.publicnode.com'
 })
 
+const earnVaultAddress = process.env.MORPHO_EARN_VAULT_ADDRESS
+if (!earnVaultAddress) {
+  throw new Error('Set MORPHO_EARN_VAULT_ADDRESS to your verified vault address')
+}
+
 const morpho = new MorphoProtocolEvm(account, {
+  chainId: 1,
+  earnVaultAddress,
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })

--- a/content/docs/sdk/lending-modules/lending-morpho-evm/index.mdx
+++ b/content/docs/sdk/lending-modules/lending-morpho-evm/index.mdx
@@ -27,12 +27,13 @@ Use the Morpho lending community module to interact with Morpho Vault V2 earn ta
 
 The module supports curated Ethereum mainnet presets and explicit Morpho target configuration. The package exports `MORPHO_VAULT_PRESETS` and `MORPHO_MARKET_PRESETS`; inspect those maps for the complete preset registry shipped with your installed version.
 
-### Tether-Aligned Presets
+### XAU₮ Borrow Preset
 
 | Operation | Preset | Target |
 |-----------|--------|--------|
-| Earn | `sky-money-usdt-savings` | sky.money USD₮ Savings |
 | Borrow | `xaut` | XAU₮ collateral |
+
+For vault operations, configure an operator-selected target after verifying its underlying asset, share token, collateral exposure, and chain. See [Explicit Targets](/sdk/lending-modules/lending-morpho-evm/configuration#explicit-targets).
 
 ## Wallet Compatibility
 

--- a/content/docs/sdk/swap-modules/swap-velora-evm/api-reference.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/api-reference.mdx
@@ -19,9 +19,9 @@ new VeloraProtocolEvm(account, config?)
 Parameters:
 - `account`: `IWalletAccount | IWalletAccountReadOnly` from `@tetherto/wdk-wallet`
 - `config` (optional):
-  - `swapMaxFee` (`bigint`): maximum total gas fee allowed (wei)
+  - `swapMaxFee` (`bigint`): exclusive cap in the fee units returned by the account's quote
 
-The beta.7 declarations accept the generic wallet interfaces, but this package still requires an EVM-compatible account with a configured JSON-RPC URL or EIP-1193 provider. Use an EVM account from WDK's EVM wallet modules; the wider interfaces do not add support for arbitrary or non-EVM accounts.
+The declarations accept the shared wallet interfaces. The implementation also reads `account._config.provider` and requires an EVM-compatible JSON-RPC URL or EIP-1193 provider. An interface match alone does not establish compatibility. Quoting needs `getAddress()` and `quoteSendTransaction()`; execution additionally requires a callable `sendTransaction()`.
 
 Example:
 
@@ -38,7 +38,7 @@ const swap = new VeloraProtocolEvm(account, { swapMaxFee: 200000000000000n })
 
 ---
 
-### `swap(options, config?)`
+#### `swap(options, config?)`
 Execute a swap via velora.
 
 Options:
@@ -48,14 +48,16 @@ Options:
 - `tokenOutAmount` (`bigint`, optional): Exact output amount (base units)
 - `to` (`string`, optional): Recipient address (defaults to account address)
 
-Config (ERC‑4337 only):
+Config (optional; wallet gas-payment fields depend on the account):
 - `paymasterToken` (`{ address: string }`, optional): Paymaster token override for this swap
 - `isSponsored` (`true`, optional): Use sponsorship mode for this swap
 - `sponsorshipPolicyId` (`string`, optional): Sponsorship policy override
 - `useNativeCoins` (`true`, optional): Pay fees in the chain's native token
-- `swapMaxFee` (`bigint`, optional): Per‑swap fee cap (wei)
+- `swapMaxFee` (`bigint`, optional): Per-swap exclusive fee cap, in the account quote's units
 
-These per-swap overrides are applied only when the protocol uses a concrete `WalletAccountEvmErc4337`. With another writable EVM account, `swap()` sends one EVM transaction and does not apply the ERC‑4337 config object.
+Since beta.8, `swap()` passes one transaction object and the same `config` to the account's `quoteSendTransaction()` and `sendTransaction()`. It does not select the path by concrete account class. Standard WDK EVM accounts ignore wallet paymaster/sponsorship fields, but the protocol applies a per-call `swapMaxFee` for these accounts too.
+
+The per-call cap overrides the constructor cap. A quote equal to or above that cap rejects the swap before sending. Match the cap to the quote's denomination: native wei for standard EVM/native-coin fees, paymaster-token base units for token-paid fees, or zero for sponsored quotes. A zero cap rejects even a zero-fee quote. `quoteSwap()` itself does not enforce the cap.
 
 Returns:
 - Standard account: `{ hash, fee, tokenInAmount, tokenOutAmount }`
@@ -69,15 +71,15 @@ Example:
 
 ```javascript
 const tx = await swap.swap({
-  tokenIn: '0xdAC17F...ec7',      // USDt
-  tokenOut: '0xC02a...6Cc2',      // WETH
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n
 })
 ```
 
 ---
 
-### `quoteSwap(options, config?)`
+#### `quoteSwap(options, config?)`
 Get estimated fee and token in/out amounts.
 
 Options are the same as `swap`.
@@ -90,7 +92,7 @@ Config (ERC‑4337 only):
 - `sponsorshipPolicyId` (`string`, optional): Sponsorship policy override
 - `useNativeCoins` (`true`, optional): Estimate fees in the chain's native token
 
-These per-call overrides are applied only when the protocol uses a concrete `WalletAccountReadOnlyEvmErc4337`. Other accounts use the ordinary single-transaction quote path and do not apply the ERC‑4337 config object.
+The protocol forwards one transaction object and `config` to any compatible account's `quoteSendTransaction()`. The account determines which wallet options apply; standard WDK EVM accounts ignore the ERC-4337 fields. The returned fee keeps the account's denomination. Quoting does not enforce `swapMaxFee` or reserve a route for later execution.
 
 Works with read‑only accounts.
 
@@ -98,8 +100,8 @@ Example:
 
 ```javascript
 const quote = await swap.quoteSwap({
-  tokenIn: '0xdAC17F...ec7',      // USDt
-  tokenOut: '0xC02a...6Cc2',      // WETH
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenOutAmount: 500000000000000000n // 0.5 WETH
 })
 ```
@@ -110,7 +112,7 @@ const quote = await swap.quoteSwap({
 
 Common errors include:
 - Insufficient liquidity / no route for pair
-- Fee exceeds `swapMaxFee`
+- Quoted fee is equal to or greater than `swapMaxFee`
 - Read‑only account cannot send swaps
 - Provider/RPC errors (invalid endpoint, network mismatch)
 
@@ -118,7 +120,7 @@ Common errors include:
 
 ## Types
 
-- `swapMaxFee: bigint` — Upper bound for gas fees (wei)
+- `swapMaxFee: bigint`: Exclusive cap in the account quote's fee units
 - `tokenInAmount/tokenOutAmount: bigint` — ERC‑20 base units
 - `paymasterToken: { address: string }` — ERC‑4337 paymaster token override
 

--- a/content/docs/sdk/swap-modules/swap-velora-evm/configuration.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/configuration.mdx
@@ -21,13 +21,15 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 // Create swap service with configuration
 const swapProtocol = new VeloraProtocolEvm(account, {
-  swapMaxFee: 200000000000000n // Optional: Max swap fee in wei
+  swapMaxFee: 200000000000000n // Optional: Exclusive fee cap in wei for this EVM account
 })
 ```
 
 ## Account Configuration
 
-The swap service uses the wallet account configuration for network access and signing. The account must expose an EVM-compatible JSON-RPC URL or EIP-1193 provider; a generic interface type does not make a non-EVM account compatible with this module:
+The swap service reads `account._config.provider` for network access. The account must expose an EVM-compatible JSON-RPC URL or EIP-1193 provider, plus `getAddress()` and `quoteSendTransaction()`. Execution also requires a callable `sendTransaction()`. A shared interface type alone does not make a non-EVM account compatible.
+
+For accounts governed by WDK transaction policies, use [`wdk.registerProtocol()`](/sdk/core-module/api-reference#registerprotocolblockchain-label-protocol-config) and the account's protocol getter. Do not pass the governed account proxy directly to this constructor: that proxy hides `_config`.
 
 ```javascript
 import { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
@@ -43,7 +45,7 @@ const account = new WalletAccountEvm(
 
 // Read-only account (quotes only)
 const readOnly = new WalletAccountReadOnlyEvm(
-  '0xYourAddress',
+  await account.getAddress(),
   {
     provider: 'https://ethereum-rpc.publicnode.com'
   }
@@ -59,29 +61,26 @@ const swapProtocol = new VeloraProtocolEvm(account, {
 
 ### Swap Max Fee
 
-The `swapMaxFee` option sets an upper bound for total gas costs to prevent excessive fees.
+The `swapMaxFee` option rejects execution when the account's quoted fee is equal to or greater than the cap. Since beta.8, the second argument to `swap()` can override this cap for standard EVM accounts as well as smart accounts. `quoteSwap()` does not enforce it.
 
 **Type:** `bigint` (optional)  
-**Unit:** Wei
+**Unit:** The account quote's fee units: native wei for standard EVM or native-coin fees, paymaster-token base units for token-paid fees, or zero for sponsored quotes. Choose a cap for the selected gas-payment mode; a zero cap rejects a zero-fee sponsored quote.
 
 **Examples:**
 
 ```javascript
-const config = {
-  // Cap total gas fee to 0.0002 ETH (in wei)
-  swapMaxFee: 200000000000000n,
-}
-
-// Usage example
+// Ethereum standard EVM account; input allowance must already be sufficient
 try {
   const result = await swapProtocol.swap({
     tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt (6 decimals)
     tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH (18 decimals)
     tokenInAmount: 1000000n
-  })
+  }, { swapMaxFee: 200000000000000n }) // Exclusive cap of 0.0002 ETH
 } catch (error) {
-  if (error.message.includes('max fee')) {
+  if (error.message === 'Exceeded maximum fee cost for swap operation.') {
     console.error('Swap stopped: Fee too high')
+  } else {
+    throw error
   }
 }
 ```
@@ -98,30 +97,32 @@ const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   provider: 'https://ethereum-rpc.publicnode.com',
   bundlerUrl: 'YOUR_BUNDLER_URL',
   paymasterUrl: 'YOUR_PAYMASTER_URL',
-  paymasterAddress: 'YOUR_PAYMASTER_ADDRESS',
+  paymasterAddress: process.env.PAYMASTER_ADDRESS,
   safeModulesVersion: '0.3.0',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   }
 })
 
-const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 200000000000000n })
+const swapAA = new VeloraProtocolEvm(aa)
 
 const result = await swapAA.swap({
-  tokenIn: '0xTokenIn',
-  tokenOut: '0xTokenOut',
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n
 }, {
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  swapMaxFee: 200000000000000n // Per‑swap override
+  swapMaxFee: 10000n // Exclusive cap of 0.01 USDt for this token-paid quote
 })
 ```
 
 ### Per-call ERC‑4337 Config
 
-The second argument to `swap()` and `quoteSwap()` accepts ERC‑4337 wallet config overrides only when the protocol uses the concrete `WalletAccountEvmErc4337` or `WalletAccountReadOnlyEvmErc4337` class, respectively. Use it to switch paymaster token, sponsorship policy, or native-coin fee behavior for a single call. `swap()` also accepts `swapMaxFee` as a per-swap fee cap. Standard EVM accounts use one ordinary EVM transaction and do not apply these per-call ERC‑4337 overrides.
+The protocol passes the second argument to the account's quote and send methods without a concrete-class check. Compatible ERC-4337 accounts use it to select paymaster-token, sponsorship, or native-coin behavior. Standard WDK EVM accounts ignore those wallet fields, but the protocol still applies `swapMaxFee` from the second argument to `swap()`. Quote and execution receive one transaction object, not an ERC-4337-specific array.
+
+The paymaster service must support the chosen chain and token. Configure its own endpoint and contract address; `PAYMASTER_ADDRESS` is deployment-specific. Approve the swap's input token for the current Velora spender before executing. The module does not create that approval for you. To change a nonzero Ethereum USD₮ allowance to another nonzero amount, first approve zero and wait for confirmation, then approve the new amount and wait again.
 
 **Type:** partial ERC‑4337 wallet config (optional)
 
@@ -129,14 +130,14 @@ The second argument to `swap()` and `quoteSwap()` accepts ERC‑4337 wallet conf
 
 ```javascript
 const result = await swapAA.swap({
-  tokenIn: '0xdAC17F...ec7',
-  tokenOut: '0xC02a...6Cc2', // WETH
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n
 }, {
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  swapMaxFee: 200000000000000n
+  swapMaxFee: 10000n // Exclusive cap of 0.01 USDt for this token-paid quote
 })
 ```
 
@@ -162,12 +163,12 @@ When calling `swap`, provide the swap parameters:
 
 ```javascript
 const swapOptions = {
-  tokenIn: '0xTokenIn',          // ERC‑20 to sell
-  tokenOut: '0xTokenOut',        // ERC‑20 to buy
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n,       // exact input (base units)
   // OR
-  // tokenOutAmount: 1000000n,   // exact output (base units)
-  to: '0xRecipient'              // optional recipient (defaults to your address)
+  // tokenOutAmount: 1000000000000000n, // Alternative: exact output of 0.001 WETH
+  to: await account.getAddress() // Optional recipient; defaults to this account
 }
 
 const result = await swapProtocol.swap(swapOptions)

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/execute-swaps.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/execute-swaps.mdx
@@ -6,7 +6,7 @@ description: Run exact-input swaps, exact-output swaps, and swaps with ERC-4337 
 This guide explains how to run a [basic exact-input swap](#basic-exact-input-swap), an [exact-output swap](#exact-output-swap), and a [swap from an ERC-4337 smart account](#swap-with-erc-4337). You should already have a [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) instance.
 
 <Callout type="warn">
-Swaps spend tokens and gas on-chain. Use amounts you control and an RPC you trust.
+Swaps spend tokens and gas on-chain. Before execution, approve the input token for the current Velora spender on the account's chain. The module does not submit approvals or reset allowances. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for approval and fee prerequisites.
 </Callout>
 
 ## Basic exact-input swap
@@ -21,7 +21,7 @@ const result = await swapProtocol.swap({
 })
 
 console.log('Swap transaction hash:', result.hash)
-console.log('Total fee (wei):', result.fee)
+console.log('Total fee (account units):', result.fee)
 console.log('Tokens sold (base units):', result.tokenInAmount)
 console.log('Tokens bought (base units):', result.tokenOutAmount)
 ```
@@ -62,7 +62,8 @@ const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   }
 })
 
-const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 200000000000000n })
+// Exclusive cap: 0.01 USDt with this six-decimal paymaster token.
+const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 10000n })
 
 const result = await swapAA.swap({
   tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -72,11 +73,11 @@ const result = await swapAA.swap({
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  swapMaxFee: 200000000000000n
+  swapMaxFee: 10000n
 })
 
 console.log('Swap hash:', result.hash)
-console.log('Total fee (wei):', result.fee)
+console.log('Total fee (USDt base units):', result.fee)
 ```
 
 <Callout type="info">

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-started.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-started.mdx
@@ -34,7 +34,7 @@ const swapProtocol = new VeloraProtocolEvm(account, {
 })
 ```
 
-Optional `swapMaxFee` caps the total gas fee in wei for swaps. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for environment-specific settings.
+Optional `swapMaxFee` is an exclusive cap in the account's quoted fee units: wei for the standard EVM account above. A fee equal to or above the cap rejects the swap. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for paymaster fee units and approval prerequisites.
 
 ## Supported networks
 

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/get-swap-quotes.mdx
@@ -16,7 +16,7 @@ const quote = await swapProtocol.quoteSwap({
   tokenInAmount: 1000000n
 })
 
-console.log('Estimated fee (wei):', quote.fee)
+console.log('Estimated fee (account units):', quote.fee)
 console.log('Tokens in (base units):', quote.tokenInAmount)
 console.log('Tokens out (base units):', quote.tokenOutAmount)
 ```
@@ -30,7 +30,7 @@ const quote = await swapProtocol.quoteSwap({
   tokenOutAmount: 500000000000000000n
 })
 
-console.log('Estimated fee (wei):', quote.fee)
+console.log('Estimated fee (account units):', quote.fee)
 console.log('Required token in (base units):', quote.tokenInAmount)
 ```
 
@@ -50,7 +50,9 @@ const quote = await swapAA.quoteSwap({
 
 ## Fee estimation
 
-You can read `quote.fee` from [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) as the estimated total swap fee in wei before calling [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
+Read `quote.fee` in the account's fee units: native wei for a standard EVM account, token base units for token-paymaster fees, or zero for sponsorship. The quote excludes any separate input-token approval. `quoteSwap()` does not enforce `swapMaxFee`.
+
+The following examples use a standard EVM account, so the cap is in wei:
 
 ```javascript title="Quote fee before deciding"
 const quote = await swapProtocol.quoteSwap({
@@ -63,7 +65,7 @@ const maxFee = 200000000000000n
 console.log('Quoted fee (wei):', quote.fee, 'cap:', maxFee)
 ```
 
-You can compare that estimate to `swapMaxFee` on [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) and only then call [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) when the quote is within your cap:
+Compare the estimate with an exclusive cap and pass the same cap to [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference). Execution obtains a fresh fee quote and rejects a fee equal to or above `swapMaxFee`:
 
 ```javascript title="Swap when fee is under cap"
 const maxFee = 200000000000000n
@@ -73,12 +75,12 @@ const quote = await swapProtocol.quoteSwap({
   tokenInAmount: 1000000n
 })
 
-if (quote.fee <= maxFee) {
+if (quote.fee < maxFee) {
   const result = await swapProtocol.swap({
     tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
     tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
     tokenInAmount: 1000000n
-  })
+  }, { swapMaxFee: maxFee })
   console.log('Swap hash:', result.hash)
 }
 ```

--- a/content/docs/sdk/swap-modules/swap-velora-evm/guides/handle-errors.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/guides/handle-errors.mdx
@@ -23,8 +23,8 @@ try {
   if (error.message.includes('liquidity')) {
     console.log('No route or insufficient liquidity for this pair')
   }
-  if (error.message.includes('max fee')) {
-    console.log('Swap fee exceeds swapMaxFee')
+  if (error.message === 'Exceeded maximum fee cost for swap operation.') {
+    console.log('Swap fee is equal to or above swapMaxFee')
   }
   if (error.message.includes('read-only')) {
     console.log('Read-only account cannot swap')
@@ -47,13 +47,13 @@ try {
     tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
     tokenInAmount: 1000000n
   })
-  console.log('Quoted fee (wei):', quote.fee)
+  console.log('Quoted fee (account units):', quote.fee)
 } catch (error) {
   console.error('Quote failed:', error.message)
 }
 ```
 
-Common causes are listed under [Errors](/sdk/swap-modules/swap-velora-evm/api-reference) in the API reference (liquidity, fee cap, read-only send attempts, RPC issues).
+Quotes can fail because of routing, liquidity, or provider errors. Fee-cap enforcement and read-only send rejection occur in `swap()`, not `quoteSwap()`. See [Errors](/sdk/swap-modules/swap-velora-evm/api-reference) in the API reference.
 
 ## Best Practices
 

--- a/content/docs/sdk/swap-modules/swap-velora-evm/index.mdx
+++ b/content/docs/sdk/swap-modules/swap-velora-evm/index.mdx
@@ -11,7 +11,7 @@ Use the Velora swap module to quote and execute token swaps on EVM chains. It wo
 
 - **Token Swapping**: Execute token swaps through velora on supported EVM networks
 - **Account Abstraction**: Compatible with standard EVM accounts and ERC‑4337 smart accounts
-- **Fee Controls**: Optional `swapMaxFee` to cap gas costs
+- **Fee Controls**: Constructor and per-call `swapMaxFee` for standard and smart accounts, in the account quote's fee units
 - **Approval-aware swaps**: Approve input tokens with the wallet account before swapping when allowance is required
 - **Provider Flexibility**: Works with JSON‑RPC URLs and EIP‑1193 providers
 - **TypeScript Support**: Full TypeScript definitions included
@@ -28,11 +28,13 @@ The swap service supports multiple EVM wallet types:
 - **ERC‑4337 Smart Accounts**: `@tetherto/wdk-wallet-evm-erc-4337` accounts with bundler/paymaster
 - **Read‑Only Accounts**: For quoting swaps without sending transactions
 
+The constructor accepts shared wallet interfaces, while the implementation requires an EVM provider in `account._config.provider`. Compatible wrappers must also expose the account methods used for quotes and execution. A callable `sendTransaction()` establishes writability; it does not establish chain or provider compatibility.
+
 ## Key Components
 
 - **velora Integration**: Uses velora aggregator for routing and quotes
 - **Quote System**: Pre‑transaction fee and amount estimation via `quoteSwap`
-- **AA Integration**: Optional paymaster, sponsorship, native-fee, and fee-cap overrides when using ERC‑4337
+- **AA Integration**: Forward paymaster, sponsorship, and native-fee overrides to compatible ERC‑4337 accounts
 - **Read-only quoting**: Quote swaps from read-only EVM and ERC‑4337 accounts
 
 ## Next Steps

--- a/content/docs/sdk/swidge-modules/swidge-orchestra/api-reference.mdx
+++ b/content/docs/sdk/swidge-modules/swidge-orchestra/api-reference.mdx
@@ -105,7 +105,7 @@ const result = await orchestra.swidge({
 
 | Field | Type | Description |
 |---|---|---|
-| `fromToken` | `string` | Source token, preferably chain-qualified such as `spark:BTC` or `bsc:USDT`. |
+| `fromToken` | `string` | Source token, preferably chain-qualified such as `spark:BTC` or `tron:USDT`. |
 | `toToken` | `string` | Destination token, preferably chain-qualified. |
 | `fromChain` | `string \| number` | Optional source-chain override. |
 | `toChain` | `string \| number` | Optional destination-chain override. |

--- a/content/docs/sdk/swidge-modules/swidge-orchestra/guides/quote-and-execute.mdx
+++ b/content/docs/sdk/swidge-modules/swidge-orchestra/guides/quote-and-execute.mdx
@@ -26,7 +26,7 @@ const tokens = await orchestra.getSupportedTokens({
 })
 ```
 
-Use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, `bsc:USDT`, or `tron:USDT`.
+Use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, or `tron:USDT`.
 
 ## Quotes
 
@@ -95,29 +95,9 @@ const intent = await orchestra.prepareSwap({
 })
 ```
 
-### EVM USD₮ to Spark BTC
+### EVM token sources
 
-EVM token sources use the WDK account's `transfer({ token, recipient, amount })` path. The source account needs native gas for its chain.
-
-```javascript title="Prepare BSC USDt to Spark BTC"
-const bsc = await wdk.getAccount('bsc', 0)
-const spark = await wdk.getAccount('spark', 0)
-
-const orchestra = new Orchestra(bsc, {
-  sourceChain: 'bsc',
-  apiKey: process.env.FLASHNET_API_KEY,
-  sourceTokenAddresses: {
-    'bsc:USDT': '0x55d398326f99059ff775485246999027b3197955'
-  }
-})
-
-const intent = await orchestra.prepareSwap({
-  fromToken: 'bsc:USDT',
-  toToken: 'spark:BTC',
-  fromTokenAmount: 5000000n,
-  recipient: await spark.getAddress()
-})
-```
+EVM token sources use the WDK account's `transfer({ token, recipient, amount })` path. The source account needs native gas for its chain. Select a route from discovery and verify the source token contract and decimals before setting `sourceTokenAddresses` and an amount in base units.
 
 ### Bitcoin L1 source
 
@@ -150,16 +130,5 @@ const submitted = await orchestra.executeSwapIntent(intent, {
 ### Destination Lightning
 
 Orchestra supports destination Lightning routes where the live route matrix exposes them. Pass a BOLT11 invoice or Lightning Address as `recipient`, and include refund metadata required by the route.
-
-```javascript title="Prepare USDt to destination Lightning"
-const intent = await orchestra.prepareSwap({
-  fromToken: 'bsc:USDT',
-  toToken: 'lightning:BTC',
-  fromTokenAmount: 5000000n,
-  recipient: bolt11Invoice,
-  refundChain: 'bsc',
-  refundAddress: await bsc.getAddress()
-})
-```
 
 Lightning as a source is not supported through this package's standard `swidge()` or `executeSwapIntent()` flow.

--- a/content/docs/sdk/swidge-modules/swidge-orchestra/usage.mdx
+++ b/content/docs/sdk/swidge-modules/swidge-orchestra/usage.mdx
@@ -29,7 +29,7 @@ console.log(chains)
 console.log(sparkToTronTokens)
 ```
 
-The returned token identifiers use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, `bsc:USDT`, or `tron:USDT`. Use the values returned by discovery when building UI route options.
+The returned token identifiers use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, or `tron:USDT`. Use the values returned by discovery when building UI route options.
 
 ## Quote before execution
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference.mdx
@@ -107,6 +107,7 @@ Treat the arrays returned through `keyPair` as read-only. Call `dispose()` when 
 
 ### Quote and Send Behavior
 
+- Owned-account quotes, signing, and sends check the configured `chainId` before proceeding, including sponsored quotes and already-signed inputs. The first successful check is cached; see [chain validation](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#chain-validation).
 - Sponsored mode returns `fee: 0n` from quote methods.
 - Paymaster-token mode returns fees in the configured paymaster token's base units.
 - `signTransaction()` returns a signed `UserOperationV8` without broadcasting it. The type comes from `abstractionkit` and is not re-exported from this package's root.
@@ -124,7 +125,7 @@ Treat the arrays returned through `keyPair` as read-only. Call `dispose()` when 
 - A string `nonceKey` is hashed to a deterministic 192-bit key. Numeric keys must be within the uint192 range; use bigint or string form above JavaScript's safe integer range.
 - Let the first delegation reach the chain before using concurrent lanes. Overlapping operations on the same lane can return hashes even when one can never receive a receipt.
 - A fresh `parallel` lane creates a permanent EntryPoint nonce slot. Reuse a bounded set of named lanes for sustained workloads.
-- The runtime accepts lane fields in per-call overrides for signing, sending, and transfers, but the beta.4 second-argument declarations omit them. Constructor-level lane fields are correctly typed.
+- The runtime accepts lane fields in per-call overrides for signing, sending, and transfers, but the beta.5 second-argument declarations omit them. Constructor-level lane fields are correctly typed.
 
 ### Transfer Fee Cap
 
@@ -193,6 +194,8 @@ Known configuration errors include:
 - missing `delegationAddress`;
 - missing `paymasterToken` when `isSponsored` is absent or `false`;
 - empty provider array;
+- unsupported `entryPointVersion` or a reference delegation address paired with the wrong version;
+- the provider chain differs from configured `chainId` during the first UserOperation chain lookup;
 - configured `paymasterAddress` does not match the paymaster returned by the RPC.
 
 ## Config Types
@@ -202,10 +205,12 @@ Known configuration errors include:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `provider` | `string \| Eip1193Provider \| Array\<string \| Eip1193Provider\>` | Yes | RPC endpoint, EIP-1193 provider, or provider failover list. |
+| `chainId` | `number` | No | Expected chain ID for the first UserOperation chain lookup. A successful check is cached; omission trusts the provider. |
+| `entryPointVersion` | `'0.8' \| '0.9'` | No | Selects the EntryPoint and matching account implementation. Defaults to `'0.8'`. |
 | `retries` | `number` | No | Additional retry attempts for provider arrays. Defaults to `3`. |
 | `bundlerUrl` | `string` | Yes | ERC-4337 bundler endpoint. |
 | `paymasterUrl` | `string` | No | Paymaster endpoint when different from `bundlerUrl`. |
-| `delegationAddress` | `string` | Yes | Smart-account implementation address used for EIP-7702 delegation. |
+| `delegationAddress` | `string` | Yes | Smart-account implementation address built for the configured `entryPointVersion`. |
 | `parallel` | `boolean` | No | Uses a fresh random nonce lane for each sign, send, or transfer operation unless `nonceKey` is set. |
 | `nonceKey` | `number \| bigint \| string` | No | Uses a reusable explicit uint192 nonce lane; strings are hashed deterministically. |
 
@@ -238,4 +243,4 @@ type Evm7702GaslessWalletConfig =
 
 The package also re-exports EVM wallet types from `@tetherto/wdk-wallet-evm`, including `FeeRates`, `KeyPair`, `EvmTransaction`, `TransactionResult`, `EvmTransferOptions`, `TransferResult`, `EvmTransactionReceipt`, `ApproveOptions`, `TypedData`, `TypedDataDomain`, and `TypedDataField`. It re-exports the shared `Finality`, `TransactionReceipt`, `WaitForTransactionTarget`, and `WaitForTransactionOptions` types from `@tetherto/wdk-wallet`.
 
-Module-specific exported types include `UserOperationReceipt`, `Evm7702GaslessTransactionDetails`, `Eip7702AuthorizationOverride`, `BuildSponsoredUserOperationOverrides`, and `SponsoredUserOperation`. `Evm7702GaslessTransactionDetails` adds `confirmations`, the native EVM `receipt`, and `userOperationReceipt` to the normalized receipt. In beta.4, `BuildSponsoredUserOperationOverrides` includes optional `nonce?: bigint` for explicitly selecting the EntryPoint nonce in lower-level builder typing; it does not expose the protected builder as a public method.
+Module-specific exported types include `UserOperationReceipt`, `Evm7702GaslessTransactionDetails`, `Eip7702AuthorizationOverride`, `BuildSponsoredUserOperationOverrides`, and `SponsoredUserOperation`. `Evm7702GaslessTransactionDetails` adds `confirmations`, the native EVM `receipt`, and `userOperationReceipt` to the normalized receipt. In beta.5, `BuildSponsoredUserOperationOverrides` includes optional `nonce?: bigint` for explicitly selecting the EntryPoint nonce in lower-level builder typing; it does not expose the protected builder as a public method.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/configuration.mdx
@@ -11,7 +11,7 @@ icon: Settings
 `WalletManagerEvm7702Gasless`, `WalletAccountEvm7702Gasless`, and `WalletAccountReadOnlyEvm7702Gasless` use the same base configuration. The account must also choose one fee mode: sponsorship policy or paymaster token.
 
 <Callout type="warn">
-Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain. The EOA delegates execution to this address.
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain and configured `entryPointVersion`. The EOA delegates execution to this address.
 </Callout>
 
 ```javascript title="Sponsored wallet configuration"
@@ -46,7 +46,7 @@ const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
 |-------|------|-------------|
 | `provider` | `string \| Eip1193Provider \| Array\<string \| Eip1193Provider\>` | RPC endpoint, EIP-1193 provider, or ordered failover list. |
 | `bundlerUrl` | `string` | ERC-4337 bundler endpoint used to build and submit UserOperations. |
-| `delegationAddress` | `string` | Smart-account implementation address used for EIP-7702 delegation. |
+| `delegationAddress` | `string` | Smart-account implementation address built for the configured `entryPointVersion`, used for EIP-7702 delegation. |
 
 Account constructors and per-call config overrides throw `ConfigurationError` if any required common field is missing.
 
@@ -54,10 +54,33 @@ Account constructors and per-call config overrides throw `ConfigurationError` if
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `chainId` | `number` | Provider-reported chain | Expected chain ID, checked before building or signing UserOperations. See [chain validation](#chain-validation) for caching and quote behavior. |
+| `entryPointVersion` | `'0.8' \| '0.9'` | `'0.8'` | Selects the EntryPoint address and matching account implementation for construction and signing. |
 | `paymasterUrl` | `string` | `bundlerUrl` | Paymaster endpoint when it differs from the bundler endpoint. |
 | `retries` | `number` | `3` | Additional retry attempts when `provider` is an array. Total attempts are `1 + retries`. |
 | `parallel` | `boolean` | `false` | Use a fresh random EntryPoint nonce lane for each sign, send, or transfer operation. Ignored when `nonceKey` is set. |
 | `nonceKey` | `number \| bigint \| string` | - | Use a reusable explicit nonce lane. Strings are hashed to a deterministic key; numeric keys must fit the uint192 range. |
+
+### EntryPoint Version
+
+Set `entryPointVersion` in the constructor to match your bundler, paymaster, and delegation implementation. Omitting it preserves EntryPoint v0.8. The selected version controls UserOperation construction, the signing domain, nonce lookup, submission, and paymaster-token queries.
+
+| `entryPointVersion` | EntryPoint address | Reference `delegationAddress` |
+|---------------------|--------------------|-------------------------------|
+| `'0.8'` (default) | `0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108` | `0xe6Cae83BdE06E4c305530e199D7217f42808555B` |
+| `'0.9'` | `0x433709009B8330FDa32311DF1C2AFA402eD8D009` | `0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5` |
+
+<Callout type="warn">
+Verify that the selected contracts are deployed on your target chain. Account creation rejects an unsupported version or a reference delegation address paired with the other version. Custom delegation addresses are accepted without verifying their EntryPoint compatibility; verify their implementation before use.
+</Callout>
+
+Configure `entryPointVersion` and `chainId` when creating the account. Per-call fee-mode overrides do not switch the account's chain or EntryPoint.
+
+### Chain Validation
+
+Set `chainId` to the expected network, for example `chainId: 1` for Ethereum mainnet. The first UserOperation chain lookup calls `eth_chainId` and throws `ConfigurationError` on a mismatch before building or signing. Owned-account quotes and sends perform this lookup too, including sponsored quotes and already-signed inputs. A read-only sponsored quote returns `0n` without checking the chain.
+
+The account caches a successful lookup. It does not detect a later network switch, so keep all failover providers on the same chain and recreate the wallet or account when changing networks. Omitting `chainId` trusts the provider-reported chain. This check does not verify the chain or EntryPoint encoded in an externally signed operation.
 
 ### Provider Failover
 
@@ -200,7 +223,7 @@ const result = await account.sendTransaction(tx, feeConfig)
 
 When an override is provided, the merged config is validated before the operation runs. `confirmFeeTokenAndAmount()` represents the application's explicit review of the changed fee token and quoted amount; the quote itself does not enforce `transactionMaxFee`, while the wallet-built send does.
 
-The beta.4 JavaScript runtime also reads `parallel` and `nonceKey` from per-call overrides for `signTransaction()`, `sendTransaction()`, and `transfer()`. The published second-argument TypeScript declarations include only fee-mode fields, so constructor-level lane configuration is the typed path in this release.
+The beta.5 JavaScript runtime also reads `parallel` and `nonceKey` from per-call overrides for `signTransaction()`, `sendTransaction()`, and `transfer()`. The published second-argument TypeScript declarations include only fee-mode fields, so constructor-level lane configuration is the typed path in this release.
 
 <Callout type="info">
 The two-minute quote cache key includes the transaction, sponsorship mode, paymaster token, expected paymaster address, and sponsorship policy ID. A matching operation also rechecks the current EntryPoint nonce before reuse. Changing any keyed fee-mode field causes a fresh quote.

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/get-started.mdx
@@ -15,7 +15,7 @@ npm install @tetherto/wdk-wallet-evm-7702-gasless
 ## Create a Sponsored Wallet
 
 <Callout type="warn">
-Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain. The EOA delegates execution to this address.
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain and EntryPoint v0.8, the default. To use v0.9, configure a [matching EntryPoint and delegation implementation](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version). The EOA delegates execution to this address.
 </Callout>
 
 ```javascript title="Create a sponsored EIP-7702 gasless wallet"
@@ -23,6 +23,7 @@ import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
 
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
+  chainId: 1,
   delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true,
@@ -44,6 +45,7 @@ If the user pays gas with an ERC-20 paymaster token, configure `paymasterToken` 
 ```javascript title="Create a paymaster-token wallet"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
+  chainId: 1,
   delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   paymasterToken: {

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/handle-errors.mdx
@@ -29,7 +29,7 @@ try {
 }
 ```
 
-Common configuration errors include missing `provider`, `bundlerUrl`, `delegationAddress`, or `paymasterToken` when the account is not sponsored.
+Common configuration errors include missing `provider`, `bundlerUrl`, `delegationAddress`, or `paymasterToken` when the account is not sponsored. An unsupported `entryPointVersion` or a reference delegation address paired with the wrong version also fails account creation. A provider-chain mismatch throws when a UserOperation flow first checks `chainId`; review [chain validation](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#chain-validation) before retrying.
 
 ## Paymaster Token Errors
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/manage-accounts.mdx
@@ -48,7 +48,7 @@ Read-only accounts do not expose `sign()`, `signTypedData()`, `signTransaction()
 
 ## Create a Read-only Account from an Address
 
-Use the verified EIP-7702 implementation address for the target chain. The placeholder below must be replaced before use.
+Use an EIP-7702 implementation address verified for the target chain and the [configured EntryPoint version](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version). The placeholder below must be replaced before use.
 
 ```javascript title="Read-only account from address"
 import { WalletAccountReadOnlyEvm7702Gasless } from '@tetherto/wdk-wallet-evm-7702-gasless'

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/send-transactions.mdx
@@ -75,7 +75,7 @@ console.log('Signed operation fee:', quote.fee)
 const result = await account.sendTransaction(signedUserOperation)
 ```
 
-Quoting a signed UserOperation avoids paymaster calls. Sponsorship mode returns `fee: 0n`; paymaster-token mode derives a native-gas ceiling in wei from the operation's existing gas fields rather than returning the token amount fixed when the operation was built. Sending broadcasts the supplied nonce, authorization, gas fields, and signature without rebuilding the operation or requesting another signature.
+Quoting a signed UserOperation avoids paymaster calls. Sponsorship mode returns `fee: 0n`; paymaster-token mode derives a native-gas ceiling in wei from the operation's existing gas fields rather than returning the token amount fixed when the operation was built. Sending broadcasts the supplied nonce, authorization, gas fields, and signature without rebuilding the operation or requesting another signature. Both quoting and sending still perform the account's [cached chain check](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#chain-validation). The check validates the RPC chain, not the signed payload; submission uses the account's configured EntryPoint.
 
 <Callout type="warn">
 `sendTransaction(signedUserOperation)` does not enforce `transactionMaxFee`: the module cannot reconstruct the token-denominated paymaster fee from an already-signed operation. Apply the cap while this wallet builds or signs the operation, and independently review signed operations received from elsewhere.
@@ -156,7 +156,7 @@ await account.sendTransaction(scheduledPayment, { nonceKey: 'scheduled-payments'
 `nonceKey` takes precedence over `parallel`. String keys are hashed into deterministic 192-bit lane keys. A number or bigint is used as the raw key and must be between `0` and `2^192 - 1`; use a bigint or string above JavaScript's safe integer range.
 
 <Callout type="warning">
-The beta.4 runtime accepts per-call `parallel` and `nonceKey`, but the published second-argument declarations omit those common fields. TypeScript object literals using the per-call form fail type checking. Configure lanes on the wallet or account constructor for typed code, or isolate an explicit local type workaround until the package declarations are corrected.
+The beta.5 runtime accepts per-call `parallel` and `nonceKey`, but the published second-argument declarations omit those common fields. TypeScript object literals using the per-call form fail type checking. Configure lanes on the wallet or account constructor for typed code, or isolate an explicit local type workaround until the package declarations are corrected.
 </Callout>
 
 Use nonce lanes with these constraints:

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/guides/transfer-tokens.mdx
@@ -42,7 +42,7 @@ In paymaster-token mode, set `transferMaxFee` to cancel `transfer()` when the es
 This comparison is intentionally stricter than `transactionMaxFee`: a transfer fee equal to `transferMaxFee` is rejected, while an equal send/sign/approve fee is allowed by `transactionMaxFee`.
 
 <Callout type="warn">
-Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain.
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain and the [configured EntryPoint version](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version).
 </Callout>
 
 ```javascript title="Cap transfer fee"

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/index.mdx
@@ -14,6 +14,7 @@ It handles EIP-7702 authorization, UserOperation construction, UserOperation sig
 - **EOA-based EIP-7702 accounts**: `getAddress()` returns the EOA address. The account delegates execution to the configured `delegationAddress` when needed.
 - **Sponsored transactions**: Set `isSponsored: true` to use a sponsorship policy. Quotes return a zero fee in sponsored mode.
 - **Paymaster-token transactions**: Configure `paymasterToken` to pay UserOperation costs in an ERC-20 token.
+- **EntryPoint selection**: Use v0.8 by default or select v0.9 with a matching delegation implementation, bundler, and paymaster. See [configuration](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version).
 - **Provider failover**: Pass one provider or an ordered list of RPC URLs / EIP-1193 providers. Provider arrays support `retries`.
 - **UserOperation finality**: Track a UserOperation from bundler acceptance through its EVM transaction's confirmed or final state with `getTransaction()` and `waitForTransaction()`.
 - **Non-broadcasting UserOperation signing**: Build and sign a self-contained `UserOperationV8` without submitting it, then quote or send that operation separately. Construction still uses the configured provider, bundler, and paymaster services.
@@ -28,7 +29,7 @@ This module depends on EVM infrastructure that supports both EIP-7702 account de
 - an RPC provider for a chain where the EIP-7702 flow is available;
 - an ERC-4337 bundler URL;
 - a paymaster endpoint, either the same as `bundlerUrl` or a separate `paymasterUrl`;
-- a trusted smart-account implementation address for `delegationAddress`;
+- a trusted smart-account implementation address for `delegationAddress`, built for the configured EntryPoint version;
 - either a sponsorship policy or an ERC-20 paymaster token configuration.
 
 <Callout type="warn">

--- a/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/usage.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-7702-gasless/usage.mdx
@@ -42,7 +42,7 @@ Get started with WDK in a Node.js environment.
 Compare WDK wallet modules across supported chains.
 </Card>
 <Card title="Configuration" href="/sdk/wallet-modules/wallet-evm-7702-gasless/configuration">
-Review fee modes, providers, nonce lanes, and per-call overrides.
+Review fee modes, providers, chain validation, EntryPoint versions, and nonce lanes.
 </Card>
 <Card title="API Reference" href="/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference">
 Review classes, methods, config types, and return values.

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
@@ -42,7 +42,7 @@ new WalletManagerEvmErc4337(seed, config)
   - `chainId` (number): The blockchain's ID (e.g., 1 for Ethereum mainnet)
   - `provider` (string | Eip1193Provider | Array\<string | Eip1193Provider\>): RPC endpoint URL, EIP-1193 provider instance, or ordered failover list
   - `bundlerUrl` (string): The URL of the bundler service
-  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.17
+  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.18
 
 **Optional common config fields:**
   - `parallel` (boolean): Put each send, sign, or transfer in a fresh random 192-bit nonce-key lane
@@ -380,7 +380,7 @@ Sends a transaction via UserOperation through the bundler.
 - `ConfigurationError` if the override is invalid or the token paymaster address returned while building mismatches the configured address.
 - `TransactionError` with `reason: TransactionErrorReason.INSUFFICIENT_BALANCE` if the paymaster reports AA50 while building or submitting the operation.
 
-When `tx` is a signed `UserOperationV7`, WDK forwards that exact operation to the bundler. It does not rebuild or re-sign it, reapply the current `transactionMaxFee`, call the paymaster RPC, or rerun the paymaster-address check. Only submit an operation produced by the same account after verifying the intended fee-mode and paymaster configuration, and submit it before its nonce becomes stale.
+When `tx` is a signed `UserOperationV7`, WDK forwards that exact operation to the bundler without checking the provider against `chainId`. It does not rebuild or re-sign it, reapply the current `transactionMaxFee`, call the paymaster RPC, or rerun the paymaster-address check. Only submit an operation produced by the same account after verifying the intended chain, EntryPoint, fee-mode, and paymaster configuration, and submit it before its nonce becomes stale.
 
 **Example:**
 ```javascript
@@ -866,7 +866,6 @@ const sameAddress = WalletAccountEvmErc4337.predictSafeAddress(
 | `getTransaction(hash)` | Returns normalized UserOperation finality using its bundling transaction | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the hash is invalid or unknown |
 | `waitForTransaction(hash, options?)` | Waits for the UserOperation to reach `confirmed` or `final`, or returns `dropped` | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the wait times out |
 | `getUserOperationReceipt(hash)` | Returns a UserOperation receipt | `Promise\<UserOperationReceipt \| null\>` | - |
-| `signTypedData(typedData)` | Signs EIP-712 typed structured data | `Promise\<string\>` | - |
 | `verifyTypedData(typedData, signature)` | Verifies an EIP-712 typed data signature | `Promise\<boolean\>` | - |
 | `getTokenBalances(tokenAddresses)` | Returns balances for multiple ERC20 tokens | `Promise\<Record\<string, bigint\>\>` | - |
 
@@ -1047,40 +1046,6 @@ if (receipt) {
 }
 ```
 
-##### `signTypedData(typedData)`
-Signs EIP-712 typed structured data using the underlying EOA address.
-
-**Parameters:**
-- `typedData` (TypedData): The typed data object containing domain, types, primaryType, and message
-
-**Returns:** `Promise\<string\>` - The typed data signature
-
-**Example:**
-```javascript
-const typedData = {
-  domain: {
-    name: 'MyDApp',
-    version: '1',
-    chainId: 1,
-    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
-  },
-  types: {
-    Transfer: [
-      { name: 'to', type: 'address' },
-      { name: 'amount', type: 'uint256' }
-    ]
-  },
-  primaryType: 'Transfer',
-  message: {
-    to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-    amount: 1000000n
-  }
-}
-
-const signature = await readOnlyAccount.signTypedData(typedData)
-console.log('Typed data signature:', signature)
-```
-
 ##### `verifyTypedData(typedData, signature)`
 Verifies an EIP-712 typed data signature against the underlying EOA address.
 
@@ -1149,6 +1114,8 @@ The package re-exports these types.
 
 ### EvmErc4337WalletConfig
 
+The constructor's `chainId` is checked against the provider's first `eth_chainId` response before building a UserOperation. A mismatch throws `ConfigurationError`; a successful lookup is cached. Sponsored quotes and already-signed operation quote/send paths do not perform this check. See [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id).
+
 The configuration is a union type combining common fields with one of three gas payment modes:
 
 ```typescript
@@ -1157,7 +1124,7 @@ interface EvmErc4337WalletCommonConfig {
   chainId: number;                          // Blockchain ID
   provider: string | Eip1193Provider | Array<string | Eip1193Provider>; // RPC provider or failover list
   bundlerUrl: string;                       // Bundler service URL
-  safeModulesVersion: string;               // Must be '0.3.0' in beta.17
+  safeModulesVersion: string;               // Must be '0.3.0' in beta.18
   parallel?: boolean;                       // Fresh random nonce-key lane per operation
   nonceKey?: number | bigint | string;      // Reusable raw or named uint192 lane key
 }
@@ -1198,7 +1165,7 @@ type EvmErc4337WalletConfig = EvmErc4337WalletCommonConfig &
 
 ### Config Override
 
-The published beta.17 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
+The published beta.18 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
 
 ```typescript
 type ConfigOverride = Partial<
@@ -1220,7 +1187,7 @@ type ConfigOverride = Partial<
 
 Overrides are shallow-merged with the account configuration, then validated. When switching modes, explicitly clear an inherited opposing flag: sponsorship requires `isSponsored: true` and `useNativeCoins: false`; native-coin mode requires `isSponsored: false` and `useNativeCoins: true`; paymaster-token mode requires both flags to be `false`. The merged configuration must also contain the URL, address, token, or policy fields required by the selected mode.
 
-At runtime, beta.17 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
+At runtime, beta.18 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
 
 In token-paymaster mode, every path that builds a UserOperation validates a non-empty paymaster address returned by the RPC against `paymasterAddress`. A case-insensitive mismatch throws `ConfigurationError` before the operation is returned or submitted.
 
@@ -1362,7 +1329,7 @@ class ConfigurationError extends ValueError {
 }
 ```
 
-`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`.
+`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`. It also reports a mismatch between the constructor's `chainId` and the provider during the first UserOperation chain lookup.
 
 ### FeeRates
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/api-reference.mdx
@@ -11,7 +11,7 @@ icon: Code
 | Class | Description | Methods |
 |-------|-------------|---------|
 | [WalletManagerEvmErc4337](#walletmanagerevmerc4337) | Main class for managing ERC-4337 EVM wallets. Extends `WalletManager` from `@tetherto/wdk-wallet`. | [Constructor](#constructor), [Methods](#methods) |
-| [WalletAccountEvmErc4337](#walletaccountevmerc4337) | Individual ERC-4337 wallet account implementation. Extends `WalletAccountReadOnlyEvmErc4337` and implements `IWalletAccount`. | [Constructor](#constructor-1), [Methods](#methods-1), [Properties](#properties) |
+| [WalletAccountEvmErc4337](#walletaccountevmerc4337) | Individual ERC-4337 wallet account implementation. Extends `WalletAccountReadOnlyEvmErc4337` and implements `IWalletAccount`. | [Constructor](#constructor-1), [Methods](#methods-1), [Properties](#properties-1) |
 | [WalletAccountReadOnlyEvmErc4337](#walletaccountreadonlyevmerc4337) | Read-only ERC-4337 wallet account. Extends `WalletAccountReadOnly` from `@tetherto/wdk-wallet`. | [Constructor](#constructor-2), [Methods](#methods-2) |
 | [ConfigurationError](#configurationerror) | Error thrown for invalid or incomplete wallet configuration, including an unexpected token paymaster address returned by the RPC. | - |
 
@@ -42,7 +42,7 @@ new WalletManagerEvmErc4337(seed, config)
   - `chainId` (number): The blockchain's ID (e.g., 1 for Ethereum mainnet)
   - `provider` (string | Eip1193Provider | Array\<string | Eip1193Provider\>): RPC endpoint URL, EIP-1193 provider instance, or ordered failover list
   - `bundlerUrl` (string): The URL of the bundler service
-  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.18
+  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.19
 
 **Optional common config fields:**
   - `parallel` (boolean): Put each send, sign, or transfer in a fresh random 192-bit nonce-key lane
@@ -133,12 +133,6 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
 | `getFeeRates()` | Returns current fee rates for transactions | `Promise\<{normal: bigint, fast: bigint}\>` | `ProviderRequiredError` if no provider |
 | `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` | - |
 
-### Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `seed` | `Uint8Array` | The wallet's seed phrase as bytes |
-
 #### `getRandomSeedPhrase(wordCount?)` (static)
 Returns a random BIP-39 seed phrase.
 
@@ -224,6 +218,12 @@ Disposes all wallet accounts, clearing private keys from memory.
 wallet.dispose()
 ```
 
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `seed` | `Uint8Array` | The wallet's seed phrase as bytes |
+
 ## WalletAccountEvmErc4337
 
 Represents an individual ERC-4337 wallet account. Extends `WalletAccountReadOnlyEvmErc4337` and implements `IWalletAccount`.
@@ -269,7 +269,8 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 
 | Method | Description | Returns | Throws |
 |--------|-------------|---------|--------|
-| `predictSafeAddress(owner, config)` | (static) Predicts the Safe address for a given owner | `string` | - |
+| `predictSafeAddress(owner, config)` | (static) Predicts the Safe address for a given owner | `string` | `ValueError` for a malformed owner address |
+| `fromSafeAddress(safeAddress, config)` | (static) Unsupported on the writable class | `never` | Always `UnsupportedOperationError` |
 | `getAddress()` | Returns the Safe account's address | `Promise\<string\>` | - |
 | `sign(message)` | Signs a message using the account's private key | `Promise\<string\>` | - |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
@@ -278,10 +279,10 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 | `quoteSendTransaction(tx, config?)` | Estimates the fee for transactions or a signed UserOperation | `Promise\<{fee: bigint}\>` | If a newly built operation's token paymaster address mismatches |
 | `transfer(options, config?, txOverrides?)` | Transfers ERC20 tokens via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max, or the token paymaster address mismatches |
 | `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If the token paymaster address mismatches |
-| `approve(options, txOverrides?)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | `ProviderRequiredError`, or `ValueError` when Ethereum USD₮ allowance must be reset |
 | `getBalance()` | Returns the native token balance (in wei) | `Promise\<bigint\>` | - |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific ERC20 token | `Promise\<bigint\>` | - |
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
+| `approve(options, txOverrides?)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | `ProviderRequiredError`, or `ValueError` when Ethereum USD₮ allowance must be reset |
 | `getAllowance(token, spender)` | Returns current token allowance for a spender | `Promise\<bigint\>` | - |
 | `getTransactionReceipt(hash)` | Maps a UserOperation hash to a native EVM receipt; deprecated in favor of `getTransaction()` | `Promise\<EvmTransactionReceipt \| null\>` | - |
 | `getTransaction(hash)` | Returns normalized UserOperation finality using its bundling transaction | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the hash is invalid or unknown |
@@ -293,7 +294,15 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 | `toReadOnlyAccount()` | Returns a read-only copy of the account | `Promise\<WalletAccountReadOnlyEvmErc4337\>` | - |
 | `dispose()` | Disposes the wallet account, clearing private keys from memory | `void` | - |
 
-##### `getAddress()`
+#### `predictSafeAddress(owner, config)` (static)
+
+Inherits the [read-only address predictor](#predictsafeaddressowner-config-static-1). It accepts an owner EOA address and `Pick<EvmErc4337WalletConfig, 'safeModulesVersion' | 'onChainIdentifier'>`, and returns a counterfactual Safe address as a `string`. A malformed owner address throws `ValueError`.
+
+#### `fromSafeAddress(safeAddress, config)` (static)
+
+Always throws `UnsupportedOperationError` and returns `never`. A Safe address alone cannot create a signing account. Use the [read-only factory](#fromsafeaddresssafeaddress-config-static-1) instead. Its parameters are `safeAddress: string` and `config: Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`.
+
+#### `getAddress()`
 Returns the Safe smart contract wallet address (not the underlying EOA address).
 
 **Returns:** `Promise\<string\>` - The Safe account's address
@@ -304,7 +313,7 @@ const address = await account.getAddress()
 console.log('Safe account address:', address) // 0x... (Smart contract address)
 ```
 
-##### `sign(message)`
+#### `sign(message)`
 Signs a message using the underlying EOA private key.
 
 **Parameters:**
@@ -319,7 +328,7 @@ const signature = await account.sign(message)
 console.log('Signature:', signature)
 ```
 
-##### `verify(message, signature)`
+#### `verify(message, signature)`
 Verifies a message signature against the underlying EOA address.
 
 **Parameters:**
@@ -334,7 +343,7 @@ const isValid = await account.verify(message, signature)
 console.log('Signature valid:', isValid)
 ```
 
-##### `signTransaction(tx, config?)`
+#### `signTransaction(tx, config?)`
 Builds and signs one ERC-4337 v0.7 UserOperation without submitting it to the bundler.
 
 **Parameters:**
@@ -360,7 +369,7 @@ const signedUserOperation = await account.signTransaction({
 The returned operation contains the selected nonce lane and fee-mode configuration used while building it. Submit it promptly through the same account and do not mutate it.
 </Callout>
 
-##### `sendTransaction(tx, config?)`
+#### `sendTransaction(tx, config?)`
 Sends a transaction via UserOperation through the bundler.
 
 **Parameters:**
@@ -418,7 +427,7 @@ const fastResult = await account.sendTransaction({
 
 Beta.17 does not reserve sequential nonces locally. With no lane option, sends use the default key-0 lane and must not overlap. `parallel: true` creates a new random lane; `nonceKey` selects a reusable named or raw lane and takes precedence. Operations sharing a lane remain sequential, so wait for inclusion before reusing it. Distinct lanes are unordered; batch dependent transactions into one UserOperation.
 
-##### `quoteSendTransaction(tx, config?)`
+#### `quoteSendTransaction(tx, config?)`
 Estimates the fee for a UserOperation without sending it.
 
 Default-lane, non-sponsored UserOperations built while quoting transaction inputs can be cached internally for up to 2 minutes. When a later default-lane `sendTransaction()` or `signTransaction()` matches, the account performs a lightweight on-chain nonce check before reuse and rebuilds if the nonce has moved. Sponsored quotes do not cache a built operation. A supplied signed UserOperation is evaluated directly rather than rebuilt.
@@ -450,7 +459,7 @@ const quote = await account.quoteSendTransaction({
 console.log('Estimated fee:', quote.fee)
 ```
 
-##### `transfer(options, config?, txOverrides?)`
+#### `transfer(options, config?, txOverrides?)`
 Transfers ERC20 tokens via UserOperation.
 
 **Parameters:**
@@ -486,7 +495,7 @@ console.log('Transfer UserOperation hash:', result.hash)
 console.log('Transfer fee:', result.fee)
 ```
 
-##### `quoteTransfer(options, config?, txOverrides?)`
+#### `quoteTransfer(options, config?, txOverrides?)`
 Estimates the fee for an ERC20 token transfer.
 
 This method does not resolve or reserve a nonce lane. A later transfer using `parallel` or `nonceKey` rebuilds in that lane.
@@ -512,7 +521,7 @@ const quote = await account.quoteTransfer({
 console.log('Transfer fee estimate:', quote.fee)
 ```
 
-##### `getBalance()`
+#### `getBalance()`
 Returns the Safe account's native token balance.
 
 **Returns:** `Promise\<bigint\>` - Balance in wei
@@ -523,7 +532,7 @@ const balance = await account.getBalance()
 console.log('Native balance:', balance, 'wei')
 ```
 
-##### `getTokenBalance(tokenAddress)`
+#### `getTokenBalance(tokenAddress)`
 Returns the balance of a specific ERC20 token in the Safe account.
 
 **Parameters:**
@@ -537,7 +546,7 @@ const tokenBalance = await account.getTokenBalance('0xdAC17F958D2ee523a220620699
 console.log('USDt balance:', tokenBalance) // In 6 decimal units
 ```
 
-##### `getPaymasterTokenBalance()`
+#### `getPaymasterTokenBalance()`
 Returns the balance of the configured paymaster token used for paying fees.
 
 **Returns:** `Promise\<bigint\>` - Paymaster token balance in base units
@@ -553,7 +562,7 @@ if (paymasterBalance < 10000n) {
 }
 ```
 
-##### `approve(options, txOverrides?)`
+#### `approve(options, txOverrides?)`
 Approves a spender to spend ERC20 tokens on behalf of the Safe account.
 
 **Parameters:**
@@ -584,7 +593,7 @@ const result = await account.approve({
 console.log('Approval hash:', result.hash)
 ```
 
-##### `getAllowance(token, spender)`
+#### `getAllowance(token, spender)`
 Returns the current token allowance for the given spender.
 
 **Parameters:**
@@ -602,7 +611,7 @@ const allowance = await account.getAllowance(
 console.log('Current allowance:', allowance)
 ```
 
-##### `getTransactionReceipt(hash)`
+#### `getTransactionReceipt(hash)`
 Maps a UserOperation hash to its native EVM bundling-transaction receipt. This method is deprecated; use `getTransaction()` and read its `receipt` and `userOperationReceipt` fields.
 
 **Parameters:**
@@ -618,7 +627,7 @@ if (receipt) {
 }
 ```
 
-##### `getTransaction(hash)`
+#### `getTransaction(hash)`
 
 Returns normalized status for an exact 32-byte UserOperation hash. Before the bundler assigns an EVM transaction hash, the result is `pending` with zero confirmations and both native receipt fields set to `null`. After inclusion, finality and confirmations come from the EVM bundling transaction, while `success` and `fee` come from the UserOperation receipt when available.
 
@@ -635,7 +644,7 @@ console.log(receipt.userOperationReceipt) // Raw bundler receipt
 
 An invalid hash throws `ValueError`; a well-formed hash unknown to the bundler throws `NoSuchElementError`. A settled `confirmed` or `final` receipt can still have `success: false`, so always inspect execution success.
 
-##### `waitForTransaction(hash, options?)`
+#### `waitForTransaction(hash, options?)`
 
 Polls by UserOperation hash until the requested finality target is reached or the underlying EVM transaction is classified as `dropped`. The default target is `confirmed`, the interval is four seconds, and the ERC-4337 timeout is 180 seconds.
 
@@ -652,7 +661,7 @@ if (receipt.finality !== 'dropped' && receipt.success === false) {
 }
 ```
 
-##### `getUserOperationReceipt(hash)`
+#### `getUserOperationReceipt(hash)`
 Returns a UserOperation receipt by hash.
 
 **Parameters:**
@@ -668,7 +677,7 @@ if (receipt) {
 }
 ```
 
-##### `signTypedData(typedData)`
+#### `signTypedData(typedData)`
 Signs EIP-712 typed structured data using the underlying EOA private key.
 
 **Parameters:**
@@ -702,7 +711,7 @@ const signature = await account.signTypedData(typedData)
 console.log('Typed data signature:', signature)
 ```
 
-##### `verifyTypedData(typedData, signature)`
+#### `verifyTypedData(typedData, signature)`
 Verifies an EIP-712 typed data signature against the underlying EOA address.
 
 **Parameters:**
@@ -717,7 +726,7 @@ const isValid = await account.verifyTypedData(typedData, signature)
 console.log('Typed data signature valid:', isValid)
 ```
 
-##### `getTokenBalances(tokenAddresses)`
+#### `getTokenBalances(tokenAddresses)`
 Returns balances for multiple ERC20 tokens in a single call.
 
 **Parameters:**
@@ -736,8 +745,8 @@ for (const [address, balance] of Object.entries(balances)) {
 }
 ```
 
-##### `toReadOnlyAccount()`
-Creates a read-only copy of the account with the same Safe address and configuration.
+#### `toReadOnlyAccount()`
+Creates a read-only copy with the same Safe address, configuration, and owner EOA address. Unlike an account created by `fromSafeAddress()`, this copy can verify the owner's message and typed-data signatures.
 
 **Returns:** `Promise\<WalletAccountReadOnlyEvmErc4337\>` - Read-only account instance
 
@@ -750,7 +759,7 @@ const balance = await readOnlyAccount.getBalance()
 // readOnlyAccount.sendTransaction() // Would not be available
 ```
 
-##### `dispose()`
+#### `dispose()`
 Disposes the wallet account, clearing private keys from memory.
 
 **Example:**
@@ -780,7 +789,7 @@ console.log('Private key length:', privateKey?.length) // 32 bytes (null after d
 ⚠️ **Security Note**: The `keyPair` property contains sensitive cryptographic material. Never log, display, or expose the private key.
 
 ## WalletAccountReadOnlyEvmErc4337
-Represents a read-only ERC-4337 wallet account that can query balances and estimate fees but cannot send transactions.
+Represents a read-only ERC-4337 wallet account that can query balances and allowances but cannot sign or send transactions. Choose the owner-based constructor to predict a Safe address, or the [known-Safe factory](#fromsafeaddresssafeaddress-config-static-1) to use a supplied Safe address directly. Non-sponsored fee estimates for a known-Safe account require deployment.
 
 ### Constants
 
@@ -800,12 +809,12 @@ new WalletAccountReadOnlyEvmErc4337(address, config)
 ```
 
 **Parameters:**
-- `address` (string): The EOA address (owner address)
+- `address` (string): The owner EOA address, not the Safe address. The account predicts the counterfactual Safe from this owner and the configuration.
 - `config` (`Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`): Configuration object without send-only fee caps
 
 **Example:**
 ```javascript
-const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
+const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x405005C7c4422390F4B334F64Cf20E0b767131d0', {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
   bundlerUrl: 'https://api.candide.dev/public/v3/1',
@@ -818,58 +827,88 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
 })
 ```
 
+**Throws:** `ValueError` for a malformed owner address or an empty provider list; `ConfigurationError` for an unsupported `safeModulesVersion`.
+
+The example owner above is a derivation fixture. Constructing an account does not deploy or fund its predicted Safe.
+
 ### Static Methods
 
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `predictSafeAddress(owner, config)` | Predicts the Safe address for a given owner without instantiating an account | `string` |
+| `fromSafeAddress(safeAddress, config)` | Creates a read-only account for a supplied Safe address without its owner | `WalletAccountReadOnlyEvmErc4337` |
 
 #### `predictSafeAddress(owner, config)` (static)
 Predicts the address of a Safe account.
 
 **Parameters:**
 - `owner` (string): The Safe owner's EOA address
-- `config` (object): Configuration with:
-  - `chainId` (number): The blockchain ID
-  - `safeModulesVersion` (string): The Safe modules version
+- `config` (`Pick<EvmErc4337WalletConfig, 'safeModulesVersion' | 'onChainIdentifier'>`): Safe derivation configuration. Set `safeModulesVersion` to `'0.3.0'`. The type also accepts the optional `onChainIdentifier` field from the account configuration.
 
 **Returns:** `string` - The predicted Safe address
 
 **Example:**
 ```javascript
 const safeAddress = WalletAccountReadOnlyEvmErc4337.predictSafeAddress(
-  '0xOwnerEOA...',
-  { chainId: 1, safeModulesVersion: '0.3.0' }
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0',
+  { safeModulesVersion: '0.3.0' }
 )
 console.log('Predicted Safe address:', safeAddress)
 
 // Also available on WalletAccountEvmErc4337 (inherited)
 const sameAddress = WalletAccountEvmErc4337.predictSafeAddress(
-  '0xOwnerEOA...',
-  { chainId: 1, safeModulesVersion: '0.3.0' }
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0',
+  { safeModulesVersion: '0.3.0' }
 )
 ```
+
+**Throws:** `ValueError` for a malformed owner address, including an invalid mixed-case checksum.
+
+#### `fromSafeAddress(safeAddress, config)` (static)
+
+Creates a read-only account whose own address is the supplied Safe address. Unlike the constructor, it does not derive a new address from an owner.
+
+**Parameters:**
+- `safeAddress` (`string`): A well-formed EVM address. Lowercase addresses are accepted and normalized to checksum form; invalid mixed-case checksums are rejected.
+- `config` (`Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`): Read-only configuration, including the network, provider, bundler URL, Safe modules version and selected gas-payment mode.
+
+**Returns:** `WalletAccountReadOnlyEvmErc4337` synchronously, not a Promise.
+
+**Throws:**
+- `ValueError` for a malformed Safe address, an invalid mixed-case checksum, or an empty provider list.
+- `ConfigurationError` for an unsupported `safeModulesVersion`.
+
+Use the factory with a Safe address already held by your application:
+
+```javascript
+const readOnlyAccount = WalletAccountReadOnlyEvmErc4337.fromSafeAddress(safeAddress, config)
+console.log('Safe address:', await readOnlyAccount.getAddress())
+```
+
+See [Read a Known Safe Address](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address) for a complete setup example. The factory performs no network lookup: it does not confirm deployment, discover an owner, or check that the address is a Safe contract. Balance and allowance queries use this address directly, including before deployment.
+
+The owner is unknown, so `verify()` and `verifyTypedData()` throw `UnsupportedOperationError`. There is no signing or transaction-submission capability. A non-sponsored quote that builds a UserOperation throws `ConfigurationError` if the Safe is undeployed, because deployment requires the owner address. Sponsored quotes return `{ fee: 0n }` before checking deployment or chain identity; that result does not confirm sponsorship eligibility or transaction executability.
 
 ### Methods
 
 | Method | Description | Returns | Throws |
 |--------|-------------|---------|--------|
 | `getAddress()` | Returns the Safe account's address | `Promise\<string\>` | - |
-| `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
+| `verify(message, signature)` | Verifies a message signature against a known owner | `Promise\<boolean\>` | `UnsupportedOperationError` for an account created from a Safe address |
 | `getBalance()` | Returns the native token balance (in wei) | `Promise\<bigint\>` | - |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific ERC20 token | `Promise\<bigint\>` | - |
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
 | `getAllowance(token, spender)` | Returns current token allowance for a spender | `Promise\<bigint\>` | - |
-| `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | If simulation fails or the token paymaster address mismatches |
-| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails or the token paymaster address mismatches |
+| `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | If simulation fails, the token paymaster address mismatches, or a non-sponsored known-Safe quote requires deployment |
+| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails, the token paymaster address mismatches, or a non-sponsored known-Safe quote requires deployment |
 | `getTransactionReceipt(hash)` | Maps a UserOperation hash to a native EVM receipt; deprecated in favor of `getTransaction()` | `Promise\<EvmTransactionReceipt \| null\>` | - |
 | `getTransaction(hash)` | Returns normalized UserOperation finality using its bundling transaction | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the hash is invalid or unknown |
 | `waitForTransaction(hash, options?)` | Waits for the UserOperation to reach `confirmed` or `final`, or returns `dropped` | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the wait times out |
 | `getUserOperationReceipt(hash)` | Returns a UserOperation receipt | `Promise\<UserOperationReceipt \| null\>` | - |
-| `verifyTypedData(typedData, signature)` | Verifies an EIP-712 typed data signature | `Promise\<boolean\>` | - |
+| `verifyTypedData(typedData, signature)` | Verifies typed data against a known owner | `Promise\<boolean\>` | `UnsupportedOperationError` for an account created from a Safe address |
 | `getTokenBalances(tokenAddresses)` | Returns balances for multiple ERC20 tokens | `Promise\<Record\<string, bigint\>\>` | - |
 
-##### `getAddress()`
+#### `getAddress()`
 Returns the Safe smart contract wallet address.
 
 **Returns:** `Promise\<string\>` - The Safe account's address
@@ -880,8 +919,8 @@ const address = await readOnlyAccount.getAddress()
 console.log('Safe address:', address)
 ```
 
-##### `verify(message, signature)`
-Verifies a message signature against the underlying EOA address.
+#### `verify(message, signature)`
+Verifies a message signature against the known owner EOA address. Throws `UnsupportedOperationError` if this account was created with `fromSafeAddress()`, because its owner is unknown.
 
 **Parameters:**
 - `message` (string): The original message
@@ -895,7 +934,7 @@ const isValid = await readOnlyAccount.verify(message, signature)
 console.log('Signature valid:', isValid)
 ```
 
-##### `getBalance()`
+#### `getBalance()`
 Returns the Safe account's native token balance.
 
 **Returns:** `Promise\<bigint\>` - Balance in wei
@@ -906,7 +945,7 @@ const balance = await readOnlyAccount.getBalance()
 console.log('Balance:', balance, 'wei')
 ```
 
-##### `getTokenBalance(tokenAddress)`
+#### `getTokenBalance(tokenAddress)`
 Returns the balance of a specific ERC20 token.
 
 **Parameters:**
@@ -920,7 +959,7 @@ const tokenBalance = await readOnlyAccount.getTokenBalance('0xdAC17F958D2ee523a2
 console.log('USDt balance:', tokenBalance)
 ```
 
-##### `getPaymasterTokenBalance()`
+#### `getPaymasterTokenBalance()`
 Returns the balance of the configured paymaster token.
 
 **Returns:** `Promise\<bigint\>` - Paymaster token balance in base units
@@ -931,7 +970,7 @@ const paymasterBalance = await readOnlyAccount.getPaymasterTokenBalance()
 console.log('Paymaster token balance:', paymasterBalance)
 ```
 
-##### `getAllowance(token, spender)`
+#### `getAllowance(token, spender)`
 Returns the current token allowance for the given spender.
 
 **Parameters:**
@@ -949,8 +988,8 @@ const allowance = await readOnlyAccount.getAllowance(
 console.log('Allowance:', allowance)
 ```
 
-##### `quoteSendTransaction(tx, config?)`
-Estimates the fee for a UserOperation.
+#### `quoteSendTransaction(tx, config?)`
+Estimates the fee for a UserOperation. For an account created with `fromSafeAddress()`, a non-sponsored quote requires a deployed Safe. Sponsored quotes return `{ fee: 0n }` without checking deployment or chain identity; they do not confirm sponsorship eligibility.
 
 **Parameters:**
 - `tx` (EvmErc4337Transaction | EvmErc4337Transaction[]): Transaction object or array
@@ -959,6 +998,7 @@ Estimates the fee for a UserOperation.
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
 **Throws:**
+- `ConfigurationError` if a non-sponsored quote for an account created with `fromSafeAddress()` finds the Safe is undeployed
 - Error if simulation fails
 - `ConfigurationError` in token-paymaster mode when the RPC returns a non-empty paymaster address that differs from the configured `paymasterAddress` (case-insensitive comparison)
 - `TransactionError` with `reason: TransactionErrorReason.INSUFFICIENT_BALANCE` if the paymaster reports AA50
@@ -983,8 +1023,8 @@ try {
 }
 ```
 
-##### `quoteTransfer(options, config?, txOverrides?)`
-Estimates the fee for an ERC20 token transfer.
+#### `quoteTransfer(options, config?, txOverrides?)`
+Estimates the fee for an ERC20 token transfer through `quoteSendTransaction()`. Its known-Safe deployment restriction and sponsored-quote exception also apply here.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options
@@ -994,6 +1034,7 @@ Estimates the fee for an ERC20 token transfer.
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
 **Throws:**
+- `ConfigurationError` if a non-sponsored quote for an account created with `fromSafeAddress()` finds the Safe is undeployed.
 - `ConfigurationError` in token-paymaster mode when the RPC returns a non-empty paymaster address that differs from the configured `paymasterAddress` (case-insensitive comparison).
 - `TransactionError` with `reason: TransactionErrorReason.INSUFFICIENT_BALANCE` if the paymaster reports AA50.
 
@@ -1007,7 +1048,7 @@ const quote = await readOnlyAccount.quoteTransfer({
 console.log('Transfer fee estimate:', quote.fee)
 ```
 
-##### `getTransactionReceipt(hash)`
+#### `getTransactionReceipt(hash)`
 Maps a UserOperation hash to its native EVM bundling-transaction receipt. This method is deprecated; use `getTransaction()` for normalized finality.
 
 **Parameters:**
@@ -1026,11 +1067,15 @@ if (receipt) {
 }
 ```
 
-##### `getTransaction(hash)` and `waitForTransaction(hash, options?)`
+#### `getTransaction(hash)`
 
-Read-only accounts expose the same UserOperation-hash semantics as owned accounts. `getTransaction()` retains the UserOperation hash in `receipt.hash`, derives finality from the bundling transaction, and exposes both the EVM receipt and raw UserOperation receipt. `waitForTransaction()` defaults to a four-second interval and 180-second timeout. Inspect `success` after inclusion.
+Read-only accounts expose the same UserOperation-hash semantics as owned accounts. `getTransaction()` retains the UserOperation hash in `receipt.hash`, derives finality from the bundling transaction, and exposes both the EVM receipt and raw UserOperation receipt.
 
-##### `getUserOperationReceipt(hash)`
+#### `waitForTransaction(hash, options?)`
+
+Waits for the requested UserOperation finality with a four-second default interval and 180-second default timeout. Inspect `success` after inclusion. See the [owned-account method](#waitfortransactionhash-options) for options and return details.
+
+#### `getUserOperationReceipt(hash)`
 Returns a UserOperation receipt by hash.
 
 **Parameters:**
@@ -1046,8 +1091,8 @@ if (receipt) {
 }
 ```
 
-##### `verifyTypedData(typedData, signature)`
-Verifies an EIP-712 typed data signature against the underlying EOA address.
+#### `verifyTypedData(typedData, signature)`
+Verifies an EIP-712 typed data signature against the known owner EOA address. Throws `UnsupportedOperationError` if this account was created with `fromSafeAddress()`, because its owner is unknown.
 
 **Parameters:**
 - `typedData` (TypedData): The original typed data object
@@ -1061,7 +1106,7 @@ const isValid = await readOnlyAccount.verifyTypedData(typedData, signature)
 console.log('Typed data signature valid:', isValid)
 ```
 
-##### `getTokenBalances(tokenAddresses)`
+#### `getTokenBalances(tokenAddresses)`
 Returns balances for multiple ERC20 tokens in a single call.
 
 **Parameters:**
@@ -1124,7 +1169,7 @@ interface EvmErc4337WalletCommonConfig {
   chainId: number;                          // Blockchain ID
   provider: string | Eip1193Provider | Array<string | Eip1193Provider>; // RPC provider or failover list
   bundlerUrl: string;                       // Bundler service URL
-  safeModulesVersion: string;               // Must be '0.3.0' in beta.18
+  safeModulesVersion: string;               // Must be '0.3.0' in beta.19
   parallel?: boolean;                       // Fresh random nonce-key lane per operation
   nonceKey?: number | bigint | string;      // Reusable raw or named uint192 lane key
 }
@@ -1165,7 +1210,7 @@ type EvmErc4337WalletConfig = EvmErc4337WalletCommonConfig &
 
 ### Config Override
 
-The published beta.18 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
+The published beta.19 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
 
 ```typescript
 type ConfigOverride = Partial<
@@ -1187,7 +1232,7 @@ type ConfigOverride = Partial<
 
 Overrides are shallow-merged with the account configuration, then validated. When switching modes, explicitly clear an inherited opposing flag: sponsorship requires `isSponsored: true` and `useNativeCoins: false`; native-coin mode requires `isSponsored: false` and `useNativeCoins: true`; paymaster-token mode requires both flags to be `false`. The merged configuration must also contain the URL, address, token, or policy fields required by the selected mode.
 
-At runtime, beta.18 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
+At runtime, beta.19 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
 
 In token-paymaster mode, every path that builds a UserOperation validates a non-empty paymaster address returned by the RPC against `paymasterAddress`. A case-insensitive mismatch throws `ConfigurationError` before the operation is returned or submitted.
 
@@ -1329,7 +1374,7 @@ class ConfigurationError extends ValueError {
 }
 ```
 
-`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`. It also reports a mismatch between the constructor's `chainId` and the provider during the first UserOperation chain lookup.
+`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`. For an account created with `fromSafeAddress()`, it also reports an undeployed Safe when a non-sponsored quote builds a UserOperation. It also reports a mismatch between the constructor's `chainId` and the provider during the first UserOperation chain lookup.
 
 ### FeeRates
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
@@ -33,7 +33,7 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, config)
 
 ## Account Configuration
 
-Both `WalletAccountEvmErc4337` and `WalletAccountReadOnlyEvmErc4337` use the same configuration structure:
+The writable account uses `EvmErc4337WalletConfig`. The read-only constructor and [`fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) use `Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`, with the same network, provider, bundler, Safe modules and gas-payment settings. Use the constructor with an owner EOA address; use the factory with a known Safe address.
 
 ```javascript
 import { WalletAccountEvmErc4337, WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -47,7 +47,7 @@ const account = new WalletAccountEvmErc4337(
 
 // Read-only account (fee caps for sending are not needed)
 const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
-  '0x...', // Owner EOA address; the module predicts the Safe address
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0', // Test owner for address derivation
   {
     chainId: 1,
     provider: 'https://rpc.mevblocker.io/fast',
@@ -62,6 +62,8 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
   }
 )
 ```
+
+The read-only example uses a test owner to derive a counterfactual Safe; it does not deploy or fund that account. For an address your application already knows, follow [Read a Known Safe Address](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address). The factory validates address syntax, the supported Safe modules version, and a nonempty provider list without verifying deployment or ownership.
 
 ## Configuration Options
 
@@ -96,7 +98,7 @@ const config = { chainId: 43114 }
 
 ### Provider
 
-The `provider` option specifies the RPC endpoint or EIP-1193 provider instance for blockchain interactions. **Required** for all operations. You can also pass an array of endpoints or providers to enable automatic failover: when a request to one provider fails, the wallet retries the next provider in the list.
+The `provider` option specifies the RPC endpoint or EIP-1193 provider instance for blockchain interactions. **Required** by the configuration type and used for network operations. Creating a read-only account or calling `getAddress()` does not make an RPC request. You can also pass an array of endpoints or providers to enable automatic failover: when a request to one provider fails, the wallet retries the next provider in the list.
 
 **Type:** `string | Eip1193Provider | Array<string | Eip1193Provider>`
 **Required:** Yes
@@ -113,10 +115,13 @@ const config = {
   provider: window.ethereum
 }
 
-// Using custom ethers provider
+// Adapt an ethers provider to EIP-1193
 import { JsonRpcProvider } from 'ethers'
+const rpc = new JsonRpcProvider('https://rpc.mevblocker.io/fast')
 const config = {
-  provider: new JsonRpcProvider('https://rpc.mevblocker.io/fast')
+  provider: {
+    request: ({ method, params }) => rpc.send(method, params ?? [])
+  }
 }
 
 // Using multiple providers for automatic failover
@@ -250,12 +255,12 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, config)
 Reusing one named lane remains sequential: wait for inclusion before submitting its next operation, or batch dependent calls into one UserOperation.
 
 <Callout type="warning">
-The beta.18 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
+The beta.19 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
 </Callout>
 
 ### Safe Modules Version
 
-The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.18 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
+The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.19 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
 
 **Type:** `string`
 **Required:** Yes

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/configuration.mdx
@@ -67,7 +67,13 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
 
 ### Chain ID
 
-The `chainId` option specifies the blockchain network ID. **Required** for fee estimation and smart account initialization.
+The `chainId` option specifies the expected blockchain network ID. **Required** for fee estimation and smart account initialization.
+
+Before building a new UserOperation, the account reads `eth_chainId` from the provider and throws `ConfigurationError` if it differs from the constructor's `chainId`. The check happens before smart-account construction and UserOperation signing. This includes non-sponsored quotes that build an operation.
+
+The first successful chain lookup is cached. Keep all failover providers on the configured chain and recreate the wallet or account when switching networks. Per-call fee-mode overrides do not change the chain being checked.
+
+Sponsored quotes return `0n` without checking the chain. Quoting or submitting an already-signed UserOperation also bypasses this check. Verify that a signed operation was built for the intended account, chain, EntryPoint, and paymaster before forwarding it.
 
 **Type:** `number`
 **Required:** Yes
@@ -244,12 +250,12 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, config)
 Reusing one named lane remains sequential: wait for inclusion before submitting its next operation, or batch dependent calls into one UserOperation.
 
 <Callout type="warning">
-The beta.17 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
+The beta.18 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
 </Callout>
 
 ### Safe Modules Version
 
-The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.17 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
+The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.18 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
 
 **Type:** `string`
 **Required:** Yes
@@ -492,7 +498,17 @@ const plasmaConfig = {
 
 ### Sepolia Testnet (USD₮ ERC-20 mock/testnet only)
 
+Choose a six-decimal USD₮ test token supported by each paymaster on chain `11155111`. Get its address from that provider's current faucet or supported-token response, verify its contract and decimals on Sepolia, and set the corresponding environment variable below. The two providers may support different test-token contracts.
+
 ````javascript
+
+const pimlicoTestTokenAddress = process.env.PIMLICO_SEPOLIA_TEST_TOKEN_ADDRESS
+const candideTestTokenAddress = process.env.CANDIDE_SEPOLIA_TEST_TOKEN_ADDRESS
+for (const address of [pimlicoTestTokenAddress, candideTestTokenAddress]) {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(address ?? '')) {
+    throw new Error('Set both verified Sepolia test-token addresses')
+  }
+}
 
 // Pimlico
 const sepoliaConfigPimlico = {
@@ -503,7 +519,7 @@ const sepoliaConfigPimlico = {
   paymasterAddress: '0x777777777777AeC03fd955926DbF81597e66834C',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDt Sepolia
+    address: pimlicoTestTokenAddress
   },
   transferMaxFee: 100000 // 0.1 USDt (6 decimals)
 }
@@ -517,7 +533,7 @@ const sepoliaConfigCandide = {
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDt Sepolia
+    address: candideTestTokenAddress
   },
   transferMaxFee: 100000
 }
@@ -525,8 +541,6 @@ const sepoliaConfigCandide = {
 
 **Important**
 Ethereum Sepolia is a testnet. The USD₮ tokens available at the links below are not real and do not entitle the holder to anything. In particular, they cannot be redeemed with Tether International, S.A. de C.V. ("Tether International") and are not Tether Tokens as described in [Tether International's Terms of Service](https://tether.to/en/legal). The USD₮ tokens available at the links below on this testnet are intended for testing WDK on Ethereum Sepolia. The links below are links to third-party websites and are Third-Party Information as described in Tether Operations, S.A. de [C.V.'s Website Terms](https://tether.io/terms/)
-
-**USD₮ on Sepolia contract:** [0xd077a400968890eacc75cdc901f0356c943e4fdb](https://sepolia.etherscan.io/address/0xd077a400968890eacc75cdc901f0356c943e4fdb)
 
 **Get test USD₮:**
 - [Pimlico faucet](https://dashboard.pimlico.io/test-erc20-faucet)

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
@@ -50,26 +50,16 @@ The paymaster token balance is held by the Safe account. Fund the Safe with enou
 
 ## Read-Only Account Balances
 
-You can check balances without a seed phrase by passing the owner EOA address to [`WalletAccountReadOnlyEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference). The module predicts the Safe address from that owner and the configuration:
+Create the read-only account with the [known-Safe workflow](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address), then use [`getBalance()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#getbalance-1) to query that Safe's native balance:
 
 ```javascript title="Read-Only Balance"
-import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
-
-const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
-  chainId: 1,
-  provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/1',
-  paymasterUrl: 'https://api.candide.dev/public/v3/1',
-  paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
-  safeModulesVersion: '0.3.0',
-  paymasterToken: {
-    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
-  }
-})
-
 const balance = await readOnlyAccount.getBalance()
-console.log('Read-only account balance:', balance, 'wei')
+console.log('Read-only Safe balance:', balance, 'wei')
 ```
+
+The same account supports the token and allowance queries listed in the [API reference](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#methods-2). Balance reads do not require the Safe to be deployed. Reading the configured paymaster token balance requires a `paymasterToken` configuration.
+
+If you have the owner EOA address instead, use the [read-only constructor](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#constructor-2). Passing a Safe address to that constructor predicts a different account; use the [factory](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) to read the supplied Safe directly.
 
 ## Next Steps
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances.mdx
@@ -45,12 +45,12 @@ console.log('Paymaster token balance:', paymasterBalance)
 ```
 
 <Callout type="info">
-The paymaster token balance determines how many gasless transactions you can execute. Ensure the paymaster has sufficient token balance before initiating gasless operations.
+The paymaster token balance is held by the Safe account. Fund the Safe with enough of the configured token to repay the paymaster before initiating token-paid operations.
 </Callout>
 
 ## Read-Only Account Balances
 
-You can check balances for any smart account address without a seed phrase using [`WalletAccountReadOnlyEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
+You can check balances without a seed phrase by passing the owner EOA address to [`WalletAccountReadOnlyEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference). The module predicts the Safe address from that owner and the configuration:
 
 ```javascript title="Read-Only Balance"
 import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/get-started.mdx
@@ -46,6 +46,8 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
 To use test/mock tokens instead of real funds, see the [testnet configuration section](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#network-specific-configurations).
 </Callout>
 
+The provider must serve the configured `chainId`. A mismatch throws when the account first builds a UserOperation; account creation alone does not establish that the provider matches. Review [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id) before sending.
+
 ## 3. Get Your First Account
 
 You can retrieve a smart account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors.mdx
@@ -3,7 +3,7 @@ title: Handle Errors
 description: Handle errors, manage fees, and dispose of sensitive data.
 ---
 
-This guide explains how to [handle transaction errors](#transaction-errors), [correct a provider-chain mismatch](#provider-chain-mismatches), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), and follow [best practices](#best-practices) for fee management and memory cleanup.
+This guide explains how to [handle transaction errors](#transaction-errors), [correct a provider-chain mismatch](#provider-chain-mismatches), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), [handle known-Safe address errors](#known-safe-address-errors), and follow [best practices](#best-practices) for fee management and memory cleanup.
 
 ## Transaction Errors
 
@@ -110,6 +110,14 @@ Lane configuration and bundler behavior can fail in several ways:
 Treat a returned hash as submission evidence, not inclusion. Pass the UserOperation hash to `waitForTransaction(hash, { timeout })` for a bounded wait, or use `getUserOperationReceipt(hash)` when you specifically need the raw bundler receipt. If one same-lane hash never resolves, inspect the bundler response and on-chain lane sequence before retrying; use a fresh lane for independent work or batch dependent calls rather than blindly resubmitting the same operation.
 
 `getTransaction()` throws `ValueError` for a malformed UserOperation hash and `NoSuchElementError` when the bundler does not know a well-formed hash. During `waitForTransaction()`, an unknown hash is treated as transient while the operation propagates. A `TimeoutError` means the requested finality was not reached in time; a returned `dropped` receipt means the underlying EVM transaction's nonce was replaced or otherwise consumed. A `confirmed` or `final` receipt can still have `success: false`.
+
+## Known-Safe Address Errors
+
+[`fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) throws `ValueError` for a malformed Safe address, an invalid mixed-case checksum, or an empty provider list. It throws [`ConfigurationError`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#configurationerror) for an unsupported `safeModulesVersion`. The owner-based constructor and [`predictSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#predictsafeaddressowner-config-static-1) also reject malformed owner addresses with `ValueError`.
+
+A known-Safe account has no owner or signing key. Its verification methods throw `UnsupportedOperationError`, and calling the factory on the writable [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#walletaccountevmerc4337) class always throws that error. Import `ValueError` and `UnsupportedOperationError` from `@tetherto/wdk-wallet`.
+
+For a non-sponsored quote, an undeployed known Safe throws `ConfigurationError` because building its deployment operation requires the owner address. Confirm the network and address, then use an owner-backed signing flow to deploy the Safe if needed. Do not treat a different address or a sponsored zero-fee quote as a deployment fix: sponsored quotes skip deployment and chain checks and do not prove sponsorship eligibility.
 
 ## Best Practices
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors.mdx
@@ -3,7 +3,7 @@ title: Handle Errors
 description: Handle errors, manage fees, and dispose of sensitive data.
 ---
 
-This guide explains how to [handle transaction errors](#transaction-errors), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), and follow [best practices](#best-practices) for fee management and memory cleanup.
+This guide explains how to [handle transaction errors](#transaction-errors), [correct a provider-chain mismatch](#provider-chain-mismatches), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), and follow [best practices](#best-practices) for fee management and memory cleanup.
 
 ## Transaction Errors
 
@@ -33,6 +33,12 @@ try {
   }
 }
 ```
+
+## Provider-Chain Mismatches
+
+When a new UserOperation is built, a provider that reports a different chain from the configured `chainId` throws [`ConfigurationError`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#configurationerror) before the operation is built or signed. Confirm the intended network and correct the RPC endpoint or constructor configuration before retrying.
+
+The first successful lookup is cached. Recreate the wallet or account when switching networks, and keep every failover provider on the same chain. A sponsored quote or an already-signed operation does not perform this check; see [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id).
 
 ## Transfer Errors
 
@@ -68,7 +74,7 @@ try {
 
 Starting in `v1.0.0-beta.15`, the shared UserOperation builder checks the configured `paymasterAddress` against a non-empty paymaster address returned by the RPC in token-paymaster mode. A case-insensitive mismatch throws the exported `ConfigurationError` before that newly built operation is returned or submitted. The error message identifies the configured address, the `paymasterUrl`, and the returned address.
 
-In beta.17, `ConfigurationError` extends `ValueError`, so a shared `ValueError` handler can catch it. Check `ConfigurationError` first when the application needs the package-specific recovery path below. Constructing a wallet with an empty provider list also throws `ValueError`; provider-required operations such as `getFeeRates()` use `ProviderRequiredError`.
+In beta.18, `ConfigurationError` extends `ValueError`, so a shared `ValueError` handler can catch it. Check `ConfigurationError` first when the application needs the package-specific recovery path below. Constructing a wallet with an empty provider list also throws `ValueError`; provider-required operations such as `getFeeRates()` use `ProviderRequiredError`.
 
 ```javascript title="Handle a Paymaster Address Mismatch"
 import { ConfigurationError } from '@tetherto/wdk-wallet-evm-erc-4337'

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts.mdx
@@ -1,9 +1,9 @@
 ---
 title: Manage Accounts
-description: Work with multiple smart accounts and custom derivation paths.
+description: Work with multiple smart accounts, custom derivation paths, and known Safe addresses.
 ---
 
-This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-index) and [use custom derivation paths](#retrieve-account-by-custom-derivation-path).
+This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-index), [use custom derivation paths](#retrieve-account-by-custom-derivation-path), and [read a known Safe address](#read-a-known-safe-address).
 
 ## Retrieve Accounts by Index
 
@@ -28,6 +28,43 @@ const customAccount = await wallet.getAccountByPath("0'/0/5")
 const customAddress = await customAccount.getAddress()
 console.log('Custom account address:', customAddress)
 ```
+
+## Read a Known Safe Address
+
+Use [`WalletAccountReadOnlyEvmErc4337.fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) when your app already has the Safe address. It does not need a seed phrase or owner address. The ordinary [read-only constructor](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#constructor-2) instead takes an owner EOA address and predicts a Safe address from it.
+
+1. Obtain the Safe address from your application and select its network configuration.
+2. Pass that address and configuration to the read-only factory.
+3. Confirm that [`getAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#getaddress-1) returns the supplied address in checksummed form.
+
+The example below derives a counterfactual Safe from an upstream test owner to demonstrate the factory. It does not deploy or fund the Safe; use your application's known Safe address for actual balance monitoring.
+
+```javascript title="Read a Known Safe Address"
+import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
+
+const config = {
+  chainId: 1,
+  provider: 'https://rpc.mevblocker.io/fast',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  safeModulesVersion: '0.3.0',
+  useNativeCoins: true
+}
+
+// Derivation fixture only; this does not prove the Safe is deployed.
+const safeAddress = WalletAccountReadOnlyEvmErc4337.predictSafeAddress(
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0',
+  { safeModulesVersion: '0.3.0' }
+)
+const readOnlyAccount = WalletAccountReadOnlyEvmErc4337.fromSafeAddress(
+  safeAddress,
+  config
+)
+console.log('Safe address:', await readOnlyAccount.getAddress())
+```
+
+The factory returns an account synchronously and does not check deployment, discover the owner, or validate that the supplied address is a Safe contract. It can [read balances](/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances#read-only-account-balances) and allowances, but cannot sign or send transactions. Its owner is unknown, so [signature verification](/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages#verify-a-signature) is unavailable.
+
+Non-sponsored quotes require this Safe to be deployed before the module can build a UserOperation. A sponsored quote returns a zero fee without checking deployment or sponsorship eligibility; see [known-Safe errors](/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors#known-safe-address-errors).
 
 ## Next Steps
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions.mdx
@@ -60,7 +60,7 @@ console.log('Estimated fee:', quote.fee)
 
 ## Sign, Quote, and Submit a UserOperation
 
-Use `signTransaction()` when a separate review or relay step needs a signed ERC-4337 v0.7 UserOperation. The method accepts one transaction, not a batch.
+Use `signTransaction()` when a separate review or relay step needs a signed ERC-4337 v0.7 UserOperation. The method accepts one transaction, not a batch. Building a new operation checks the provider against the configured `chainId`; see [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id).
 
 ```javascript title="Sign, Quote, and Submit"
 const tx = {
@@ -79,6 +79,8 @@ console.log('UserOperation hash:', result.hash)
 <Callout type="warning">
 Only submit an operation produced by the same account with the intended fee-mode configuration. WDK preserves the signed nonce and configuration, does not rebuild or re-sign the operation, and does not reapply `transactionMaxFee` during signed submission. Do not mutate the operation, and submit it before its nonce becomes stale.
 </Callout>
+
+Quoting and forwarding an already-signed UserOperation skip the provider-chain check. Verify its account, chain, EntryPoint, and paymaster configuration before submission.
 
 For signed UserOperations, sponsored mode quotes `0n`. Other modes quote a 20% buffered native-gas ceiling in wei. In paymaster-token mode, that signed-operation quote is not a token-denominated paymaster charge.
 
@@ -152,7 +154,7 @@ const refunds = await account.sendTransaction(txB, { nonceKey: 'refunds' })
 One lane is still sequential. Two concurrent sends using the same named or default lane can return UserOperation hashes even though one never receives a receipt. Wait for inclusion before reusing a lane. If calls depend on one another, batch them with `sendTransaction([tx1, tx2])` so they execute in order under one nonce. Different lanes are independent and can be included in either order.
 </Callout>
 
-`signTransaction()` preserves the lane chosen by the same configuration rules. In beta.17, per-call `parallel` and `nonceKey` work at runtime but are missing from the published per-call TypeScript declarations; construction-level lane configuration is typed.
+`signTransaction()` preserves the lane chosen by the same configuration rules. In beta.18, per-call `parallel` and `nonceKey` work at runtime but are missing from the published per-call TypeScript declarations; construction-level lane configuration is typed.
 
 ## Send with Custom Paymaster Token
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages.mdx
@@ -16,13 +16,15 @@ console.log('Signature:', signature)
 
 ## Verify a Signature
 
-You can verify a signature using a read-only account. Use [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) to create one, then call [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
+You can verify a signature using a read-only account that retains the owner EOA address. Use [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) to create one, then call [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Verify Signature"
 const readOnlyAccount = await account.toReadOnlyAccount()
 const isValid = await readOnlyAccount.verify('Hello, ERC-4337!', signature)
 console.log('Signature valid:', isValid)
 ```
+
+Accounts created with [`fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) do not know the owner. Their [`verify()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#verifymessage-signature-1) and [`verifyTypedData()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#verifytypeddatatypeddata-signature-1) methods throw `UnsupportedOperationError`; they do not perform Safe contract signature verification. Use an owner-based read-only account when you need to verify that owner's signature.
 
 ## Sign Typed Data (EIP-712)
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/guides/transfer-tokens.mdx
@@ -52,7 +52,7 @@ If the estimated fee exceeds `transferMaxFee`, the transfer throws `MaximumFeeEx
 
 ## Transfer in a Nonce Lane
 
-`transfer()` follows the same beta.17 nonce-lane rules as sends. Use a stable named lane for an independent transfer stream, and wait for inclusion before reusing that lane:
+`transfer()` follows the same beta.18 nonce-lane rules as sends. Use a stable named lane for an independent transfer stream, and wait for inclusion before reusing that lane:
 
 ```javascript title="Transfer In A Named Lane"
 const result = await account.transfer({
@@ -64,7 +64,7 @@ const result = await account.transfer({
 })
 ```
 
-`quoteTransfer()` estimates the transfer but does not select or reserve a lane. A lane transfer rebuilds its UserOperation. The beta.17 runtime accepts lane fields per call, while the published per-call TypeScript declaration omits them; see [Use Parallel Nonce Lanes](/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions#use-parallel-nonce-lanes).
+`quoteTransfer()` estimates the transfer but does not select or reserve a lane. A lane transfer rebuilds its UserOperation. The beta.18 runtime accepts lane fields per call, while the published per-call TypeScript declaration omits them; see [Use Parallel Nonce Lanes](/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions#use-parallel-nonce-lanes).
 
 ## Transfer with UserOperation Gas Overrides
 

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/index.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/index.mdx
@@ -11,6 +11,7 @@ Use the ERC-4337 wallet module when your app needs EVM smart accounts, UserOpera
 
 - **BIP-39 Seed Phrase Support**: Generate and validate BIP-39 mnemonic seed phrases
 - **EVM Derivation Paths**: Support for BIP-44 standard derivation paths for Ethereum (m/44'/60')
+- **Known-Safe Monitoring**: [Read an existing Safe address](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address) without its owner address or a seed phrase
 - **Multi-Account Management**: Create and manage multiple account abstraction wallets from a single seed phrase
 - **ERC-4337 Support**: Full implementation of ERC-4337 account abstraction standard
 - **UserOperation Management**: Create and send UserOperations through bundlers

--- a/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/usage.mdx
+++ b/content/docs/sdk/wallet-modules/wallet-evm-erc-4337/usage.mdx
@@ -16,7 +16,7 @@ The `@tetherto/wdk-wallet-evm-erc-4337` module provides account abstraction wall
 Install the package and create your first smart account.
 </Card>
 <Card title="Manage Accounts" href="/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts">
-Work with multiple smart accounts and custom derivation paths.
+Work with derived smart accounts or monitor a known Safe address.
 </Card>
 <Card title="Check Balances" href="/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances">
 Query native, ERC-20, and paymaster token balances.

--- a/content/docs/start-building/react-native-quickstart.mdx
+++ b/content/docs/start-building/react-native-quickstart.mdx
@@ -216,9 +216,18 @@ import { bundle } from './.wdk'
 
 Create a configuration file for your WDK setup (e.g., `src/config/wdk.ts`):
 
+Set `EXPO_PUBLIC_SEPOLIA_TEST_TOKEN_ADDRESS` to a six-decimal USD₮ test token currently supported by your configured paymaster on Sepolia. Verify the address, decimals, and paymaster support through the provider's faucet and Sepolia deployment data. The address is public configuration. Use the same value in the wallet configuration and asset used for transfers.
+
+The example uses [Expo CLI environment-variable loading](https://docs.expo.dev/guides/environment-variables/). For a bare React Native app, obtain the address through your existing public-config mechanism or replace the exported constant's value with the verified address; installing Expo modules alone does not load this environment variable.
+
 ```typescript
 // src/config/wdk.ts
 import type { WdkConfigs } from '@tetherto/wdk-react-native-core'
+
+export const sepoliaTestTokenAddress: string = process.env.EXPO_PUBLIC_SEPOLIA_TEST_TOKEN_ADDRESS ?? ''
+if (!/^0x[0-9a-fA-F]{40}$/.test(sepoliaTestTokenAddress)) {
+  throw new Error('Set EXPO_PUBLIC_SEPOLIA_TEST_TOKEN_ADDRESS to your verified test token')
+}
 
 export const wdkConfigs: WdkConfigs = {
   networks: {
@@ -226,13 +235,14 @@ export const wdkConfigs: WdkConfigs = {
       blockchain: 'ethereum',
       config: {
         chainId: 11155111, // Sepolia testnet
+        safeModulesVersion: '0.3.0',
         provider: 'https://rpc.sepolia.org',
         bundlerUrl: 'https://api.candide.dev/public/v3/11155111',
         paymasterUrl: 'https://api.candide.dev/public/v3/11155111',
         paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
         transferMaxFee: 5000000,
         paymasterToken: {
-          address: '0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0', // USDt on Sepolia
+          address: sepoliaTestTokenAddress,
         },
       },
     },
@@ -242,7 +252,7 @@ export const wdkConfigs: WdkConfigs = {
 ```
 
 <Callout type="info">
-This example uses **Sepolia testnet** with a free public RPC so you can start immediately without API keys. For production or mainnet configuration, see the [Chain Configuration Guide](/sdk/core-module/configuration).
+This example uses **Sepolia testnet**. Configure and fund the selected test token before sending. For production or mainnet configuration, see the [Chain Configuration Guide](/sdk/core-module/configuration).
 </Callout>
 
 ### Step 5: Add WdkAppProvider
@@ -377,7 +387,9 @@ Now that you have WDK integrated, here's what you can explore:
 Use the `useAccount()` hook to send transactions:
 
 ```tsx
+// src/screens/SendScreen.tsx
 import { useAccount, BaseAsset } from '@tetherto/wdk-react-native-core'
+import { sepoliaTestTokenAddress } from '../config/wdk'
 
 const usdt = new BaseAsset({
   id: 'usdt-ethereum',
@@ -386,7 +398,7 @@ const usdt = new BaseAsset({
   name: 'Tether USD',
   decimals: 6,
   isNative: false,
-  address: '0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0', // USDt on Sepolia
+  address: sepoliaTestTokenAddress,
 })
 
 function SendScreen({ recipient }: { recipient: string }) {

--- a/content/docs/start-building/react-native-quickstart.mdx
+++ b/content/docs/start-building/react-native-quickstart.mdx
@@ -125,15 +125,15 @@ Integrate WDK into your existing React Native or Expo project using `@tetherto/w
 ### Step 1: Install
 
 ```bash
-npm install @tetherto/wdk-react-native-core@1.0.0-beta.18 react-native-bare-kit
+npm install @tetherto/wdk-react-native-core@1.0.0-beta.19 react-native-bare-kit
 npx expo install expo-crypto
 ```
 
 <Callout type="warn">
-The `v1.0.0-beta.18` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
+The `v1.0.0-beta.19` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
 </Callout>
 
-Beta.18 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is both inside the package range and compatible with the app's Expo SDK. If the SDK requires a version outside that range, do not force the peer installation; use compatible releases instead. Bare React Native apps must [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
+Beta.19 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is both inside the package range and compatible with the app's Expo SDK. If the SDK requires a version outside that range, do not force the peer installation; use compatible releases instead. Bare React Native apps must [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
 
 ### Step 2: Configure Android minSdkVersion
 
@@ -500,7 +500,7 @@ Ensure your component is rendered inside `WdkAppProvider`. The provider must be 
 
 **No biometric prompt appears before a wallet operation**
 
-React Native Core beta.18 does not enforce biometrics and does not accept a `requireBiometrics` provider prop. Run your app's biometric, passcode, or other authentication flow before calling `createWallet()`, `restoreWallet()`, `unlock()`, `switchWallet()`, or key-access methods.
+React Native Core beta.19 does not enforce biometrics and does not accept a `requireBiometrics` provider prop. Run your app's biometric, passcode, or other authentication flow before calling `createWallet()`, `restoreWallet()`, `unlock()`, `switchWallet()`, or key-access methods.
 
 For background locking, revoke the app's authenticated UI state synchronously, then call and catch `lock()`. The lifecycle mutex rejects instead of queuing when another guarded operation is running, so track a pending lock and retry it after the in-flight guarded operation settles. Require authentication again on foreground and do not treat the SDK session as locked until a retry succeeds.
 
@@ -516,7 +516,7 @@ npx react-native start --reset-cache
 
 **TypeScript cannot resolve React Native Core**
 
-Beta.18's published `default` and `types` export targets are absent. Configure TypeScript to select the included React Native source export:
+Beta.19's published `default` and `types` export targets are absent. Configure TypeScript to select the included React Native source export:
 
 ```json
 {
@@ -527,7 +527,7 @@ Beta.18's published `default` and `types` export targets are absent. Configure T
 }
 ```
 
-Use a current React Native or Expo Metro configuration that honors package exports and retains the `react-native` condition. `skipLibCheck` can suppress checks inside declarations after resolution; it cannot repair the missing beta.18 export targets.
+Use a current React Native or Expo Metro configuration that honors package exports and retains the `react-native` condition. `skipLibCheck` can suppress checks inside declarations after resolution; it cannot repair the missing beta.19 export targets.
 
 ### Complete Setup Checklist
 

--- a/content/docs/tools/pear-wrk-wdk/api-reference.mdx
+++ b/content/docs/tools/pear-wrk-wdk/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pear Worklet WDK API Reference
-description: API reference for the HRPC client, registerRpcHandlers helper, and request types in @tetherto/pear-wrk-wdk
+description: API reference for Pear Worklet HRPC, JSON-RPC, module calls, request types, and suspend diagnostics
 docType: reference
 schemaType: APIReference
 ---
@@ -71,7 +71,7 @@ Returns:
 
 The handler requires `encryptionKey` and `encryptedSeed` to be passed together or omitted together. When a seeded WDK instance already exists, the runtime disposes it and closes its generic modules before re-registering the wallets and optional protocols in `config`.
 
-In beta.11, HRPC generic modules are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules.
+In beta.13, generic modules on either transport are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules.
 
 #### `resetWdkWallets`
 
@@ -124,7 +124,9 @@ A full disposal closes all generic modules and clears the WDK instance. A non-em
 
 `options.protocolType` may be `swap`, `swidge`, `bridge`, `lending`, or `fiat`. When present, the runtime requires a non-empty `options.protocolName` and resolves the protocol-specific account wrapper before invoking `methodName`. Swidge calls resolve the wrapper with `account.getSwidgeProtocol(protocolName)`.
 
-When `RpcContext.allowedMethods` defines the target surface, `methodName` must appear in its `methods` array. Account restrictions are keyed by network; protocol restrictions are nested by network, protocol type, and protocol name. Omitted surfaces remain unrestricted, while `methods: []` denies every call on that exact surface. Denied calls fail before dispatch with the runtime code `METHOD_NOT_ALLOWED` and do not use `options.defaultValue`.
+When `RpcContext.allowedMethods` defines the target surface, `methodName` must appear in its `methods` array. Account restrictions are keyed by network; protocol restrictions are nested by network, protocol type, and protocol name. Omitted surfaces remain unrestricted, while `methods: []` denies every call on that exact surface. Denied calls fail before dispatch with the runtime code `METHOD_NOT_ALLOWED`.
+
+A missing wallet or protocol method fails with `BAD_REQUEST`. Beta.13 removes the `options.defaultValue` fallback from both runtime dispatch and `CallMethodOptions`; callers must handle unsupported methods themselves.
 
 #### `registerWallet`
 
@@ -145,19 +147,19 @@ Returns:
 
 #### `callModule`
 
-Call one method on a configured generic module. This command is available on HRPC only.
+Call one method on a configured generic module. Both HRPC and JSON-RPC support this operation in beta.13.
 
 - `module` (`string`): Module name shared by `RpcContext.moduleManagers` and `WdkWorkletConfig.modules`.
 - `method` (`string`): Non-empty method name on the constructed module instance.
 - `args?` (`string`): Optional JSON string of arguments. Arrays are spread as positional arguments; a non-array value is passed as one argument.
 
-Returns `CallModuleResponse` with optional `result`, a JSON string. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization.
+HRPC returns `CallModuleResponse` with optional `result`, a JSON string. JSON-RPC decodes that string and returns the value at `response.result.result`. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization. Return a JSON-serializable value, or `null` for no result; an `undefined` result cannot be decoded by the JSON-RPC transport.
 
 When `RpcContext.allowedModuleMethods` defines the target module, `method` must appear in that module's `methods` array. Omitted modules remain unrestricted, while `methods: []` denies every method on that module. A denied call fails with `METHOD_NOT_ALLOWED` before instance lookup or dispatch.
 
 #### `moduleEvent`
 
-Send an HRPC module event to the host.
+Send an HRPC module event to the host. JSON-RPC forwards the same event as a `moduleEvent` notification with decoded `params.payload`; it has no request `id`.
 
 - `module` (`string`): Module name.
 - `event` (`string`): Event name.
@@ -220,7 +222,7 @@ Registers the host-side handler used to receive `moduleEvent()` messages.
 Import this helper from `@tetherto/pear-wrk-wdk/worklet`. It registers the package's server-side handlers on the provided RPC instance.
 
 - `rpc` (`any`): RPC server instance that supports the generated handler registration methods.
-- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. HRPC generic modules can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime` and `moduleInstances`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts HRPC generic-module dispatch.
+- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. Generic modules on either transport can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime` and `moduleInstances`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts generic-module dispatch on both transports.
 
 ### Types
 
@@ -250,9 +252,9 @@ interface RpcContext {
 }
 ```
 
-The four allowlist helper interfaces are exported types in beta.11. Every omitted level remains unrestricted. Use an explicit empty `methods` array to deny all dynamic calls on one exact surface.
+The four allowlist helper interfaces are exported types in beta.13. Every omitted level remains unrestricted. Use an explicit empty `methods` array to deny all dynamic calls on one exact surface.
 
-The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.11 published error-code declaration does not include that member. Treat the literal runtime code as authoritative for this release.
+The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.13 published error-code declaration does not include that member. Treat the literal runtime code as authoritative for this release.
 
 #### `WdkWorkletConfig`
 
@@ -293,7 +295,7 @@ interface WdkModuleManager {
 }
 ```
 
-The factory must consume `seed` synchronously rather than retain it. Module instances can optionally implement `close()`, `suspend()`, and `resume()`. The runtime calls `close()` during full disposal or reinitialization; targeted blockchain disposal and `resetWdkWallets()` leave generic modules running. Worklet Bundler-generated HRPC entrypoints forward Bare lifecycle events to `suspend()` and `resume()`; manual Pear integrations must wire those events themselves. Declared `events` are forwarded from the instance, and the injected `emit()` function can emit events directly.
+The factory must consume `seed` synchronously rather than retain it. Module instances can optionally implement `close()`, `suspend()`, and `resume()`. The runtime calls `close()` during full disposal or reinitialization; targeted blockchain disposal and `resetWdkWallets()` leave generic modules running. Manual Pear integrations must forward Bare lifecycle events to `context.moduleRuntime.suspendAll()` and `resumeAll()`; registering either transport alone does not install those listeners. Declared `events` are forwarded from the instance, and the injected `emit()` function can emit events directly.
 
 #### Module request types
 
@@ -336,7 +338,6 @@ enum ProtocolType {
 
 interface CallMethodOptions {
   transformResult: Function
-  defaultValue: any
   protocolType: ProtocolType
   protocolName: string
 }
@@ -344,7 +345,23 @@ interface CallMethodOptions {
 
 The published declarations include `ProtocolType`, but the top-level JavaScript entry does not export that enum value at runtime. Pass the corresponding string literal, such as `'swidge'`, in serialized request options.
 
-The published `CallMethodOptions` declaration marks every field as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used.
+The published `CallMethodOptions` declaration marks every remaining field as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used. `transformResult` is a function-valued internal handler option; it cannot be sent through JSON serialization. Do not place a function in serialized request options.
+
+### Diagnostic export: `registerHandleLeakCheck(options?)`
+
+Import this helper from `@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check`:
+
+```ts
+interface HandleLeakCheckOptions {
+  tickIntervalMs?: number
+}
+
+function registerHandleLeakCheck(options?: HandleLeakCheckOptions): void
+```
+
+`tickIntervalMs` is the sampling interval in milliseconds, defaulting to `1000`. The helper logs immediately on Bare `suspend`, repeats with an unreferenced timer, and stops on `idle` or `resume`. Handle records include type, native address, `isActive`, `isClosing`, and `hasRef`; it reports rather than closes handles.
+
+Register once per worklet. The helper performs no interval validation and returns without registering listeners when `bare-walk-handles` or Bare lifecycle events are unavailable. Logs use `console.warn` independently of `LOG_LEVEL`. This helper is opt-in; transport registration does not enable it.
 
 ## JSON-RPC Transport
 
@@ -358,7 +375,7 @@ registerJsonRpcHandlers(ipc, context)
 
 The server reads UTF-8 JSON-RPC 2.0 messages framed with a four-byte unsigned big-endian payload length. Every request requires an ID, and an ID cannot be reused while its earlier request is still in flight. Malformed frames are dropped without a response. The package does not export a JSON-RPC client or native-host helper.
 
-Beta.11 supports these JSON-RPC method names:
+Beta.13 supports these JSON-RPC method names:
 
 - `workletStart`
 - `generateEntropyAndEncrypt`
@@ -366,16 +383,17 @@ Beta.11 supports these JSON-RPC method names:
 - `getSeedAndEntropyFromMnemonic`
 - `initializeWDK`
 - `callMethod`
+- `callModule`
 - `registerWallet`
 - `registerProtocol`
 - `dispose`
 
-JSON-RPC does not support `resetWdkWallets`, generic-module calls, or module events in this release. Use HRPC for those operations.
+JSON-RPC does not support `resetWdkWallets` in this release. Use HRPC for selective wallet resets. Generic modules require `context.moduleManagers` and matching runtime `config.modules`; `initializeWDK` constructs them only when the request includes the encrypted seed pair.
 
-The HRPC and JSON-RPC transports share the `callMethod` handler, so both support the `swidge` protocol type and enforce `RpcContext.allowedMethods` in beta.11. JSON-RPC has no `callModule` surface, so `allowedModuleMethods` is HRPC-only.
+The transports share the wallet/protocol handler and module runtime. Both support the `swidge` protocol type, enforce `RpcContext.allowedMethods`, and enforce `allowedModuleMethods` for generic-module calls. JSON-RPC `callModule` parameters match `CallModuleRequest`, including its JSON-string `args`. Results use `response.result.result`; events arrive as `moduleEvent` notifications with `params: { module, event, payload }` and a decoded payload. See the [JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 <Callout type="warn">
-INFO-level logging can include wallet-call arguments and JSON-RPC parameters or results. Production defaults to ERROR logging; do not enable more verbose logging for requests that may contain seeds, mnemonics, keys, or other sensitive values.
+Beta.13 removes JSON-RPC parameters and results from INFO request/response logs and logs wallet-call arguments at DEBUG. Mnemonic validation errors identify invalid word positions without echoing the words. This does not provide general secret redaction: DEBUG arguments, module errors, and application logs can still contain sensitive values. Production defaults to ERROR logging; avoid sensitive values in custom logs and errors.
 </Callout>
 
 Mnemonic strings, encryption-key strings, and encrypted payload strings cannot be zeroed in JavaScript. Discard references promptly and never log them. The runtime validates imported mnemonics for 12 or 24 English BIP-39 words and clears temporary byte buffers where possible.

--- a/content/docs/tools/pear-wrk-wdk/api-reference.mdx
+++ b/content/docs/tools/pear-wrk-wdk/api-reference.mdx
@@ -69,9 +69,9 @@ Returns:
 - `encryptedSeed?` (`string`): Base64-encoded encrypted seed buffer.
 - `config` (`string`): JSON stringified `WdkWorkletConfig`.
 
-The handler requires `encryptionKey` and `encryptedSeed` to be passed together or omitted together. When a seeded WDK instance already exists, the runtime disposes it and closes its generic modules before re-registering the wallets and optional protocols in `config`.
+The handler requires `encryptionKey` and `encryptedSeed` to be passed together or omitted together. When a seeded WDK instance already exists, the runtime closes its generic modules and calls `wdk.dispose()` before validating the new config. In beta.14, a replacement seed pair then causes the old retained buffer to be zeroed before the new seed is decrypted. Config-only reinitialization reuses the existing WDK object and seed buffer.
 
-In beta.13, generic modules on either transport are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules.
+Generic modules on either transport are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules. See [initialization and cleanup limits](/tools/pear-wrk-wdk/configuration#initialization-rules).
 
 #### `resetWdkWallets`
 
@@ -112,7 +112,9 @@ Returns:
 
 - `args` (`DisposeRequest`): Optional `blockchains` array. Omit it or pass an empty array for a full disposal.
 
-A full disposal closes all generic modules and clears the WDK instance. A non-empty `blockchains` array disposes only those wallets and leaves generic modules running.
+A full disposal closes all generic modules and clears the WDK instance. Beta.14 also zeroes and releases `context.wdkSeedBuffer`. After module shutdown completes, this cleanup runs even if `wdk.dispose()` throws. A non-empty `blockchains` array disposes only those wallets and retains the instance, seed buffer, and generic modules.
+
+HRPC sends this request without awaiting a response and returns `void`. JSON-RPC returns `{ status: 'disposed' }` inside its response `result` when the handler completes successfully. See [disposal limits](/tools/pear-wrk-wdk/configuration#dispose-wdk).
 
 #### `callMethod`
 
@@ -127,6 +129,8 @@ A full disposal closes all generic modules and clears the WDK instance. A non-em
 When `RpcContext.allowedMethods` defines the target surface, `methodName` must appear in its `methods` array. Account restrictions are keyed by network; protocol restrictions are nested by network, protocol type, and protocol name. Omitted surfaces remain unrestricted, while `methods: []` denies every call on that exact surface. Denied calls fail before dispatch with the runtime code `METHOD_NOT_ALLOWED`.
 
 A missing wallet or protocol method fails with `BAD_REQUEST`. Beta.13 removes the `options.defaultValue` fallback from both runtime dispatch and `CallMethodOptions`; callers must handle unsupported methods themselves.
+
+Beta.14 removes `options.transformResult` from `CallMethodOptions` and no longer invokes it in the handler. Transform results after receiving them in the host. Invalid JSON in `args` or `options` still fails with `BAD_REQUEST`, but no longer includes the native JSON parser's error detail.
 
 #### `registerWallet`
 
@@ -147,19 +151,21 @@ Returns:
 
 #### `callModule`
 
-Call one method on a configured generic module. Both HRPC and JSON-RPC support this operation in beta.13.
+Call one method on a configured generic module. Both HRPC and JSON-RPC support this operation since beta.13.
 
 - `module` (`string`): Module name shared by `RpcContext.moduleManagers` and `WdkWorkletConfig.modules`.
 - `method` (`string`): Non-empty method name on the constructed module instance.
-- `args?` (`string`): Optional JSON string of arguments. Arrays are spread as positional arguments; a non-array value is passed as one argument.
+- `args?` (`string`): Optional JSON string of arguments. Arrays are spread as positional arguments; omitted or decoded `null` arguments call the method with no arguments. Other values are passed as one argument.
 
-HRPC returns `CallModuleResponse` with optional `result`, a JSON string. JSON-RPC decodes that string and returns the value at `response.result.result`. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization. Return a JSON-serializable value, or `null` for no result; an `undefined` result cannot be decoded by the JSON-RPC transport.
+HRPC returns `CallModuleResponse` with optional `result`, a JSON string. JSON-RPC decodes that string and returns the value at `response.result.result`. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization. In beta.14, a top-level `undefined` or `null` result becomes the HRPC string `"null"` and the decoded JSON-RPC value `null`. Other falsy results such as `false`, `0`, and `''` are preserved. This module normalization does not apply to wallet or protocol `callMethod()` results.
 
 When `RpcContext.allowedModuleMethods` defines the target module, `method` must appear in that module's `methods` array. Omitted modules remain unrestricted, while `methods: []` denies every method on that module. A denied call fails with `METHOD_NOT_ALLOWED` before instance lookup or dispatch.
 
 #### `moduleEvent`
 
 Send an HRPC module event to the host. JSON-RPC forwards the same event as a `moduleEvent` notification with decoded `params.payload`; it has no request `id`.
+
+Beta.14 fixes HRPC event forwarding from hosted modules by preserving the RPC receiver when sending `moduleEvent()`. The event payload shape is unchanged.
 
 - `module` (`string`): Module name.
 - `event` (`string`): Event name.
@@ -222,9 +228,13 @@ Registers the host-side handler used to receive `moduleEvent()` messages.
 Import this helper from `@tetherto/pear-wrk-wdk/worklet`. It registers the package's server-side handlers on the provided RPC instance.
 
 - `rpc` (`any`): RPC server instance that supports the generated handler registration methods.
-- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. Generic modules on either transport can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime` and `moduleInstances`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts generic-module dispatch on both transports.
+- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. Generic modules on either transport can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime`, `moduleInstances`, and, in beta.14, `wdkSeedBuffer`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts generic-module dispatch on both transports.
 
 ### Types
+
+#### `RpcContext.wdkSeedBuffer`
+
+`wdkSeedBuffer?: Buffer | null` is a runtime-managed field added in beta.14. It retains the decrypted buffer passed to the WDK constructor so the runtime can zero it on full disposal or seed replacement. Do not populate it manually. Targeted wallet disposal and config-only reinitialization retain it. See [initialization rules](/tools/pear-wrk-wdk/configuration#initialization-rules) for failure-path limits.
 
 #### `RpcContext` Method Restrictions
 
@@ -254,7 +264,7 @@ interface RpcContext {
 
 The four allowlist helper interfaces are exported types in beta.13. Every omitted level remains unrestricted. Use an explicit empty `methods` array to deny all dynamic calls on one exact surface.
 
-The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.13 published error-code declaration does not include that member. Treat the literal runtime code as authoritative for this release.
+The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.14 published error-code declaration still does not include that member. Treat the literal runtime code as authoritative for this release.
 
 #### `WdkWorkletConfig`
 
@@ -337,7 +347,6 @@ enum ProtocolType {
 }
 
 interface CallMethodOptions {
-  transformResult: Function
   protocolType: ProtocolType
   protocolName: string
 }
@@ -345,7 +354,7 @@ interface CallMethodOptions {
 
 The published declarations include `ProtocolType`, but the top-level JavaScript entry does not export that enum value at runtime. Pass the corresponding string literal, such as `'swidge'`, in serialized request options.
 
-The published `CallMethodOptions` declaration marks every remaining field as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used. `transformResult` is a function-valued internal handler option; it cannot be sent through JSON serialization. Do not place a function in serialized request options.
+The published `CallMethodOptions` declaration marks both fields as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used. Beta.14 removes the former function-valued `transformResult` field; apply transformations in the host after decoding the response.
 
 ### Diagnostic export: `registerHandleLeakCheck(options?)`
 
@@ -375,7 +384,7 @@ registerJsonRpcHandlers(ipc, context)
 
 The server reads UTF-8 JSON-RPC 2.0 messages framed with a four-byte unsigned big-endian payload length. Every request requires an ID, and an ID cannot be reused while its earlier request is still in flight. Malformed frames are dropped without a response. The package does not export a JSON-RPC client or native-host helper.
 
-Beta.13 supports these JSON-RPC method names:
+Beta.14 supports these JSON-RPC method names:
 
 - `workletStart`
 - `generateEntropyAndEncrypt`
@@ -393,7 +402,7 @@ JSON-RPC does not support `resetWdkWallets` in this release. Use HRPC for select
 The transports share the wallet/protocol handler and module runtime. Both support the `swidge` protocol type, enforce `RpcContext.allowedMethods`, and enforce `allowedModuleMethods` for generic-module calls. JSON-RPC `callModule` parameters match `CallModuleRequest`, including its JSON-string `args`. Results use `response.result.result`; events arrive as `moduleEvent` notifications with `params: { module, event, payload }` and a decoded payload. See the [JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 <Callout type="warn">
-Beta.13 removes JSON-RPC parameters and results from INFO request/response logs and logs wallet-call arguments at DEBUG. Mnemonic validation errors identify invalid word positions without echoing the words. This does not provide general secret redaction: DEBUG arguments, module errors, and application logs can still contain sensitive values. Production defaults to ERROR logging; avoid sensitive values in custom logs and errors.
+Beta.14 redacts named secret fields in object arguments to the package logger. It does not scrub raw strings, typed-array arguments, or formatted Error stacks. Production defaults to ERROR logging; see [logging configuration and limits](/tools/pear-wrk-wdk/configuration#configure-logging).
 </Callout>
 
 Mnemonic strings, encryption-key strings, and encrypted payload strings cannot be zeroed in JavaScript. Discard references promptly and never log them. The runtime validates imported mnemonics for 12 or 24 English BIP-39 words and clears temporary byte buffers where possible.

--- a/content/docs/tools/pear-wrk-wdk/configuration.mdx
+++ b/content/docs/tools/pear-wrk-wdk/configuration.mdx
@@ -3,7 +3,7 @@ title: Pear Worklet WDK Configuration
 description: Configure Pear Worklet HRPC and JSON-RPC contexts, WDK payloads, and generic modules
 ---
 
-This page explains how to [build the worklet context](#worklet-context), [shape the worklet config payload](#worklet-config-payload), [initialize WDK](#initialize-wdk), [call generic modules](#call-generic-module-methods), [choose a transport](#json-rpc-transport), and [inspect suspend delays](#inspect-suspend-delays).
+This page explains how to configure a beta.14 worklet context, initialize and dispose WDK, call wallet and generic-module methods, and configure logging and suspend diagnostics. Use the table of contents to find each task.
 
 ## Worklet Context
 
@@ -138,7 +138,7 @@ const context = {
 Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on it.
 
 <Callout type="warn">
-These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.13 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration omits that new member; handle the literal runtime code until the declaration is corrected.
+These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.14 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration still omits that member; handle the literal runtime code until the declaration is corrected.
 </Callout>
 
 ## Worklet Config Payload
@@ -180,7 +180,7 @@ const workletConfig = {
 - `modules` is optional and contains runtime config for named generic modules. Each key must match a `moduleManagers` key in the worklet context and the corresponding build-time Worklet Bundler module name.
 - `resetWdkWallets()` reads only the `networks` portion of the decoded config.
 
-JSON-RPC generic modules require Pear Worklet beta.13. Supply the same `moduleManagers`, `allowedModuleMethods`, and runtime `modules` config used by HRPC. If generating the entrypoint, use Worklet Bundler beta.12 with Pear Worklet beta.13.
+JSON-RPC generic-module support was introduced in Pear Worklet beta.13. Supply the same `moduleManagers`, `allowedModuleMethods`, and runtime `modules` config used by HRPC. For generated entrypoints, use [Worklet Bundler beta.13 with Pear Worklet beta.14](/tools/worklet-bundler/configuration#install-the-packages).
 
 ## Initialize WDK
 
@@ -202,9 +202,25 @@ await hrpc.initializeWDK({
 
 - Pass both `encryptionKey` and `encryptedSeed`, or omit both together.
 - On first initialization, the worklet must receive an encrypted seed pair so it can create `context.wdk`.
-- If `context.wdk` already exists, a later `initializeWDK()` call disposes the existing instance and closes its generic modules before re-registering wallets and protocols from the new config.
-- In beta.13, generic modules on either transport are constructed only when that `initializeWDK()` request includes both `encryptionKey` and `encryptedSeed`. A seedless reinitialization closes existing module instances but does not rebuild them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
+- If `context.wdk` already exists, reinitialization closes its generic modules and calls `wdk.dispose()` before validating the new config. With both seed fields present, beta.14 then zeroes the old retained seed buffer before attempting replacement. Validate the replacement payload before sending it; a failed replacement does not restore the old seed.
+- Without a seed pair, reinitialization reuses the existing WDK object and retained seed to re-register wallets and protocols. It closes generic modules without rebuilding them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
 - Module `close()` is called during full disposal or reinitialization. Targeted blockchain disposal leaves generic modules running. Optional `suspend()` and `resume()` methods run only when the host forwards Bare lifecycle events; the manual context above does so.
+
+The runtime manages the decrypted buffer through `context.wdkSeedBuffer`; do not set this field yourself. If the WDK constructor throws, beta.14 zeroes the newly decrypted buffer. Later wallet or protocol registration failures retain the new instance and seed, so handle those failures and dispose the instance when abandoning initialization.
+
+## Dispose WDK
+
+Send a full disposal request when the worklet should release its WDK instance:
+
+```javascript title="Dispose The Worklet WDK"
+hrpc.dispose({})
+```
+
+A full disposal closes generic modules, disposes WDK, and zeroes and releases its retained seed buffer. Once module shutdown completes, the instance and buffer are cleared even if `wdk.dispose()` throws. HRPC `dispose()` is one-way and returns `void`; its return does not acknowledge cleanup completion.
+
+To dispose only selected wallets, pass a non-empty `blockchains` array, such as `hrpc.dispose({ blockchains: ['ethereum'] })`. This retains the WDK instance, seed buffer, and generic modules. An omitted or empty array requests full disposal.
+
+This cleanup covers the buffer retained by the worklet runtime. It cannot erase JavaScript strings or copies retained by application or module code.
 
 ## Reset Selected Wallets
 
@@ -250,10 +266,13 @@ const result = await hrpc.callMethod({
 - `args` is optional and must be a JSON string when provided.
 - `options` is optional and must be a JSON string when provided.
 - When `args` decodes to an array, the handler spreads the values as positional method arguments.
-- When `args` decodes to an object or primitive, the handler passes it as a single argument.
+- Omitted or decoded `null` arguments call the method with no arguments. Other objects or primitives are passed as one argument.
 - Set `options.protocolType` to `swap`, `swidge`, `bridge`, `lending`, or `fiat` to call a protocol wrapper. Every protocol call requires a non-empty `options.protocolName`.
 - When `context.allowedMethods` contains the target account or protocol surface, `methodName` must appear in that exact surface's `methods` array.
 - In beta.13, a missing wallet or protocol method fails with `BAD_REQUEST`. The removed `options.defaultValue` field no longer supplies a fallback; catch unsupported-method errors in the host.
+- Beta.14 removes `options.transformResult` from the declarations and ignores it during dispatch. Transform the returned value in the host instead.
+
+Invalid JSON in `config`, `args`, or `options` fails with `BAD_REQUEST`. Beta.14 reports a message such as `args must be valid JSON` without the native parser's error detail.
 
 ## Call Generic Module Methods
 
@@ -269,7 +288,9 @@ const response = await hrpc.callModule({
 const theme = response.result ? JSON.parse(response.result) : undefined
 ```
 
-`args` is an optional JSON string. Arrays are spread into positional arguments; a non-array value is passed as one argument. Promise results are awaited, `.toArray()` results are materialized, and `Uint8Array` values are normalized to hex before the response is serialized.
+`args` is an optional JSON string. Arrays are spread into positional arguments; omitted or decoded `null` arguments call the method with no arguments. Other values are passed as one argument. Promise results are awaited, `.toArray()` results are materialized, and `Uint8Array` values are normalized to hex before the response is serialized.
+
+In beta.14, a module method that returns `undefined` or `null` produces the JSON string `"null"` in the HRPC response. JSON-RPC decodes it to `response.result.result === null`. This normalization applies to `callModule()`, not wallet or protocol `callMethod()` results.
 
 When `context.allowedModuleMethods` contains the target module, `method` must appear in its `methods` array. A denied call returns `METHOD_NOT_ALLOWED` before module instance lookup or dispatch.
 
@@ -320,8 +341,14 @@ A declared module event arrives as a notification without an `id`; `params.paylo
 
 Manual JSON-RPC entrypoints must forward Bare `suspend` and `resume` events to `context.moduleRuntime` as shown in the HRPC context example. Registering JSON-RPC handlers alone does not install those lifecycle listeners.
 
+## Configure Logging
+
+Set `LOG_LEVEL` in the worklet environment before loading the package. Accepted values are `DEBUG`, `INFO`, `WARN`, `ERROR`, and `NONE`; beta.14 trims whitespace and ignores case. An unrecognized value falls back to `ERROR`. With `LOG_LEVEL` unset or empty, `NODE_ENV=development` selects `DEBUG`; other environments default to `ERROR`.
+
+At every enabled level, the package logger replaces object fields named `mnemonic`, `encryptionKey`, `encryptedSeed`, `encryptedSeedBuffer`, `encryptedEntropy`, `encryptedEntropyBuffer`, or `seed` with `[redacted]`. Matching is case-sensitive. Nested objects at depth three are replaced with `[object]`.
+
 <Callout type="warn">
-Beta.13 omits JSON-RPC parameters and results from its INFO request/response logs and moves wallet-call arguments to DEBUG. DEBUG can still expose sensitive arguments, and module errors or application logs are not generally redacted. Keep production logging at its default ERROR level and avoid sensitive values in custom logs and error messages.
+This is field-based redaction, not a general secret filter. Raw strings, serialized JSON, typed-array arguments, and formatted Error stacks are not scrubbed. Wallet-call arguments can appear at DEBUG, and module error messages and application logs can still expose sensitive values. Keep production logging at `ERROR` and avoid secrets in custom logs and errors.
 </Callout>
 
 ## Inspect Suspend Delays
@@ -336,7 +363,7 @@ registerHandleLeakCheck({ tickIntervalMs: 1000 })
 
 The helper logs a handle snapshot immediately on `suspend`, then repeats every `tickIntervalMs` milliseconds until `idle` or `resume`. The default interval is `1000` ms. Its timer is unreferenced so the diagnostic itself does not keep the event loop active. It reports handles; it does not close them or suspend modules.
 
-Provide a positive interval; the beta.13 helper passes the value to the timer without validating it. Registration is a no-op if the optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable. Diagnostic output uses `console.warn` regardless of `LOG_LEVEL`, so register it only when you need handle diagnostics.
+Provide a positive interval; the beta.14 helper passes the value to the timer without validating it. Registration is a no-op if the optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable. Diagnostic output uses `console.warn` regardless of `LOG_LEVEL`, so register it only when you need handle diagnostics.
 
 ***
 

--- a/content/docs/tools/pear-wrk-wdk/configuration.mdx
+++ b/content/docs/tools/pear-wrk-wdk/configuration.mdx
@@ -3,7 +3,7 @@ title: Pear Worklet WDK Configuration
 description: Configure Pear Worklet HRPC and JSON-RPC contexts, WDK payloads, and generic modules
 ---
 
-This page explains how to [build the worklet context](#worklet-context), [shape the worklet config payload](#worklet-config-payload), [initialize WDK](#initialize-wdk), [call generic modules](#call-generic-module-methods), and [choose a transport](#json-rpc-transport).
+This page explains how to [build the worklet context](#worklet-context), [shape the worklet config payload](#worklet-config-payload), [initialize WDK](#initialize-wdk), [call generic modules](#call-generic-module-methods), [choose a transport](#json-rpc-transport), and [inspect suspend delays](#inspect-suspend-delays).
 
 ## Worklet Context
 
@@ -85,7 +85,7 @@ module.exports = (rpc) => {
 - `protocolManagers`: A map from protocol name to protocol manager implementation.
 - `wdkLoadError`: Any startup error captured while loading WDK. Use `null` when there is no load failure.
 
-For HRPC generic modules, `moduleManagers` optionally maps module names to `{ createModule, events? }`. The factory receives `{ seed, config, capabilities, emit }` and can return an instance or a promise. `capabilities` is an optional host-supplied object and is empty by default. The runtime manages `moduleRuntime` and `moduleInstances`; do not initialize those fields yourself. Manual integrations must forward Bare `suspend` and `resume` events as shown if module instances should receive those lifecycle calls. Worklet Bundler-generated HRPC entrypoints wire them automatically.
+For generic modules on either transport, `moduleManagers` optionally maps module names to `{ createModule, events? }`. The factory receives `{ seed, config, capabilities, emit }` and can return an instance or a promise. `capabilities` is an optional host-supplied object and is empty by default. The runtime manages `moduleRuntime` and `moduleInstances`; do not initialize those fields yourself. Manual integrations must forward Bare `suspend` and `resume` events as shown if module instances should receive those lifecycle calls. See [Worklet Bundler lifecycle behavior](/tools/worklet-bundler/configuration#suspend-and-resume-behavior) for generated entrypoints.
 
 ## Restrict Dynamic Methods
 
@@ -118,11 +118,11 @@ This map applies to the shared HRPC and JSON-RPC `callMethod()` handler. Restric
 - Omitting the map, a network, `protocols`, a protocol type, a protocol name, or `methods` leaves that exact surface unrestricted.
 - An explicit `methods: []` denies every call on that exact account or protocol surface.
 - Protocol calls use their nested list rather than falling back to the account list.
-- A denied method fails before account or protocol dispatch with `METHOD_NOT_ALLOWED`; `defaultValue` is not returned.
+- A denied method fails before account or protocol dispatch with `METHOD_NOT_ALLOWED`.
 
 ### Generic Module Methods
 
-`allowedModuleMethods` is keyed by the `moduleManagers` name and applies to HRPC `callModule()` only:
+`allowedModuleMethods` is keyed by the `moduleManagers` name and applies to `callModule()` on both HRPC and JSON-RPC:
 
 ```javascript title="Restrict Dynamic Module Calls"
 const context = {
@@ -138,7 +138,7 @@ const context = {
 Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on it.
 
 <Callout type="warn">
-These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.11 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration omits that new member; handle the literal runtime code until the declaration is corrected.
+These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.13 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration omits that new member; handle the literal runtime code until the declaration is corrected.
 </Callout>
 
 ## Worklet Config Payload
@@ -177,12 +177,10 @@ const workletConfig = {
 - `networks` is required and must contain at least one network entry.
 - Each network entry must include `blockchain` and an object `config`.
 - `protocols` is optional during initialization.
-- `modules` is optional and contains runtime config for named generic modules. Each key must match a `moduleManagers` key in the HRPC context and the corresponding build-time Worklet Bundler module name.
+- `modules` is optional and contains runtime config for named generic modules. Each key must match a `moduleManagers` key in the worklet context and the corresponding build-time Worklet Bundler module name.
 - `resetWdkWallets()` reads only the `networks` portion of the decoded config.
 
-<Callout type="warn">
-Generic modules are HRPC-only in beta.11. The JSON-RPC handler does not construct modules or expose module calls and events.
-</Callout>
+JSON-RPC generic modules require Pear Worklet beta.13. Supply the same `moduleManagers`, `allowedModuleMethods`, and runtime `modules` config used by HRPC. If generating the entrypoint, use Worklet Bundler beta.12 with Pear Worklet beta.13.
 
 ## Initialize WDK
 
@@ -205,8 +203,8 @@ await hrpc.initializeWDK({
 - Pass both `encryptionKey` and `encryptedSeed`, or omit both together.
 - On first initialization, the worklet must receive an encrypted seed pair so it can create `context.wdk`.
 - If `context.wdk` already exists, a later `initializeWDK()` call disposes the existing instance and closes its generic modules before re-registering wallets and protocols from the new config.
-- In beta.11, generic modules are constructed only when that `initializeWDK()` request includes both `encryptionKey` and `encryptedSeed`. A seedless reinitialization closes existing module instances but does not rebuild them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
-- Module `close()` is called during full disposal or reinitialization. Targeted blockchain disposal leaves generic modules running. Optional `suspend()` and `resume()` methods run only when the host forwards Bare lifecycle events; the manual context above and Worklet Bundler-generated HRPC entrypoints do so.
+- In beta.13, generic modules on either transport are constructed only when that `initializeWDK()` request includes both `encryptionKey` and `encryptedSeed`. A seedless reinitialization closes existing module instances but does not rebuild them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
+- Module `close()` is called during full disposal or reinitialization. Targeted blockchain disposal leaves generic modules running. Optional `suspend()` and `resume()` methods run only when the host forwards Bare lifecycle events; the manual context above does so.
 
 ## Reset Selected Wallets
 
@@ -255,6 +253,7 @@ const result = await hrpc.callMethod({
 - When `args` decodes to an object or primitive, the handler passes it as a single argument.
 - Set `options.protocolType` to `swap`, `swidge`, `bridge`, `lending`, or `fiat` to call a protocol wrapper. Every protocol call requires a non-empty `options.protocolName`.
 - When `context.allowedMethods` contains the target account or protocol surface, `methodName` must appear in that exact surface's `methods` array.
+- In beta.13, a missing wallet or protocol method fails with `BAD_REQUEST`. The removed `options.defaultValue` field no longer supplies a fallback; catch unsupported-method errors in the host.
 
 ## Call Generic Module Methods
 
@@ -299,11 +298,45 @@ module.exports = (ipc) => {
 
 Messages are UTF-8 JSON-RPC 2.0 objects prefixed by a four-byte unsigned big-endian payload length. Requests require an ID, and IDs must be unique while a request is in flight. The package exports no JSON-RPC host/client helper; the native host must implement framing and correlation.
 
-JSON-RPC beta.11 supports WDK initialization and disposal, secret/mnemonic operations, wallet and protocol calls, and dynamic wallet/protocol registration. Its shared `callMethod` handler supports the `swidge` protocol type and enforces `context.allowedMethods`. It does not support `resetWdkWallets`, `callModule`, `allowedModuleMethods`, or module events. See the [API reference](/tools/pear-wrk-wdk/api-reference#json-rpc-transport) for the exact method list.
+JSON-RPC beta.13 supports generic-module initialization, `callModule`, `allowedModuleMethods`, and `moduleEvent` notifications alongside wallet and protocol operations. `resetWdkWallets` remains HRPC-only. See the [API reference](/tools/pear-wrk-wdk/api-reference#json-rpc-transport) for all methods and response shapes.
+
+Send a module call as a framed JSON-RPC request; `args` remains a JSON string:
+
+```json title="Call A Module Over JSON-RPC"
+{"jsonrpc":"2.0","id":1,"method":"callModule","params":{"module":"preferences","method":"getTheme","args":"[]"}}
+```
+
+For a module that returns `'dark'`, the response contains the decoded value inside `result.result`:
+
+```json title="JSON-RPC Module Result"
+{"jsonrpc":"2.0","id":1,"result":{"result":"dark"}}
+```
+
+A declared module event arrives as a notification without an `id`; `params.payload` is already decoded:
+
+```json title="JSON-RPC Module Event"
+{"jsonrpc":"2.0","method":"moduleEvent","params":{"module":"preferences","event":"changed","payload":{"theme":"dark"}}}
+```
+
+Manual JSON-RPC entrypoints must forward Bare `suspend` and `resume` events to `context.moduleRuntime` as shown in the HRPC context example. Registering JSON-RPC handlers alone does not install those lifecycle listeners.
 
 <Callout type="warn">
-INFO-level logs can contain wallet-call arguments and JSON-RPC parameters or results. Keep production logging at its default ERROR level when requests may contain sensitive values.
+Beta.13 omits JSON-RPC parameters and results from its INFO request/response logs and moves wallet-call arguments to DEBUG. DEBUG can still expose sensitive arguments, and module errors or application logs are not generally redacted. Keep production logging at its default ERROR level and avoid sensitive values in custom logs and error messages.
 </Callout>
+
+## Inspect Suspend Delays
+
+Register the optional [`registerHandleLeakCheck()`](/tools/pear-wrk-wdk/api-reference#diagnostic-export-registerhandleleakcheckoptions) helper once in a Bare worklet entrypoint:
+
+```javascript title="Inspect Bare Handles During Suspend"
+const { registerHandleLeakCheck } = require('@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check')
+
+registerHandleLeakCheck({ tickIntervalMs: 1000 })
+```
+
+The helper logs a handle snapshot immediately on `suspend`, then repeats every `tickIntervalMs` milliseconds until `idle` or `resume`. The default interval is `1000` ms. Its timer is unreferenced so the diagnostic itself does not keep the event loop active. It reports handles; it does not close them or suspend modules.
+
+Provide a positive interval; the beta.13 helper passes the value to the timer without validating it. Registration is a no-op if the optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable. Diagnostic output uses `console.warn` regardless of `LOG_LEVEL`, so register it only when you need handle diagnostics.
 
 ***
 

--- a/content/docs/tools/pear-wrk-wdk/index.mdx
+++ b/content/docs/tools/pear-wrk-wdk/index.mdx
@@ -3,7 +3,7 @@ title: Pear Worklet WDK
 description: HRPC and framed JSON-RPC infrastructure for running WDK inside a Bare worklet
 ---
 
-Pear Worklet WDK is the low-level transport and handler layer for running WDK inside a Bare worklet. It provides an `HRPC` client and server helper, a separate framed JSON-RPC server entrypoint for native hosts, and typed request payloads for WDK, wallet, protocol, and HRPC-only generic-module operations.
+Pear Worklet WDK is the low-level transport and handler layer for running WDK inside a Bare worklet. It provides an `HRPC` client and server helper, a separate framed JSON-RPC server entrypoint for native hosts, and request payloads for WDK, wallet, protocol, and generic-module operations.
 
 Powered by `@tetherto/pear-wrk-wdk`.
 
@@ -13,9 +13,10 @@ Powered by `@tetherto/pear-wrk-wdk`.
 - **Typed lifecycle requests**: Initialize WDK with `initializeWDK({ config, encryptionKey, encryptedSeed })` and tear it down with `dispose()`
 - **Selective wallet resets**: Re-register only the wallet modules listed in a new worklet `networks` config using `resetWdkWallets({ config })`
 - **Generic wallet and protocol calls**: Call account methods through `callMethod({ methodName, network, accountIndex, args, options })`, including Swidge protocols by name
-- **Opt-in method allowlists**: Restrict wallet and nested protocol calls for HRPC and JSON-RPC, plus generic-module calls for HRPC
-- **HRPC generic modules**: Construct named modules during WDK initialization, call their methods with `callModule()`, and forward declared events to the host
+- **Opt-in method allowlists**: Restrict wallet and nested protocol calls for HRPC and JSON-RPC, plus generic-module calls on both transports
+- **Generic modules on both transports**: Construct named modules during WDK initialization, call their methods with `callModule()`, and forward declared events to the host
 - **Framed JSON-RPC server**: Register a length-prefixed JSON-RPC 2.0 server through `@tetherto/pear-wrk-wdk/jsonrpc`
+- **Suspend diagnostics**: Opt in to handle snapshots during Bare suspend-to-idle transitions with `registerHandleLeakCheck()`
 - **Dynamic registration hooks**: Register additional wallets or protocols with `registerWallet()` and `registerProtocol()`
 
 ## Why this matters
@@ -34,7 +35,7 @@ The top-level package exports the `HRPC` runtime value. Import `registerRpcHandl
 </Callout>
 
 <Callout type="warn">
-Generic-module calls and events are HRPC-only in `v1.0.0-beta.11`; the JSON-RPC handler does not expose them. This package also does not export a pre-built WDK bundle.
+In `v1.0.0-beta.13`, a missing wallet or protocol method returns `BAD_REQUEST` even if the caller supplies `options.defaultValue`. Handle unsupported methods in the host. The package does not export a pre-built WDK bundle.
 </Callout>
 
 <Cards>

--- a/content/docs/tools/pear-wrk-wdk/index.mdx
+++ b/content/docs/tools/pear-wrk-wdk/index.mdx
@@ -5,7 +5,7 @@ description: HRPC and framed JSON-RPC infrastructure for running WDK inside a Ba
 
 Pear Worklet WDK is the low-level transport and handler layer for running WDK inside a Bare worklet. It provides an `HRPC` client and server helper, a separate framed JSON-RPC server entrypoint for native hosts, and request payloads for WDK, wallet, protocol, and generic-module operations.
 
-Powered by `@tetherto/pear-wrk-wdk`.
+Powered by `@tetherto/pear-wrk-wdk`. These pages cover `v1.0.0-beta.14`.
 
 ## Features
 
@@ -27,7 +27,7 @@ Powered by `@tetherto/pear-wrk-wdk`.
 - You can host the same wallet and protocol handlers behind HRPC or a native JSON-RPC bridge, within each transport's supported method set
 
 <Callout type="info">
-Use this package when you need direct control over the worklet host and RPC layer. If you want generated worklet entry files instead, start with [`@tetherto/wdk-worklet-bundler`](https://github.com/tetherto/wdk-worklet-bundler).
+Use this package when you need direct control over the worklet host and RPC layer. If you want generated worklet entry files instead, start with [Worklet Bundler](/tools/worklet-bundler).
 </Callout>
 
 <Callout type="info">
@@ -35,7 +35,7 @@ The top-level package exports the `HRPC` runtime value. Import `registerRpcHandl
 </Callout>
 
 <Callout type="warn">
-In `v1.0.0-beta.13`, a missing wallet or protocol method returns `BAD_REQUEST` even if the caller supplies `options.defaultValue`. Handle unsupported methods in the host. The package does not export a pre-built WDK bundle.
+Since beta.13, a missing wallet or protocol method returns `BAD_REQUEST` even if the caller supplies `options.defaultValue`. Beta.14 also removes `options.transformResult`. Handle unsupported methods and transform returned values in the host. The package does not export a pre-built WDK bundle.
 </Callout>
 
 <Cards>

--- a/content/docs/tools/react-native-core/api-reference.mdx
+++ b/content/docs/tools/react-native-core/api-reference.mdx
@@ -50,7 +50,7 @@ Must be placed at the root of your component tree. All hooks in this library req
 | `children` | `React.ReactNode` | **required** | Child components |
 
 <Callout type="warn">
-Starting in `v1.0.0-beta.17`, `enableAutoInitialization`, `currentUserId`, and `clearSensitiveDataOnBackground` are no longer provider props. `requireBiometrics`, which was removed earlier, is also not accepted by beta.18. The app owns wallet identity, background-locking behavior, and biometric or other authentication checks.
+Starting in `v1.0.0-beta.17`, `enableAutoInitialization`, `currentUserId`, and `clearSensitiveDataOnBackground` are no longer provider props. `requireBiometrics`, which was removed earlier, is also not accepted by beta.19. The app owns wallet identity, background-locking behavior, and biometric or other authentication checks.
 </Callout>
 
 ### Example
@@ -183,15 +183,15 @@ Hook for wallet lifecycle operations: create, restore, lock, unlock, delete, and
 Only one wallet can be active. Call and await `lock()` before creating or restoring a different identity. To select a wallet that is already stored, use `switchWallet()` or lock and then unlock that wallet explicitly. `createWallet()`, `restoreWallet()`, `lock()`, `unlock()`, `switchWallet()`, and `createTemporaryWallet()` use a fail-fast mutex, so an overlapping guarded call rejects instead of queuing. The mutex timeout does not cancel an already-running underlying operation. `switchWallet()` is serialized, but it is not transactional: it locks first and does not restore the previous wallet if the new unlock fails.
 
 <Callout type="error">
-`deleteWallet()` and `clearTemporaryWallet()` are not protected by that mutex in beta.18. Deleting even an inactive wallet resets shared local worklet lifecycle state, while the Bare worklet and IPC remain running; this is not remote key cleanup or memory zeroization. The underlying secure-storage deletion can also be partially completed if individual storage operations fail. Authenticate and explicitly confirm destructive deletion, verify another recovery path first, serialize it against every lifecycle operation in the app, call and await `lock()` before deleting the active wallet, and verify the stored wallet inventory afterward.
+`deleteWallet()` and `clearTemporaryWallet()` are not protected by that mutex in beta.19. Deleting even an inactive wallet resets shared local worklet lifecycle state, while the Bare worklet and IPC remain running; this is not remote key cleanup or memory zeroization. The underlying secure-storage deletion can also be partially completed if individual storage operations fail. Authenticate and explicitly confirm destructive deletion, verify another recovery path first, serialize it against every lifecycle operation in the app, call and await `lock()` before deleting the active wallet, and verify the stored wallet inventory afterward.
 </Callout>
 
 <Callout type="error">
-`lock()` is an application-state boundary, not a zeroization guarantee. Beta.18 clears the active ID, local addresses, and local initialization flags, but it does not terminate the Bare worklet or send a remote cleanup request. Do not claim that calling it proves seeds or keys were erased from worklet memory.
+`lock()` is an application-state boundary, not a zeroization guarantee. Beta.19 clears the active ID, local addresses, and local initialization flags, but it does not terminate the Bare worklet or send a remote cleanup request. Do not claim that calling it proves seeds or keys were erased from worklet memory.
 </Callout>
 
 <Callout type="warn">
-React Native Core beta.18 does not enforce biometrics before wallet lifecycle or key-access methods. Authenticate in the app before invoking these methods. For app-background locking, close the authenticated UI boundary immediately and retry `lock()` after any in-flight guarded operation settles; a mutex rejection does not queue or cancel that operation.
+React Native Core beta.19 does not enforce biometrics before wallet lifecycle or key-access methods. Authenticate in the app before invoking these methods. For app-background locking, close the authenticated UI boundary immediately and retry `lock()` after any in-flight guarded operation settles; a mutex rejection does not queue or cancel that operation.
 </Callout>
 
 #### Advanced Crypto Methods

--- a/content/docs/tools/react-native-core/index.mdx
+++ b/content/docs/tools/react-native-core/index.mdx
@@ -21,7 +21,7 @@ Starting in `v1.0.0-beta.17`, wallet identity is caller-owned and the library no
 </Callout>
 
 <Callout type="warn">
-The `v1.0.0-beta.18` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
+The `v1.0.0-beta.19` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
 </Callout>
 
 ## Quick Start
@@ -29,11 +29,11 @@ The `v1.0.0-beta.18` npm artifact includes the React Native source entry at `src
 ### 1. Install
 
 ```bash
-npm install @tetherto/wdk-react-native-core@1.0.0-beta.18 react-native-bare-kit
+npm install @tetherto/wdk-react-native-core@1.0.0-beta.19 react-native-bare-kit
 npx expo install expo-crypto
 ```
 
-Beta.18 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is inside the package range and matches the app's Expo SDK. If the SDK requires a version outside the range, do not force the peer installation; use compatible releases instead. In a bare React Native app, [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
+Beta.19 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is inside the package range and matches the app's Expo SDK. If the SDK requires a version outside the range, do not force the peer installation; use compatible releases instead. In a bare React Native app, [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
 
 ### 2. Wrap Your App
 

--- a/content/docs/tools/wdk-utils/api-reference.mdx
+++ b/content/docs/tools/wdk-utils/api-reference.mdx
@@ -28,13 +28,14 @@ schemaType: APIReference
 | `decodeLnurl(address)` | Decode an LNURL string into its original URL. | `LnurlDecodingResult` |
 | `validateLightningAddress(address)` | Validate a Lightning Address in `user@domain.tld` form. | `LightningAddressValidationResult` |
 | `validateSparkAddress(address)` | Validate a Spark address or a Bitcoin L1 deposit address accepted by Spark flows. | `SparkAddressValidationResult` |
+| `validateTonAddress(address)` | Validate raw TON address structure or a user-friendly address and its checksum. | `TonAddressValidationResult` |
 | `validateTronAddress(address)` | Validate a Tron Base58Check address and prefix byte. | `TronAddressValidationResult` |
 | `validateUmaAddress(address)` | Validate a Universal Money Address. | `UmaAddressValidationResult` |
 | `resolveUmaUsername(uma)` | Split a valid UMA string into `localPart`, `domain`, and `lightningAddress`. | Parsed UMA details or `null`. |
 
 #### `validateAddress(chainId, address)`
 
-Validate an address with the chain-specific validator selected by a CAIP-2 chain ID or a bare namespace accepted by WDK Utils. The supported namespaces are `bip122`, `eip155`, `solana`, `spark`, and `tron`.
+Validate an address with the chain-specific validator selected by a CAIP-2 chain ID or a bare namespace accepted by WDK Utils. The supported namespaces are `bip122`, `eip155`, `solana`, `spark`, `ton`, and `tron`.
 
 ```javascript title="Validate An Address For A CAIP-2 Chain"
 import { validateAddress } from '@tetherto/wdk-utils'
@@ -58,7 +59,7 @@ For `bip122` and `spark`, the reference selects the expected network. Other supp
 
 Validate a Base58Check Bitcoin address and identify whether it matches a supported P2PKH or P2SH network version byte.
 
-The current beta.11 type declaration includes an internal `{ decoded: Uint8Array }` branch in this return type. The shipped runtime returns validation results rather than exposing that intermediate decode object.
+The beta.12 type declaration includes an internal `{ decoded: Uint8Array }` branch in this return type. The shipped runtime returns validation results rather than exposing that intermediate decode object.
 
 ```javascript title="Validate A Base58 Bitcoin Address"
 import { validateBase58 } from '@tetherto/wdk-utils'
@@ -303,6 +304,35 @@ const l1Deposit = validateSparkAddress(
 
 Bitcoin L1 deposit-address formats can be shared by Spark testnet/signet or regtest/local, so the compatibility array can contain two networks.
 
+#### `validateTonAddress(address)`
+
+Validate a required string `address` in raw `<workchain>:<64 hex characters>` form or user-friendly base64/base64url form. The synchronous signature is `validateTonAddress(address: string): TonAddressValidationResult`.
+
+```javascript title="Validate A TON Address"
+import { validateTonAddress } from '@tetherto/wdk-utils'
+
+const result = validateTonAddress(
+  'EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF'
+)
+// { success: true, type: 'ton' }
+```
+
+The package root exports these types:
+
+- `TonAddressValidationSuccess`: `{ success: true, type: 'ton' }`.
+- `TonAddressValidationFailure`: the shared failure shape, `{ success: false, reason: string }`.
+- `TonAddressValidationResult`: the union of those success and failure types. `ValidateAddressResult` also includes it when `validateAddress()` dispatches the `ton` namespace.
+
+The validator trims surrounding whitespace. Raw addresses receive a structure check for a signed integer workchain ID and 64 hexadecimal characters; they have no checksum. User-friendly addresses must have 48 characters, decode to the expected size, carry a bounceable or non-bounceable tag, and pass the CRC16-CCITT checksum. Standard base64 and URL-safe base64 are accepted.
+
+Runtime failure reasons are:
+
+- `EMPTY_ADDRESS`: the string is empty after trimming.
+- `INVALID_FORMAT`: the input is not a string or its structure, encoding, decoded size, or tag is invalid.
+- `INVALID_CHECKSUM`: the user-friendly address checksum does not match.
+
+Success does not establish account existence, ownership, or whether a workchain is supported. Test-only user-friendly addresses are accepted, and the result does not identify their network. `validateAddress()` also does not enforce the TON reference against the address's test-only flag; apply the intended network and recipient policy separately.
+
 #### `validateTronAddress(address)`
 
 Validate a Tron Base58Check address. The helper checks the `T` prefix, the 34-character address length, the Tron prefix byte, and the checksum.
@@ -408,6 +438,10 @@ import { decryptWithKey } from '@tetherto/wdk-utils'
 const plaintext = decryptWithKey(encrypted, key)
 ```
 
+#### `DEFAULT_SCRYPT_PARAMS`
+
+The exported default cost parameters are `{ N: 65536, r: 8, p: 1 }`. The encryption helpers use these values for omitted scrypt parameters.
+
 ### Seed Key Derivation Helpers
 
 Derive deterministic, domain-separated key material from high-entropy seed bytes.
@@ -490,7 +524,7 @@ const shares = await splitMnemonic(seedPhrase, {
 - The returned shares are unencrypted lowercase hex strings.
 - The package-specific share strings are not SLIP-39 mnemonic shares. They do not include the recovery threshold or a format-version marker, so retain that metadata separately.
 - Invalid BIP-39 words, word counts, and checksums are rejected.
-- Node.js uses the dependency's `node:crypto` implementation. Browser and React Native paths must provide secure `crypto.getRandomValues`; React Native apps may need to load `react-native-get-random-values` before importing WDK Utils. In Bare, import from the package root so the Bare entrypoint provides the Node-compatible crypto path; do not load the React Native polyfill. The dependency versions currently resolved for a fresh beta.11 installation require Bare `1.28.0` or later.
+- Node.js uses the dependency's `node:crypto` implementation. Browser and React Native paths must provide secure `crypto.getRandomValues`; React Native apps may need to load `react-native-get-random-values` before importing WDK Utils. In Bare, import from the package root so the Bare entrypoint provides the Node-compatible crypto path; do not load the React Native polyfill. With `bare-module` 6.4.0, the beta.12 dependency tree requires Bare `1.29.4` or later.
 
 #### `combineMnemonic(shares)`
 
@@ -538,11 +572,13 @@ const looksLikeRequest = isBip21Request(
 
 Parse a BIP-21 Bitcoin payment URI. The helper validates the Bitcoin address, accepts optional `amount`, `label`, and `message` parameters, rejects unsupported `req-` parameters, and returns machine-readable failure reasons.
 
+Raw non-ASCII characters in the query return `INVALID_FORMAT`. Percent-encode query text: `label=Caf%C3%A9` is accepted and decoded to `Café`, while `label=Café` is rejected. `isBip21Request()` checks the request shape and does not perform this validation.
+
 ```javascript title="Parse A BIP-21 Request"
 import { parseBip21Request } from '@tetherto/wdk-utils'
 
 const result = parseBip21Request(
-  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Coffee&message=Thanks'
+  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Caf%C3%A9&message=Thanks'
 )
 ```
 
@@ -562,7 +598,7 @@ const result = parseBip21Request(
 
 #### `encodeBip21Request(request)`
 
-Encode a BIP-21 Bitcoin payment URI from a request object. The helper validates the Bitcoin address and amount before returning the URI.
+Encode a BIP-21 Bitcoin payment URI from a request object. The helper validates the Bitcoin address and amount, then percent-encodes the query values before returning the URI. Pass the original `label` and `message` text; do not pre-encode these fields.
 
 ```javascript title="Encode A BIP-21 Request"
 import { encodeBip21Request } from '@tetherto/wdk-utils'
@@ -599,6 +635,8 @@ const looksLikeRequest = isEip681Request(
 #### `parseEip681Request(input)`
 
 Parse a supported EIP-681 transfer request. The published runtime supports `transfer` requests, accepts `value` as an alias for `uint256`, and normalizes scientific-notation amounts into integer `amountSmallest` strings.
+
+Raw non-ASCII characters anywhere in the query return `INVALID_FORMAT`, including in parameters the parser otherwise ignores. Percent-encode non-ASCII query text before parsing. `isEip681Request()` only checks the request shape; a positive detection result does not prove that the query is valid.
 
 ```javascript title="Parse An EIP-681 Request"
 import { parseEip681Request } from '@tetherto/wdk-utils'

--- a/content/docs/tools/wdk-utils/configuration.mdx
+++ b/content/docs/tools/wdk-utils/configuration.mdx
@@ -40,6 +40,7 @@ import {
   validateLightningAddress,
   validateSolanaAddress,
   validateSparkAddress,
+  validateTonAddress,
   validateTronAddress,
   validateUmaAddress,
   resolveUmaUsername
@@ -121,15 +122,17 @@ import {
 ## Runtime notes
 
 - `@tetherto/wdk-utils` exports plain functions. There is no client object to initialize.
-- The package publishes a default module entrypoint through `index.js` and a Bare runtime entrypoint through `bare.js`. The dependency versions currently resolved for a fresh beta.11 installation require Bare `1.28.0` or later.
-- `validateAddress()` dispatches the CAIP-2 namespaces `bip122`, `eip155`, `solana`, `spark`, and `tron` to their chain validators. Unsupported namespaces return `UNSUPPORTED_CHAIN`, and malformed chain IDs return `INVALID_CHAIN_ID`.
+- The package publishes a default module entrypoint through `index.js` and a Bare runtime entrypoint through `bare.js`. With `bare-module` 6.4.0, the beta.12 dependency tree requires Bare `1.29.4` or later.
+- `validateAddress()` dispatches the CAIP-2 namespaces `bip122`, `eip155`, `solana`, `spark`, `ton`, and `tron` to their chain validators. Unsupported namespaces return `UNSUPPORTED_CHAIN`, and malformed chain IDs return `INVALID_CHAIN_ID`.
 - For `bip122` and `spark`, the chain reference selects the expected network. A missing, unknown, or incompatible reference returns `NETWORK_MISMATCH`. Other supported namespaces validate the address format but do not enforce the reference value.
 - Successful Bitcoin and Spark validators return `compatibleNetworks`, because some address formats are valid on more than one network. WDK Utils validates structure and network compatibility, not account existence, ownership, or recipient intent.
+- `validateTonAddress()` accepts raw TON addresses and user-friendly base64/base64url addresses. It checks the checksum only for user-friendly inputs and does not enforce mainnet/testnet compatibility. See [TON validation](/tools/wdk-utils/api-reference#validatetonaddressaddress) for result types and failures.
 - `validateSolanaAddress()` accepts base58-encoded 32-byte public keys, including off-curve program-derived addresses. Solana has no address checksum, so the helper cannot detect every mistyped address.
 - `splitMnemonic()` accepts valid 12-, 15-, 18-, 21-, or 24-word English BIP-39 phrases. It returns hex-encoded Shamir shares and supports threshold schemes from 2-of-2 through 255-of-255.
 - `combineMnemonic()` verifies an embedded 32-bit integrity checksum before returning the reconstructed phrase. The checksum normally detects accidental corruption, but it can collide and does not authenticate shares.
 - `encrypt()` requires `globalThis.crypto.getRandomValues`. In Node.js, `splitMnemonic()` uses the dependency's `node:crypto` implementation; browser and React Native paths require `globalThis.crypto.getRandomValues`. In React Native, load `react-native-get-random-values` before importing `@tetherto/wdk-utils` when the runtime does not provide secure random bytes. In Bare, import from the package root so the Bare entrypoint provides the Node-compatible crypto path; do not load the React Native polyfill.
 - `parseBip21Request()` accepts `bitcoin:` URIs with a validated Bitcoin address and optional `amount`, `label`, and `message` parameters.
+- `parseBip21Request()` and `parseEip681Request()` reject raw non-ASCII query text with `INVALID_FORMAT`. Percent-encode query values, for example `Caf%C3%A9` for `Café`. The BIP-21 encoder handles encoding for its `label` and `message` fields.
 - `encodeBip21Request()` validates the Bitcoin address and amount before returning a `bitcoin:` URI.
 - `encrypt()` returns a versioned payload with hex-encoded `salt`, `iv`, `tag`, and `ciphertext` fields plus the scrypt cost parameters used for key derivation.
 - `decrypt()` reads the scrypt cost parameters from the encrypted payload when they are present.
@@ -169,6 +172,17 @@ const tron = validateTronAddress('TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH')
 const uma = validateUmaAddress('$you@uma.money')
 ```
 
+Validate a TON address using [`validateTonAddress()`](/tools/wdk-utils/api-reference#validatetonaddressaddress). This address is a format-validation fixture; a successful result does not verify the account or its owner:
+
+```javascript title="Validate A TON Address"
+import { validateTonAddress } from '@tetherto/wdk-utils'
+
+const result = validateTonAddress(
+  'EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF'
+)
+// { success: true, type: 'ton' }
+```
+
 You can decode BOLT11 invoice details before presenting a payment request:
 
 ```javascript title="Decode A BOLT11 Invoice"
@@ -179,19 +193,19 @@ const invoice = decodeBolt11(
 )
 ```
 
-You can parse and encode a BIP-21 Bitcoin payment request:
+Parse a BIP-21 Bitcoin payment request with a percent-encoded label, or pass the original label to `encodeBip21Request()` to encode it:
 
 ```javascript title="Handle A BIP-21 Request"
 import { encodeBip21Request, parseBip21Request } from '@tetherto/wdk-utils'
 
 const parsed = parseBip21Request(
-  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Coffee'
+  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Caf%C3%A9'
 )
 
 const encoded = encodeBip21Request({
   address: '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
   amount: '0.001',
-  label: 'Coffee'
+  label: 'Café'
 })
 ```
 

--- a/content/docs/tools/wdk-utils/guides/shamir-secret-sharing.mdx
+++ b/content/docs/tools/wdk-utils/guides/shamir-secret-sharing.mdx
@@ -20,7 +20,7 @@ You need:
 - A recovery policy that defines the total number of shares (`n`) and the threshold needed to recover (`k`). Both values must be integers, `2 <= k <= n <= 255`.
 - A secure way to distribute and retain each share separately, plus a tamper-evident record for authenticating the share bytes during recovery.
 - Cryptographically secure randomness. Node.js uses its `node:crypto` implementation. Browser and React Native paths must provide `globalThis.crypto.getRandomValues`; React Native runtimes may need a polyfill.
-- Bare `1.28.0` or later when using the package's Bare entrypoint. That entrypoint loads `bare-node-runtime/global`, and the dependency versions currently resolved for a fresh beta.11 installation enforce this minimum.
+- Bare `1.29.4` or later when using the package's Bare entrypoint. That entrypoint loads `bare-node-runtime/global`; the beta.12 dependency tree with `bare-module` 6.4.0 declares this minimum.
 
 <Callout type="warn">
 The helper receives only the mnemonic words. It does not include an optional BIP-39 passphrase, derivation path, network, account index, or other wallet metadata. Preserve everything your wallet needs for recovery through a separate protected process.

--- a/content/docs/tools/wdk-utils/index.mdx
+++ b/content/docs/tools/wdk-utils/index.mdx
@@ -3,12 +3,12 @@ title: WDK Utils
 description: Chain-aware address validation, mnemonic sharing, seed encryption, deterministic key derivation, and payment-request helpers for @tetherto/wdk-utils
 ---
 
-WDK Utils provides CAIP-2-aware and chain-specific validation helpers for Bitcoin, EVM, Lightning, Solana, Spark, Tron, and UMA identifiers, Shamir-based mnemonic sharing, passphrase-based seed encryption, deterministic HKDF-SHA256 and Ed25519 key derivation, BIP-21 Bitcoin payment URI helpers, BOLT11 invoice helpers, and EIP-681 request parsing for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+WDK Utils provides CAIP-2-aware and chain-specific validation helpers for Bitcoin, EVM, Lightning, Solana, Spark, TON, Tron, and UMA identifiers, Shamir-based mnemonic sharing, passphrase-based seed encryption, deterministic HKDF-SHA256 and Ed25519 key derivation, BIP-21 Bitcoin payment URI helpers, BOLT11 invoice helpers, and EIP-681 request parsing for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
 
 ## Features
 
-- **Chain-aware address validation**: Dispatch to Bitcoin, EVM, Solana, Spark, or Tron validation with a CAIP-2 chain ID, including network checks for Bitcoin and Spark.
-- **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Solana, Spark, Tron, and UMA inputs before you hand them to a wallet flow.
+- **Chain-aware address validation**: Dispatch to Bitcoin, EVM, Solana, Spark, TON, or Tron validation with a CAIP-2 chain ID, including network checks for Bitcoin and Spark.
+- **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Solana, Spark, TON, Tron, and UMA inputs before you hand them to a wallet flow.
 - **Mnemonic sharing helpers**: Split an English BIP-39 mnemonic into threshold-based Shamir shares and combine enough shares to recover it.
 - **BIP-21 payment URI helpers**: Detect, parse, and encode `bitcoin:` payment URIs with optional amount, label, and message fields.
 - **Seed encryption helpers**: Encrypt and decrypt seed phrases or other strings with AES-256-GCM and scrypt-derived keys.

--- a/content/docs/tools/worklet-bundler/api-reference.mdx
+++ b/content/docs/tools/worklet-bundler/api-reference.mdx
@@ -54,19 +54,19 @@ interface WdkBundleConfig {
 }
 ```
 
-`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to both HRPC and JSON-RPC. These inline helper shapes are present in the config declaration but are not named exports from the beta.12 npm entrypoint.
+`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to both HRPC and JSON-RPC. These inline helper shapes are present in the config declaration but are not named exports from the beta.13 npm entrypoint.
 
 Every omitted map, level, or `methods` field remains unrestricted. An explicit `methods: []` denies every method on that exact surface. Both generated contexts receive `allowedMethods` and `allowedModuleMethods`.
 
-Beta.12 generates `modules` for both transports. Use Pear Worklet beta.13 for JSON-RPC module calls and events. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
+Beta.13 generates `modules` for both transports. Use Pear Worklet beta.13 for JSON-RPC module calls and events. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
 
 <Callout type="warn">
-Beta.12 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
+Beta.13 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
 </Callout>
 
 `options.handleLeakCheck` is optional and applies only to generated HRPC entrypoints. Set `true` to use Pear Worklet beta.13's default `1000` ms interval, or a positive number to pass as `tickIntervalMs`. Omit it to disable diagnostics; `false`, zero, negative numbers, and strings fail `loadConfig()` validation. The interval controls repeated sampling after an immediate suspend snapshot, not a one-time delay.
 
-Generation checks whether the installed Pear Worklet diagnostic subpath resolves, warning and skipping it if unavailable. The helper logs through `console.warn` until Bare `idle` or `resume`; it does not close handles. JSON-RPC generation accepts the option but does not emit diagnostic registration in beta.12.
+Generation checks whether the installed Pear Worklet diagnostic subpath resolves, warning and skipping it if unavailable. The helper logs through `console.warn` until Bare `idle` or `resume`; it does not close handles. JSON-RPC generation accepts the option but does not emit diagnostic registration in beta.13.
 
 #### `ResolvedConfig`
 
@@ -190,7 +190,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `silent`
 - `skipTypes`
 - `skipGeneration`: Reuse an existing generated entrypoint. If `config.options.convertEsmToCjs` changed, regenerate the entrypoint first so its `.mjs` loader behavior matches the bundle conversion.
-- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.12 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
+- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.13 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
 
 `deferOptionalPeers` is a per-run API option. It is not a `WdkBundleConfig` field and cannot be set in `wdk.config.js`.
 
@@ -204,7 +204,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `error?`
 - `missingModule?`
 
-In beta.12, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
+In beta.13, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
 
 ```typescript title="Generate A Bundle Programmatically"
 import { generateBundle, loadConfig } from '@tetherto/wdk-worklet-bundler'
@@ -223,11 +223,11 @@ Use `generateSourceFiles()` when you want the generated entrypoint without the f
 
 Use `generateEntryPoint()` when you need the generated HRPC Bare entrypoint written to a chosen output directory. This path includes configured generic modules, both method-allowlist maps, module lifecycle/event wiring, and the optional `handleLeakCheck` diagnostic.
 
-Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.12 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.12 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
+Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.13 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.13 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
 
 #### `generateJsonRpcEntryPoint(config, outputDir)`
 
-Generate the framed JSON-RPC entrypoint used by native hosts. Beta.12 includes wallet, protocol, and generic-module managers plus both method-allowlist maps. With Pear Worklet beta.13, it supports module calls/events and forwards Bare `suspend` and `resume` to the module runtime. It does not generate HRPC's HTTP-agent lifecycle hooks or the `handleLeakCheck` diagnostic. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
+Generate the framed JSON-RPC entrypoint used by native hosts. Beta.13 includes wallet, protocol, and generic-module managers plus both method-allowlist maps. With Pear Worklet beta.13, it supports module calls/events and forwards Bare `suspend` and `resume` to the module runtime. It does not generate HRPC's HTTP-agent lifecycle hooks or the `handleLeakCheck` diagnostic. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
 
 #### `linkAddons(config, options?)`
 
@@ -256,11 +256,11 @@ convertBundleEsmToCjs('./.wdk-bundle/wdk-worklet.bundle.js', {
 })
 ```
 
-The beta.12 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
+The beta.13 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
 
 This helper rewrites only the packed bundle. For `.mjs` files to load as CommonJS at runtime, generate the HRPC or JSON-RPC entrypoint with `options.convertEsmToCjs: true` before packing, or provide equivalent loader behavior yourself. Do not convert a bundle while reusing an entrypoint generated with conversion disabled.
 
-The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.12 package entrypoint.
+The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.13 package entrypoint.
 
 #### `validateBundle(bundlePath)`
 
@@ -289,7 +289,7 @@ The published CLI exposes these commands through `wdk-worklet-bundler`:
 For the end-to-end config workflow and transport defaults, see the [Worklet Bundler configuration guide](/tools/worklet-bundler/configuration).
 
 <Callout type="warn">
-Beta.12 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
+Beta.13 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
 </Callout>
 
 ***

--- a/content/docs/tools/worklet-bundler/api-reference.mdx
+++ b/content/docs/tools/worklet-bundler/api-reference.mdx
@@ -49,19 +49,24 @@ interface WdkBundleConfig {
     platforms?: Array<'ios' | 'macos' | 'android'>
     swiftTarget?: string
     convertEsmToCjs?: boolean
+    handleLeakCheck?: number | true
   }
 }
 ```
 
-`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to HRPC only. These inline helper shapes are present in the config declaration but are not named exports from the beta.11 npm entrypoint.
+`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to both HRPC and JSON-RPC. These inline helper shapes are present in the config declaration but are not named exports from the beta.12 npm entrypoint.
 
-Every omitted map, level, or `methods` field remains unrestricted. An explicit `methods: []` denies every method on that exact surface. Generated HRPC contexts receive both maps; generated JSON-RPC contexts receive only `allowedMethods`.
+Every omitted map, level, or `methods` field remains unrestricted. An explicit `methods: []` denies every method on that exact surface. Both generated contexts receive `allowedMethods` and `allowedModuleMethods`.
 
-`modules` is generated only for HRPC through beta.11. JSON-RPC entry generation ignores that map. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
+Beta.12 generates `modules` for both transports. Use Pear Worklet beta.13 for JSON-RPC module calls and events. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
 
 <Callout type="warn">
-Beta.11 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
+Beta.12 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
 </Callout>
+
+`options.handleLeakCheck` is optional and applies only to generated HRPC entrypoints. Set `true` to use Pear Worklet beta.13's default `1000` ms interval, or a positive number to pass as `tickIntervalMs`. Omit it to disable diagnostics; `false`, zero, negative numbers, and strings fail `loadConfig()` validation. The interval controls repeated sampling after an immediate suspend snapshot, not a one-time delay.
+
+Generation checks whether the installed Pear Worklet diagnostic subpath resolves, warning and skipping it if unavailable. The helper logs through `console.warn` until Bare `idle` or `resume`; it does not close handles. JSON-RPC generation accepts the option but does not emit diagnostic registration in beta.12.
 
 #### `ResolvedConfig`
 
@@ -185,7 +190,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `silent`
 - `skipTypes`
 - `skipGeneration`: Reuse an existing generated entrypoint. If `config.options.convertEsmToCjs` changed, regenerate the entrypoint first so its `.mjs` loader behavior matches the bundle conversion.
-- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.11 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
+- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.12 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
 
 `deferOptionalPeers` is a per-run API option. It is not a `WdkBundleConfig` field and cannot be set in `wdk.config.js`.
 
@@ -199,7 +204,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `error?`
 - `missingModule?`
 
-In beta.11, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
+In beta.12, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
 
 ```typescript title="Generate A Bundle Programmatically"
 import { generateBundle, loadConfig } from '@tetherto/wdk-worklet-bundler'
@@ -216,13 +221,13 @@ Use `generateSourceFiles()` when you want the generated entrypoint without the f
 
 #### `generateEntryPoint(config, outputDir)`
 
-Use `generateEntryPoint()` when you need the generated HRPC Bare entrypoint written to a chosen output directory. This path includes configured generic modules, both method-allowlist maps, and module lifecycle/event wiring.
+Use `generateEntryPoint()` when you need the generated HRPC Bare entrypoint written to a chosen output directory. This path includes configured generic modules, both method-allowlist maps, module lifecycle/event wiring, and the optional `handleLeakCheck` diagnostic.
 
-Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.11 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.11 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
+Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.12 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.12 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
 
 #### `generateJsonRpcEntryPoint(config, outputDir)`
 
-Generate the framed JSON-RPC entrypoint used by native hosts. Through beta.11 this path includes wallet and protocol managers plus `allowedMethods`, but not generic `modules` or `allowedModuleMethods`. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
+Generate the framed JSON-RPC entrypoint used by native hosts. Beta.12 includes wallet, protocol, and generic-module managers plus both method-allowlist maps. With Pear Worklet beta.13, it supports module calls/events and forwards Bare `suspend` and `resume` to the module runtime. It does not generate HRPC's HTTP-agent lifecycle hooks or the `handleLeakCheck` diagnostic. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
 
 #### `linkAddons(config, options?)`
 
@@ -251,11 +256,11 @@ convertBundleEsmToCjs('./.wdk-bundle/wdk-worklet.bundle.js', {
 })
 ```
 
-The beta.11 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
+The beta.12 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
 
 This helper rewrites only the packed bundle. For `.mjs` files to load as CommonJS at runtime, generate the HRPC or JSON-RPC entrypoint with `options.convertEsmToCjs: true` before packing, or provide equivalent loader behavior yourself. Do not convert a bundle while reusing an entrypoint generated with conversion disabled.
 
-The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.11 package entrypoint.
+The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.12 package entrypoint.
 
 #### `validateBundle(bundlePath)`
 
@@ -284,7 +289,7 @@ The published CLI exposes these commands through `wdk-worklet-bundler`:
 For the end-to-end config workflow and transport defaults, see the [Worklet Bundler configuration guide](/tools/worklet-bundler/configuration).
 
 <Callout type="warn">
-Beta.11 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
+Beta.12 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
 </Callout>
 
 ***

--- a/content/docs/tools/worklet-bundler/configuration.mdx
+++ b/content/docs/tools/worklet-bundler/configuration.mdx
@@ -10,11 +10,11 @@ This page shows how to install `@tetherto/wdk-worklet-bundler` and its Pear runt
 Install the bundler as a development dependency and Pear Worklet as a runtime dependency in the host project:
 
 ```bash title="Install The Bundler And Runtime"
-npm install @tetherto/pear-wrk-wdk@1.0.0-beta.13
+npm install @tetherto/pear-wrk-wdk@1.0.0-beta.14
 npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.13
 ```
 
-Worklet Bundler beta.13 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
+Worklet Bundler beta.13 generates entrypoints that import Pear Worklet. These examples pair it with Pear Worklet beta.14 for generic-module calls and events, seed-buffer cleanup, and the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
 
 ## Create `wdk.config.js`
 
@@ -178,7 +178,7 @@ Use `modules` for named generic packages that expose a module factory. Each entr
 
 The factory receives `{ seed, config, capabilities, emit }` and can return the module instance or a promise for it. A module that needs the seed must consume it synchronously rather than retain it. The build-time name, such as `preferences`, must match the key in the host's runtime module config.
 
-Beta.13 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
+Beta.13 generates these modules for both transports. With Pear Worklet beta.14, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 ### `transport` (optional)
 
@@ -207,7 +207,7 @@ The published config type supports these build options:
 - `linkAddons` (`boolean`): Link native addons with `bare-link`. Defaults to `true` for JSON-RPC and `false` for HRPC.
 - `platforms` (`('ios' | 'macos' | 'android')[]`): Addon platforms. Defaults to all three when addon linking is active.
 - `swiftTarget` (`string`): Xcode target written to `addons.yml`. Defaults to `app`.
-- `handleLeakCheck` (`number | true`, HRPC only): Opt in to repeated handle snapshots while suspended. `true` uses Pear Worklet beta.13's default `1000` ms interval; a positive number sets the interval in milliseconds. Omit the field to disable it. `false`, zero, negative numbers, and strings fail config validation.
+- `handleLeakCheck` (`number | true`, HRPC only): Opt in to repeated handle snapshots while suspended. `true` uses Pear Worklet's default `1000` ms interval; a positive number sets the interval in milliseconds. Omit the field to disable it. `false`, zero, negative numbers, and strings fail config validation.
 - `convertEsmToCjs` (`boolean`): Convert the bundle for a Bare port whose JavaScript engine cannot load ES modules, such as JSC or QuickJS. Defaults to `false` for both transports. Leave it off only when every target uses an ESM-capable engine such as V8.
 
 ### Configure suspend diagnostics

--- a/content/docs/tools/worklet-bundler/configuration.mdx
+++ b/content/docs/tools/worklet-bundler/configuration.mdx
@@ -10,11 +10,11 @@ This page shows how to install `@tetherto/wdk-worklet-bundler` and its Pear runt
 Install the bundler as a development dependency and Pear Worklet as a runtime dependency in the host project:
 
 ```bash title="Install The Bundler And Runtime"
-npm install @tetherto/pear-wrk-wdk@1.0.0-beta.12
-npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.11
+npm install @tetherto/pear-wrk-wdk@1.0.0-beta.13
+npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.12
 ```
 
-Worklet Bundler beta.11 generates entrypoints that import Pear Worklet and includes that runtime in validation and installation for both HRPC and JSON-RPC. Pear Worklet beta.12 enforces the wallet, protocol, and generic-module method allowlists documented here. The GitHub beta.8 release introduced the configuration but has no public npm artifact.
+Worklet Bundler beta.12 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
 
 ## Create `wdk.config.js`
 
@@ -24,7 +24,7 @@ Use `init` to create a starter config, or write the file yourself:
 npx wdk-worklet-bundler init
 ```
 
-The published config surface accepts `networks`, optional `protocols`, HRPC-only generic `modules`, dynamic-call allowlists, `transport`, `preloadModules`, `output`, and `options`:
+The published config surface accepts `networks`, optional `protocols`, generic `modules`, dynamic-call allowlists, `transport`, `preloadModules`, `output`, and `options`:
 
 ```javascript title="Example wdk.config.js"
 module.exports = {
@@ -147,9 +147,9 @@ Restrictions are opt-in per exact surface:
 This configuration is not default-deny. List every wallet and protocol surface exposed to an untrusted host, and use an explicit empty list when that surface should accept no dynamic calls.
 </Callout>
 
-### `allowedModuleMethods` (optional, HRPC only)
+### `allowedModuleMethods` (optional)
 
-Use `allowedModuleMethods` to restrict HRPC `callModule()` dispatch. Keys must match the names under `modules`:
+Use `allowedModuleMethods` to restrict `callModule()` dispatch on both HRPC and JSON-RPC. Keys must match the names under `modules`:
 
 ```javascript title="Restrict Generic Module Calls"
 module.exports = {
@@ -166,9 +166,9 @@ module.exports = {
 }
 ```
 
-Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on that module. JSON-RPC worklets do not generate generic modules or receive `allowedModuleMethods`.
+Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on that module. Both generated transports receive this map.
 
-### `modules` (optional, HRPC only)
+### `modules` (optional)
 
 Use `modules` for named generic packages that expose a module factory. Each entry supports:
 
@@ -178,13 +178,11 @@ Use `modules` for named generic packages that expose a module factory. Each entr
 
 The factory receives `{ seed, config, capabilities, emit }` and can return the module instance or a promise for it. A module that needs the seed must consume it synchronously rather than retain it. The build-time name, such as `preferences`, must match the key in the host's runtime module config.
 
-<Callout type="warn">
-Through beta.11, generic modules are included only in generated HRPC entrypoints. Do not configure `modules` with `transport: 'jsonrpc'`; the current schema accepts the field, but JSON-RPC generation ignores it.
-</Callout>
+Beta.12 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 ### `transport` (optional)
 
-Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.11, ESM-to-CJS conversion is an independent, explicit option for both transports.
+Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.12, ESM-to-CJS conversion is an independent, explicit option for both transports.
 
 ### `preloadModules` (optional)
 
@@ -195,7 +193,7 @@ Use `preloadModules` for native addons or other modules that must be required be
 Supported output fields are:
 
 - `bundle`: Bundle path. Defaults to `./.wdk-bundle/wdk-worklet.bundle.js` for HRPC and `./.wdk-bundle/wdk-worklet.bundle` for JSON-RPC.
-- `types`: Declared in the beta.11 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
+- `types`: Declared in the beta.12 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
 - `addons.ios`, `addons.macos`, `addons.android`: Platform addon directories. Defaults are `./ios-addons`, `./mac-addons`, and `./android-addons`.
 - `addonsYml`: BareKit Swift dependency file. Defaults to `./ios-addons/addons.yml` and is generated when iOS addons are linked.
 
@@ -203,13 +201,38 @@ Supported output fields are:
 
 The published config type supports these build options:
 
-- `minify` (`boolean`): Declared in the beta.11 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
-- `sourceMaps` (`boolean`): Declared in the beta.11 config type but not read by the bundle path, so it does not produce source maps.
+- `minify` (`boolean`): Declared in the beta.12 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
+- `sourceMaps` (`boolean`): Declared in the beta.12 config type but not read by the bundle path, so it does not produce source maps.
 - `targets` (`string[]`): Override the default Bare build hosts. The shipped defaults cover iOS arm64 and simulator targets plus Android arm, arm64, ia32, and x64 hosts.
 - `linkAddons` (`boolean`): Link native addons with `bare-link`. Defaults to `true` for JSON-RPC and `false` for HRPC.
 - `platforms` (`('ios' | 'macos' | 'android')[]`): Addon platforms. Defaults to all three when addon linking is active.
 - `swiftTarget` (`string`): Xcode target written to `addons.yml`. Defaults to `app`.
+- `handleLeakCheck` (`number | true`, HRPC only): Opt in to repeated handle snapshots while suspended. `true` uses Pear Worklet beta.13's default `1000` ms interval; a positive number sets the interval in milliseconds. Omit the field to disable it. `false`, zero, negative numbers, and strings fail config validation.
 - `convertEsmToCjs` (`boolean`): Convert the bundle for a Bare port whose JavaScript engine cannot load ES modules, such as JSC or QuickJS. Defaults to `false` for both transports. Leave it off only when every target uses an ESM-capable engine such as V8.
+
+### Configure suspend diagnostics
+
+Set `options.handleLeakCheck` to inspect handles that remain active after an HRPC worklet suspends:
+
+```javascript title="Sample Handles During Suspend"
+module.exports = {
+  networks: {
+    ethereum: { package: '@tetherto/wdk-wallet-evm' }
+  },
+  transport: 'hrpc',
+  options: {
+    handleLeakCheck: 5000
+  }
+}
+```
+
+This emits `registerHandleLeakCheck({ tickIntervalMs: 5000 })`. The diagnostic logs immediately on `suspend` and every five seconds until `idle` or `resume`. It uses an unreferenced timer and `console.warn` independently of `LOG_LEVEL`; it does not close handles or replace module lifecycle handling.
+
+If the installed Pear Worklet package does not expose `@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check`, generation warns and omits the diagnostic. If the export exists but its optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable, the runtime helper does nothing.
+
+<Callout type="warn">
+Beta.12 emits this diagnostic only for HRPC. Setting `options.handleLeakCheck` in a JSON-RPC config passes validation but does not emit diagnostic registration. Custom JSON-RPC entrypoints can register the [Pear Worklet helper](/tools/pear-wrk-wdk/configuration#inspect-suspend-delays) themselves.
+</Callout>
 
 ### Configure ESM-to-CJS conversion
 
@@ -226,14 +249,14 @@ module.exports = {
 }
 ```
 
-In the normal `generate` or `generateBundle()` path, beta.11 uses one flag for both build-time conversion and the generated runtime loader:
+In the normal `generate` or `generateBundle()` path, beta.12 uses one flag for both build-time conversion and the generated runtime loader:
 
 - After `bare-pack`, it converts `.js`, `.mjs`, and `.cjs` files to CommonJS, lowers dynamic `import()`, removes `"type": "module"` from bundled package manifests, and rebuilds bundle offsets with `bare-bundle`.
 - It preserves raw bundles and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by supported `bare-pack` output suffixes. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported.
 - It validates the rewritten file map, offsets, lengths, CommonJS syntax, entrypoint, package manifests, and absence of dynamic imports before generation succeeds.
 - The generated HRPC or JSON-RPC entrypoint routes `.mjs` files through the CommonJS loader only when conversion is enabled.
 
-There is no beta.11 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
+There is no beta.12 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
 
 ## Configure JSON-RPC and native addons
 
@@ -275,11 +298,11 @@ npx wdk-worklet-bundler validate
 
 ## Handle peer dependencies
 
-Worklet Bundler beta.11 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
+Worklet Bundler beta.12 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
 
 - During bundle generation, missing required peers are offered for installation. In a non-interactive environment without `--install`, the CLI prints the exact manual install command and continues; `bare-pack` can still fail if the bundle needs that peer. The peer scan is skipped by `--source-only`.
 - Missing optional peers are not prompted for or installed. By default, the bundler passes each one to `bare-pack --defer`, so an unused optional feature does not block the build.
-- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.11 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
+- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.12 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
 
 Use `--no-defer-optional-peers` when the app uses an optional feature and you want a missing peer to fail during the build:
 
@@ -301,25 +324,25 @@ Use `generate` to build the worklet artifact:
 npx wdk-worklet-bundler generate --install
 ```
 
-`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.11, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
+`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.12, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
 
 Use `--source-only` when you want the generated `.wdk/wdk-worklet.generated.js` entrypoint and related artifacts without running `bare-pack`. This mode also skips bundle conversion. If `options.convertEsmToCjs` is `true` and you run `bare-pack` yourself, convert the packed bundle with `convertBundleEsmToCjs()` before deployment; the source-only entrypoint already contains the matching `.mjs` loader patch. Keep the same conversion setting when generating the entrypoint and converting the bundle.
 
-The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.11, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
+The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.12, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
 
 `--skip-generation` reuses an existing generated entrypoint. If `options.convertEsmToCjs` changed since that entrypoint was created, regenerate without `--skip-generation` before building so the runtime `.mjs` loader matches the bundle conversion setting.
 
 ## Suspend and resume behavior
 
-Generated HRPC worklet entrypoints register Bare lifecycle handlers for `suspend` and `resume`, then apply those handlers to both the `bare-http1` and `bare-https` global agents. No config flag is required for this behavior. Beta.11 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events.
+Generated HRPC and JSON-RPC entrypoints forward Bare `suspend` and `resume` events to the configured generic modules' optional lifecycle methods. Pear Worklet closes modules during full disposal or reinitialization; targeted wallet disposal leaves them running.
 
-This matters when a generated HRPC worklet performs HTTPS-backed fetches. Starting in beta.3, those generated entrypoints suspend and resume both agents together.
+HRPC entrypoints additionally suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare `suspend`, `resume`, and `idle` events. JSON-RPC beta.12 does not include that HTTP-agent handling. These lifecycle hooks require no diagnostic flag; `options.handleLeakCheck` only adds HRPC handle reporting.
 
 ## Troubleshooting
 
 - If `loadConfig()` cannot find a config file, run `npx wdk-worklet-bundler init` or pass `--config \<path\>`.
 - If `validate` or `generate` reports missing modules, use `generate --install` or inspect the install command from the exported helper APIs in the [API Reference](/tools/worklet-bundler/api-reference).
-- When `bare-pack` reports an unresolved package subpath, beta.11 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
+- When `bare-pack` reports an unresolved package subpath, beta.12 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
 - If you need to inspect generated source before bundling, use `generate --source-only` and review the files in `.wdk/`. For a CommonJS-only target, pack and convert that source as described above before running it.
 
 ***

--- a/content/docs/tools/worklet-bundler/configuration.mdx
+++ b/content/docs/tools/worklet-bundler/configuration.mdx
@@ -11,10 +11,10 @@ Install the bundler as a development dependency and Pear Worklet as a runtime de
 
 ```bash title="Install The Bundler And Runtime"
 npm install @tetherto/pear-wrk-wdk@1.0.0-beta.13
-npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.12
+npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.13
 ```
 
-Worklet Bundler beta.12 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
+Worklet Bundler beta.13 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
 
 ## Create `wdk.config.js`
 
@@ -178,11 +178,11 @@ Use `modules` for named generic packages that expose a module factory. Each entr
 
 The factory receives `{ seed, config, capabilities, emit }` and can return the module instance or a promise for it. A module that needs the seed must consume it synchronously rather than retain it. The build-time name, such as `preferences`, must match the key in the host's runtime module config.
 
-Beta.12 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
+Beta.13 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 ### `transport` (optional)
 
-Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.12, ESM-to-CJS conversion is an independent, explicit option for both transports.
+Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.13, ESM-to-CJS conversion is an independent, explicit option for both transports.
 
 ### `preloadModules` (optional)
 
@@ -193,7 +193,7 @@ Use `preloadModules` for native addons or other modules that must be required be
 Supported output fields are:
 
 - `bundle`: Bundle path. Defaults to `./.wdk-bundle/wdk-worklet.bundle.js` for HRPC and `./.wdk-bundle/wdk-worklet.bundle` for JSON-RPC.
-- `types`: Declared in the beta.12 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
+- `types`: Declared in the beta.13 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
 - `addons.ios`, `addons.macos`, `addons.android`: Platform addon directories. Defaults are `./ios-addons`, `./mac-addons`, and `./android-addons`.
 - `addonsYml`: BareKit Swift dependency file. Defaults to `./ios-addons/addons.yml` and is generated when iOS addons are linked.
 
@@ -201,8 +201,8 @@ Supported output fields are:
 
 The published config type supports these build options:
 
-- `minify` (`boolean`): Declared in the beta.12 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
-- `sourceMaps` (`boolean`): Declared in the beta.12 config type but not read by the bundle path, so it does not produce source maps.
+- `minify` (`boolean`): Declared in the beta.13 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
+- `sourceMaps` (`boolean`): Declared in the beta.13 config type but not read by the bundle path, so it does not produce source maps.
 - `targets` (`string[]`): Override the default Bare build hosts. The shipped defaults cover iOS arm64 and simulator targets plus Android arm, arm64, ia32, and x64 hosts.
 - `linkAddons` (`boolean`): Link native addons with `bare-link`. Defaults to `true` for JSON-RPC and `false` for HRPC.
 - `platforms` (`('ios' | 'macos' | 'android')[]`): Addon platforms. Defaults to all three when addon linking is active.
@@ -231,7 +231,7 @@ This emits `registerHandleLeakCheck({ tickIntervalMs: 5000 })`. The diagnostic l
 If the installed Pear Worklet package does not expose `@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check`, generation warns and omits the diagnostic. If the export exists but its optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable, the runtime helper does nothing.
 
 <Callout type="warn">
-Beta.12 emits this diagnostic only for HRPC. Setting `options.handleLeakCheck` in a JSON-RPC config passes validation but does not emit diagnostic registration. Custom JSON-RPC entrypoints can register the [Pear Worklet helper](/tools/pear-wrk-wdk/configuration#inspect-suspend-delays) themselves.
+Beta.13 emits this diagnostic only for HRPC. Setting `options.handleLeakCheck` in a JSON-RPC config passes validation but does not emit diagnostic registration. Custom JSON-RPC entrypoints can register the [Pear Worklet helper](/tools/pear-wrk-wdk/configuration#inspect-suspend-delays) themselves.
 </Callout>
 
 ### Configure ESM-to-CJS conversion
@@ -249,14 +249,14 @@ module.exports = {
 }
 ```
 
-In the normal `generate` or `generateBundle()` path, beta.12 uses one flag for both build-time conversion and the generated runtime loader:
+In the normal `generate` or `generateBundle()` path, beta.13 uses one flag for both build-time conversion and the generated runtime loader:
 
 - After `bare-pack`, it converts `.js`, `.mjs`, and `.cjs` files to CommonJS, lowers dynamic `import()`, removes `"type": "module"` from bundled package manifests, and rebuilds bundle offsets with `bare-bundle`.
 - It preserves raw bundles and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by supported `bare-pack` output suffixes. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported.
 - It validates the rewritten file map, offsets, lengths, CommonJS syntax, entrypoint, package manifests, and absence of dynamic imports before generation succeeds.
 - The generated HRPC or JSON-RPC entrypoint routes `.mjs` files through the CommonJS loader only when conversion is enabled.
 
-There is no beta.12 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
+There is no beta.13 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
 
 ## Configure JSON-RPC and native addons
 
@@ -298,11 +298,11 @@ npx wdk-worklet-bundler validate
 
 ## Handle peer dependencies
 
-Worklet Bundler beta.12 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
+Worklet Bundler beta.13 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
 
 - During bundle generation, missing required peers are offered for installation. In a non-interactive environment without `--install`, the CLI prints the exact manual install command and continues; `bare-pack` can still fail if the bundle needs that peer. The peer scan is skipped by `--source-only`.
 - Missing optional peers are not prompted for or installed. By default, the bundler passes each one to `bare-pack --defer`, so an unused optional feature does not block the build.
-- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.12 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
+- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.13 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
 
 Use `--no-defer-optional-peers` when the app uses an optional feature and you want a missing peer to fail during the build:
 
@@ -324,11 +324,11 @@ Use `generate` to build the worklet artifact:
 npx wdk-worklet-bundler generate --install
 ```
 
-`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.12, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
+`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.13, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
 
 Use `--source-only` when you want the generated `.wdk/wdk-worklet.generated.js` entrypoint and related artifacts without running `bare-pack`. This mode also skips bundle conversion. If `options.convertEsmToCjs` is `true` and you run `bare-pack` yourself, convert the packed bundle with `convertBundleEsmToCjs()` before deployment; the source-only entrypoint already contains the matching `.mjs` loader patch. Keep the same conversion setting when generating the entrypoint and converting the bundle.
 
-The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.12, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
+The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.13, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
 
 `--skip-generation` reuses an existing generated entrypoint. If `options.convertEsmToCjs` changed since that entrypoint was created, regenerate without `--skip-generation` before building so the runtime `.mjs` loader matches the bundle conversion setting.
 
@@ -336,13 +336,13 @@ The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`,
 
 Generated HRPC and JSON-RPC entrypoints forward Bare `suspend` and `resume` events to the configured generic modules' optional lifecycle methods. Pear Worklet closes modules during full disposal or reinitialization; targeted wallet disposal leaves them running.
 
-HRPC entrypoints additionally suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare `suspend`, `resume`, and `idle` events. JSON-RPC beta.12 does not include that HTTP-agent handling. These lifecycle hooks require no diagnostic flag; `options.handleLeakCheck` only adds HRPC handle reporting.
+HRPC entrypoints additionally suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare `suspend`, `resume`, and `idle` events. JSON-RPC beta.13 does not include that HTTP-agent handling. These lifecycle hooks require no diagnostic flag; `options.handleLeakCheck` only adds HRPC handle reporting.
 
 ## Troubleshooting
 
 - If `loadConfig()` cannot find a config file, run `npx wdk-worklet-bundler init` or pass `--config \<path\>`.
 - If `validate` or `generate` reports missing modules, use `generate --install` or inspect the install command from the exported helper APIs in the [API Reference](/tools/worklet-bundler/api-reference).
-- When `bare-pack` reports an unresolved package subpath, beta.12 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
+- When `bare-pack` reports an unresolved package subpath, beta.13 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
 - If you need to inspect generated source before bundling, use `generate --source-only` and review the files in `.wdk/`. For a CommonJS-only target, pack and convert that source as described above before running it.
 
 ***

--- a/content/docs/tools/worklet-bundler/index.mdx
+++ b/content/docs/tools/worklet-bundler/index.mdx
@@ -7,19 +7,20 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 
 ## Features
 
-- **Config-driven bundle generation**: Map logical network names to wallet packages, protocol names to protocol packages, and HRPC-only generic-module names to package factories.
+- **Config-driven bundle generation**: Map logical network names to wallet packages, protocol names to protocol packages, and generic-module names to package factories.
 - **HRPC and JSON-RPC transports**: Generate an HRPC JavaScript bundle by default or a length-prefixed JSON-RPC bundle for native hosts.
 - **Generated worklet artifacts**: Produce a Bare bundle, a stable `./.wdk` host import, and generated TypeScript types.
 - **Native addon outputs**: Link iOS, macOS, and Android addons and generate `addons.yml` for JSON-RPC/native integrations.
 - **Dependency validation helpers**: Validate configured modules, detect the active package manager, and generate install or uninstall commands when dependencies are missing.
-- **Dynamic-call allowlists**: Restrict generated wallet and protocol `callMethod()` surfaces for HRPC and JSON-RPC, plus generic-module `callModule()` surfaces for HRPC.
+- **Dynamic-call allowlists**: Restrict generated wallet and protocol `callMethod()` surfaces for HRPC and JSON-RPC, plus generic-module `callModule()` surfaces on both transports.
 - **Optional peer deferral**: Defer missing peers marked optional by their package metadata, or require them at build time with `--no-defer-optional-peers`.
 - **Explicit ESM-to-CJS conversion**: Opt in for JSC, QuickJS, or another CommonJS-only Bare engine, with a matching runtime loader patch and post-conversion bundle validation.
 - **CLI workflow**: Use `init`, `validate`, `generate`, `list-modules`, and `clean` without building your own wrapper.
-- **Bare lifecycle handling**: Generated HRPC entrypoints suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare suspend, resume, and idle events.
+- **Bare lifecycle handling**: Generated entrypoints forward suspend and resume events to generic modules. HRPC entrypoints also suspend and resume both HTTP global agents.
+- **Opt-in handle diagnostics**: Use `options.handleLeakCheck` to inspect suspend-to-idle delays in generated HRPC worklets.
 
 <Callout type="info">
-`v1.0.0-beta.10` makes ESM-to-CJS conversion explicit and transport-independent. When enabled in `wdk.config.js`, the generated entrypoint installs the matching `.mjs` CommonJS loader patch and the build validates the rewritten raw or default UTF-8-wrapped bundle before succeeding. The release also exports `convertBundleEsmToCjs()` and `validateBundle()` for programmatic workflows.
+`v1.0.0-beta.12` adds generic modules and their method allowlists to JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The new `options.handleLeakCheck` diagnostic is generated only for HRPC.
 </Callout>
 
 ## Why this matters
@@ -29,7 +30,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - Transport-specific defaults produce a JavaScript HRPC bundle for React Native Core or native addon artifacts for JSON-RPC hosts; JavaScript-engine compatibility is configured separately.
 
 <Callout type="warn">
-Generic `modules` are generated only for HRPC through beta.11. A JSON-RPC config can currently accept a `modules` field but silently omits those modules from the generated entrypoint.
+`options.handleLeakCheck` is opt-in and reports active handles without closing them. JSON-RPC entrypoints do not enable this diagnostic in beta.12; see [configuration](/tools/worklet-bundler/configuration#configure-suspend-diagnostics) for the transport boundary.
 </Callout>
 
 <Cards>

--- a/content/docs/tools/worklet-bundler/index.mdx
+++ b/content/docs/tools/worklet-bundler/index.mdx
@@ -20,7 +20,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - **Opt-in handle diagnostics**: Use `options.handleLeakCheck` to inspect suspend-to-idle delays in generated HRPC worklets.
 
 <Callout type="info">
-`v1.0.0-beta.13` supports generic modules and their method allowlists in JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The `options.handleLeakCheck` diagnostic is generated only for HRPC.
+`v1.0.0-beta.13` supports generic modules and their method allowlists in JSON-RPC entrypoints, including module suspend/resume forwarding. The [installation example](/tools/worklet-bundler/configuration#install-the-packages) pairs it with Pear Worklet `v1.0.0-beta.14` for runtime module calls and events. The `options.handleLeakCheck` diagnostic is generated only for HRPC.
 </Callout>
 
 ## Why this matters

--- a/content/docs/tools/worklet-bundler/index.mdx
+++ b/content/docs/tools/worklet-bundler/index.mdx
@@ -20,7 +20,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - **Opt-in handle diagnostics**: Use `options.handleLeakCheck` to inspect suspend-to-idle delays in generated HRPC worklets.
 
 <Callout type="info">
-`v1.0.0-beta.12` adds generic modules and their method allowlists to JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The new `options.handleLeakCheck` diagnostic is generated only for HRPC.
+`v1.0.0-beta.13` supports generic modules and their method allowlists in JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The `options.handleLeakCheck` diagnostic is generated only for HRPC.
 </Callout>
 
 ## Why this matters
@@ -30,7 +30,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - Transport-specific defaults produce a JavaScript HRPC bundle for React Native Core or native addon artifacts for JSON-RPC hosts; JavaScript-engine compatibility is configured separately.
 
 <Callout type="warn">
-`options.handleLeakCheck` is opt-in and reports active handles without closing them. JSON-RPC entrypoints do not enable this diagnostic in beta.12; see [configuration](/tools/worklet-bundler/configuration#configure-suspend-diagnostics) for the transport boundary.
+`options.handleLeakCheck` is opt-in and reports active handles without closing them. JSON-RPC entrypoints do not enable this diagnostic in beta.13; see [configuration](/tools/worklet-bundler/configuration#configure-suspend-diagnostics) for the transport boundary.
 </Callout>
 
 <Cards>

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -5873,6 +5873,25 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### September 03, 2026
+
+**What's New**
+- **worklet-bundler** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.12)): Generate generic modules, method allowlists, and module suspend/resume handlers for JSON-RPC. Add `options.handleLeakCheck` for opt-in HRPC handle diagnostics; use Pear Worklet beta.13 for these runtime features.
+- **wallet-evm-7702-gasless** ([v1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm-7702-gasless/releases/tag/v1.0.0-beta.5)): Add configurable EntryPoint v0.8/v0.9 with matching delegation implementations, and check configured `chainId` on the first UserOperation chain lookup.
+
+**Fixes**
+- **bridge-usdt0-evm** ([v1.0.0-beta.9](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/releases/tag/v1.0.0-beta.9)): Accept shared WDK account interfaces and allow EVM-compatible accounts with a callable `sendTransaction()` to execute `bridge()`. ERC-4337 helper selection and approval batching still depend on the bridge package's concrete account classes.
+- **wallet-evm-erc-4337** ([v1.0.0-beta.18](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.18)): Validate the provider against configured `chainId` on the first chain lookup before building UserOperations for signing.
+
+---
+
+### September 02, 2026
+
+**Changes**
+- **pear-wrk-wdk** ([v1.0.0-beta.13](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.13)): [Breaking] Remove the `callMethod()` default-value fallback; missing methods now fail with `BAD_REQUEST`. Add generic-module calls and events over JSON-RPC, opt-in suspend handle diagnostics, and narrower logging of request and mnemonic data.
+
+---
+
 ### August 30, 2026
 
 **What's New**
@@ -7288,7 +7307,7 @@ Use the USD₮0 bridge module to move USD₮0 and XAU₮0 across supported chain
 - **LayerZero Integration**: Uses LayerZero protocol for secure cross-chain transfers
 - **Expanded Multi-Chain Support**: Discover 25 configured EVM and non-EVM network keys
 - **Non-EVM Destinations**: Bridge toward Solana, TON, and TRON when the source token has a compatible route contract
-- **Account Abstraction**: Works with both standard EVM wallets and ERC-4337 smart accounts
+- **Account Compatibility**: Accepts the shared WDK account interfaces; execution requires a callable `sendTransaction()` method and EVM transaction support. See [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) for ERC-4337 batching limits.
 - **Fee Management**: Built-in fee calculation and bridge cost estimation
 - **Token Support**: Supports USD₮0 and XAU₮0 ecosystem tokens
 - **Route Overrides**: Custom OFT contract addresses and destination endpoint IDs
@@ -7337,7 +7356,7 @@ All source chains above, plus:
 
 ### Non-EVM route candidates
 
-For auto-resolved routes toward Solana, TON, or TRON, beta.7 skips the source chain's ordinary `oftContract`. The bundled configuration can instead consider these source contracts:
+For auto-resolved routes toward Solana, TON, or TRON, the protocol skips the source chain's ordinary `oftContract`. The bundled configuration can instead consider these source contracts:
 
 | Source token contract family | EVM source chains with a bundled candidate |
 |---|---|
@@ -7359,7 +7378,7 @@ Standard EVM accounts can use every supported EVM source route with a matching t
 </Callout>
 
 <Callout type="warn">
-ERC-4337 `fee` and `bridgeFee` values can use different denominations in `1.0.0-beta.7`. Review the [fee-unit limitation](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#fee-units-and-bridgemaxfee) before configuring `bridgeMaxFee`.
+ERC-4337 `fee` and `bridgeFee` values can use different denominations in `1.0.0-beta.9`. Review the [fee-unit limitation](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#fee-units-and-bridgemaxfee) before configuring `bridgeMaxFee`.
 </Callout>
 
 ## Next Steps
@@ -7409,7 +7428,7 @@ new Usdt0ProtocolEvm(account, config?)
 ```
 
 **Parameters:**
-- `account` (WalletAccountEvm | WalletAccountEvmErc4337 | WalletAccountReadOnlyEvm | WalletAccountReadOnlyEvmErc4337): The wallet account to use for bridge operations
+- `account` (`IWalletAccount` or `IWalletAccountReadOnly` from `@tetherto/wdk-wallet`): The wallet account to use for bridge operations. See [account requirements](#account-requirements).
 - `config` (BridgeProtocolConfig, optional): Configuration object
   - `bridgeMaxFee` (number | bigint, optional): Rejects `bridge()` when the implementation's combined fee value is at or above this cap
 
@@ -7426,6 +7445,18 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
   bridgeMaxFee: 1000000000000000n // Standard Ethereum account: source native base units
 })
 ```
+
+### Account requirements
+
+The constructor accepts the shared `IWalletAccount` and `IWalletAccountReadOnly` interfaces in `1.0.0-beta.9`. For execution, `bridge()` checks whether the account has a callable `sendTransaction()` method instead of requiring a `WalletAccountEvm` instance.
+
+The account must still implement EVM-compatible `getAddress()` and `quoteSendTransaction()` operations. Both bridge methods require an RPC URL or EIP-1193 provider in the wallet configuration. The constructor reads `account._config.provider`, an internal field absent from the shared interfaces. Implementing the interface alone does not establish runtime compatibility; an account without `_config` fails construction.
+
+Read-only accounts can use `quoteBridge()`, subject to the same provider, route, balance, and allowance requirements. They cannot execute `bridge()` without `sendTransaction()`.
+
+<Callout type="warn">
+ERC-4337 helper selection and approval batching still depend on the concrete classes resolved by the bridge package: `WalletAccountReadOnlyEvmErc4337` for helper construction and quotes, and `WalletAccountEvmErc4337` for execution. A custom account or an account from a separate copy of the ERC-4337 package does not receive that path solely because it implements `sendTransaction()`. The bridge release depends on ERC-4337 wallet `1.0.0-beta.11`; verify package deduplication and runtime class identity when combining wallet versions. See [Bridge with ERC-4337](/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-with-4337#prerequisites).
+</Callout>
 
 ### Methods
 
@@ -7455,7 +7486,7 @@ With a standard EVM account, approve the source-chain bridge spender before call
 **Returns:** `Promise<BridgeResult>` - Bridge operation result
 
 **Throws:**
-- Error if account is read-only
+- Error if the account has no callable `sendTransaction()` method
 - Error if no provider is configured
 - Error if the combined fee value is equal to or greater than `bridgeMaxFee`
 
@@ -7473,7 +7504,7 @@ await standardAccount.approve({
 const result = await standardBridgeProtocol.bridge({
   targetChain: 'arbitrum',
   recipient: '0x...', // Recipient address
-  token: '0x...', // ₮ contract address
+  token: '0x...', // USDt contract address
   amount: 1000000n,
   oftContractAddress: '0x...' // Same address used as approval spender
 })
@@ -7501,7 +7532,7 @@ console.log('Bridge fee:', result2.bridgeFee)
 ```
 
 #### `quoteBridge(options, config?)`
-Estimates the cost of a bridge operation without executing it.
+Estimates the cost of a bridge operation without executing it. Read-only accounts are accepted, and this method does not enforce `bridgeMaxFee`.
 
 For standard EVM accounts, some providers estimate the same bridge transaction that `bridge()` sends. If that estimate fails because token allowance is missing, approve the source-chain bridge spender before calling `quoteBridge()`. ERC-4337 quotes include the bundled approval transaction. For `WalletAccountReadOnlyEvmErc4337`, `quoteBridge()` uses the same ordered batch as `bridge()`: on Ethereum mainnet for the resolved USD₮ token at `0xdAC17F958D2ee523a2206206994597C13D831ec7`, an existing non-zero allowance and non-zero `approveAmount` produce `approve(spender, 0)`, `approve(spender, approveAmount)`, then the helper bridge call; otherwise the batch is the approval followed by the helper call.
 
@@ -7624,13 +7655,14 @@ type Erc4337BridgeConfig = Erc4337QuoteConfig & {
 
 | Account flow | `fee` | `bridgeFee` |
 |---|---|---|
-| Standard EVM | Source-chain native base units | Source-chain native base units |
+| `WalletAccountEvm` | Source-chain native base units | Source-chain native base units |
+| Other compatible accounts using the single-transaction path | Account-specific `quoteSendTransaction()` fee units | Source-chain native base units |
 | ERC-4337 with native gas | Source-chain native base units | Bridged-token base units |
 | ERC-4337 with token-paid gas | Paymaster-token base units | Bridged-token base units |
 | ERC-4337 with sponsored gas | `0` | Bridged-token base units |
 
 <Callout type="warn">
-In `1.0.0-beta.7`, the ERC-4337 path numerically adds `fee + bridgeFee` when checking `bridgeMaxFee`, even when the fields have different denominations. Do not interpret that sum as a total monetary cost. Set an ERC-4337 cap only after confirming that the selected account payment mode produces compatible units. The equality boundary is rejected.
+In `1.0.0-beta.9`, `bridge()` numerically adds `fee + bridgeFee` when checking `bridgeMaxFee`, even when the fields have different denominations. This affects ERC-4337 helper flows and any compatible account whose quoted fee is not in source-chain native base units. Do not interpret that sum as a total monetary cost. Set a cap only after confirming that the selected account payment mode produces compatible units. The equality boundary is rejected.
 </Callout>
 
 `Erc4337QuoteConfig` is a partial operation-level override of the wallet's token-paid, sponsored, or native-gas configuration. Sponsored gas uses `isSponsored: true` and can include `sponsorshipPolicyId`; native gas uses `useNativeCoins: true`. See the [ERC-4337 wallet configuration](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) for the complete account requirements.
@@ -7914,7 +7946,9 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 
 ## Account Configuration
 
-The bridge protocol uses the wallet account's configuration for blockchain access:
+The constructor accepts `IWalletAccount` or `IWalletAccountReadOnly` from `@tetherto/wdk-wallet`. Execution requires EVM transaction support and a callable `sendTransaction()` method; read-only accounts can quote. See [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) for custom accounts and ERC-4337 class identity.
+
+The bridge protocol reads the provider from the wallet account's internal configuration for blockchain access:
 
 ```javascript
 import { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
@@ -7951,10 +7985,10 @@ The `bridgeMaxFee` option rejects `bridge()` when the implementation's `fee + br
 
 **Type:** `number | bigint` (optional)
 
-For a standard EVM account, both fields use the source chain's native base unit. For example, Ethereum and Arbitrum report the values in wei.
+For `WalletAccountEvm`, both fields use the source chain's native base unit, such as wei on Ethereum and Arbitrum. Other compatible accounts retain their own `quoteSendTransaction()` fee denomination, while the single-transaction path still returns `bridgeFee` in source native base units. Confirm the units match before setting a cap.
 
 <Callout type="warn">
-For an ERC-4337 helper flow, `bridgeFee` is in bridged-token base units. The account's `fee` uses native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. In `1.0.0-beta.7`, the protocol numerically adds these values when enforcing `bridgeMaxFee`. Do not treat that sum as one currency or set a cap until your payment mode uses compatible units.
+For an ERC-4337 helper flow, `bridgeFee` is in bridged-token base units. The account's `fee` uses native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. In `1.0.0-beta.9`, the protocol numerically adds these values when enforcing `bridgeMaxFee`. Do not treat that sum as one currency or set a cap until your payment mode uses compatible units.
 </Callout>
 
 **Examples:**
@@ -7989,7 +8023,7 @@ try {
 
 ### Provider
 
-The `provider` option comes from the wallet account configuration and specifies how to connect to the blockchain.
+The `provider` option comes from the wallet account configuration and specifies how to connect to the blockchain. Both `bridge()` and `quoteBridge()` require it. The constructor reads `account._config.provider`; `_config` is not part of the shared account interfaces, so accepting an interface in TypeScript does not guarantee runtime compatibility.
 
 **Type:** `string | Eip1193Provider`
 
@@ -8012,7 +8046,7 @@ Pass either an RPC URL string or a genuine EIP-1193 provider. An ethers `JsonRpc
 
 ## ERC-4337 Configuration
 
-When using ERC-4337 accounts, you can override configuration options during bridge operations:
+When using ERC-4337 accounts recognized by the bridge package's concrete class checks, you can override configuration options during bridge operations. Review the [class identity requirement](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) before combining package versions:
 
 ```javascript
 // Bridge with ERC-4337 account
@@ -8204,7 +8238,7 @@ Get started with WDK's Bridge USD₮0 EVM Protocol usage
 URL: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-cross-ecosystem
 Description: Send USD₮0 from EVM toward Solana, TON, or TRON recipients.
 
-This guide covers [prerequisites](#prerequisites) and how to [bridge to Solana](#bridge-to-solana), [bridge to TON](#bridge-to-ton), and [bridge to TRON](#bridge-to-tron) using [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config). The same [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#usdt0protocolevm) instance you use for EVM destinations applies; only `targetChain` and `recipient` formats change.
+This guide covers [prerequisites](#prerequisites), how to [verify the route](#verify-the-route), and how to [bridge to Solana](#bridge-to-solana), [bridge to TON](#bridge-to-ton), and [bridge to TRON](#bridge-to-tron) using [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config). The same [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#usdt0protocolevm) instance you use for EVM destinations applies; only `targetChain` and `recipient` formats change.
 
 ## Prerequisites
 
@@ -8214,7 +8248,7 @@ The examples below use a standard EVM account. For `USDT_BRIDGE_SPENDER_ADDRESS`
 
 ## Verify the route
 
-For Solana, TON, and TRON targets, beta.7 does not auto-resolve the source chain's ordinary USD₮0 OFT. Its bundled auto-resolution candidates are:
+For Solana, TON, and TRON targets, the protocol does not auto-resolve the source chain's ordinary USD₮0 OFT. Its bundled auto-resolution candidates are:
 
 | Source token contract family | EVM source chains with a bundled candidate |
 |---|---|
@@ -8463,6 +8497,7 @@ This guide covers [prerequisites](#prerequisites), how to [create an ERC-4337 ac
 * `@tetherto/wdk-wallet-evm-erc-4337` installed alongside [@tetherto/wdk-protocol-bridge-usdt0-evm](https://www.npmjs.com/package/@tetherto/wdk-protocol-bridge-usdt0-evm).
 * Bundler and paymaster endpoints for your chain (example uses Arbitrum public URLs from the API reference).
 * An ERC-4337 source chain with a configured transaction-value helper: Ethereum, Arbitrum, Plasma, or Polygon.
+* An account recognized as the same ERC-4337 class instance used by the bridge package. In `1.0.0-beta.9`, the bridge depends on ERC-4337 wallet `1.0.0-beta.11` and still uses concrete class checks for its helper and batching flow. Separate package copies, including those introduced by differing versions, can miss this path. Verify deduplication and runtime class identity before using this guide. The new `sendTransaction()` capability check alone does not enable batching. See [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements).
 
 ## Create a WalletAccountEvmErc4337 account
 
@@ -8525,7 +8560,7 @@ The bundled approval sequence and helper call produce one UserOperation hash. Fo
 </Callout>
 
 <Callout type="warn">
-In `1.0.0-beta.7`, `bridgeFee` for this helper flow is in bridged-token base units. The account's `fee` is in native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. The protocol numerically adds those values when enforcing `bridgeMaxFee`. Do not interpret the sum as one currency or set an ERC-4337 cap until your integration has confirmed compatible units for its payment mode.
+In `1.0.0-beta.9`, `bridgeFee` for this helper flow is in bridged-token base units. The account's `fee` is in native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas. The protocol numerically adds those values when enforcing `bridgeMaxFee`. Do not interpret the sum as one currency or set an ERC-4337 cap until your integration has confirmed compatible units for its payment mode.
 </Callout>
 
 <Callout type="warn">
@@ -8542,7 +8577,7 @@ Bridge to non-EVM chains in [Bridge cross-ecosystem](/sdk/bridge-modules/bridge-
 URL: https://docs.wdk.tether.io/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started
 Description: Install the bridge package, wire WalletAccountEvm, and review supported chains.
 
-This guide shows how to [install the package](#install-the-package), [create an EVM account](#create-an-evm-account), [instantiate the bridge protocol](#instantiate-the-bridge-protocol), and review [supported chains](#supported-chains).
+This guide shows how to [install the package](#install-the-package), [create an EVM account](#create-an-evm-account), [instantiate the bridge protocol](#instantiate-the-bridge-protocol), [use a read-only account](#use-a-read-only-account-optional), and review [supported chains](#supported-chains).
 
 ## Install the package
 
@@ -8554,7 +8589,7 @@ This guide shows how to [install the package](#install-the-package), [create an 
 You can add the published package to your project from npm: [@tetherto/wdk-protocol-bridge-usdt0-evm](https://www.npmjs.com/package/@tetherto/wdk-protocol-bridge-usdt0-evm).
 
 ```bash title="Install @tetherto/wdk-protocol-bridge-usdt0-evm"
-npm install @tetherto/wdk-protocol-bridge-usdt0-evm
+npm install @tetherto/wdk-protocol-bridge-usdt0-evm @tetherto/wdk-wallet-evm
 ```
 
 ## Create an EVM account
@@ -8590,8 +8625,23 @@ const bridgeProtocol = new Usdt0ProtocolEvm(account, {
 For standard EVM accounts, `fee` and `bridgeFee` are source-chain native base units. ERC-4337 fee units depend on the account's gas-payment mode while `bridgeFee` is returned in bridged-token base units. Read [Fee units and `bridgeMaxFee`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#fee-units-and-bridgemaxfee) before setting a cap for an ERC-4337 flow.
 
 <Callout type="info">
-The account must not be read-only. Read-only accounts cannot call [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference).
+The constructor also accepts the shared WDK account interfaces. [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) requires a callable `sendTransaction()` method and EVM transaction support. Read [account requirements](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements) before supplying a custom account or combining ERC-4337 package versions.
 </Callout>
+
+## Use a read-only account (optional)
+
+For quotes without signing, create a [`WalletAccountReadOnlyEvm`](/sdk/wallet-modules/wallet-evm/api-reference#walletaccountreadonlyevm) for the source address and pass it to [`Usdt0ProtocolEvm`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#constructor):
+
+```javascript title="Create a read-only bridge"
+import { WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
+
+const readOnlyAccount = new WalletAccountReadOnlyEvm(await account.getAddress(), {
+  provider: 'https://eth.drpc.org'
+})
+const readOnlyBridge = new Usdt0ProtocolEvm(readOnlyAccount)
+```
+
+You can now call [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) with your route options. The source address needs any allowance and balance required by the route's gas estimate; a read-only account cannot grant that allowance. Calling [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) on this instance rejects before sending a transaction.
 
 ## Supported chains
 
@@ -8648,7 +8698,7 @@ This guide describes [errors thrown by the bridge](#errors-from-the-bridge-proto
 
 ## Errors from the bridge protocol
 
-Calls to [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) and [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) throw when the account is read-only, no provider is configured, the route is invalid, the combined fee value is at or above [`bridgeMaxFee`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeprotocolconfig), or the destination matches the source chain. The [API reference](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#error-handling) lists representative `error.message` substrings.
+Both [`bridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeoptions-config) and [`quoteBridge()`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#quotebridgeoptions-config) require a provider and valid route options. Only execution rejects an account without a callable `sendTransaction()` method and enforces [`bridgeMaxFee`](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#bridgeprotocolconfig). Read-only accounts can quote; a quote does not enforce the cap. For auto-resolved routes, the source and destination must differ. The [API reference](/sdk/bridge-modules/bridge-usdt0-evm/api-reference#error-handling) lists representative `error.message` substrings.
 
 ## Catch and branch on error messages
 
@@ -8733,7 +8783,7 @@ The [@tetherto/wdk-protocol-bridge-usdt0-evm](https://www.npmjs.com/package/@tet
 
 <Cards>
 <Card title="Get Started" href="/sdk/bridge-modules/bridge-usdt0-evm/guides/get-started">
-Install the package, attach WalletAccountEvm, and review supported chains.
+Install the package, attach a signing or read-only EVM account, and review supported chains.
 </Card>
 <Card title="Bridge Tokens" href="/sdk/bridge-modules/bridge-usdt0-evm/guides/bridge-tokens">
 EVM-to-EVM bridges, quotes, fee caps, and optional OFT or endpoint overrides.
@@ -18781,12 +18831,13 @@ Use the Morpho lending community module to interact with Morpho Vault V2 earn ta
 
 The module supports curated Ethereum mainnet presets and explicit Morpho target configuration. The package exports `MORPHO_VAULT_PRESETS` and `MORPHO_MARKET_PRESETS`; inspect those maps for the complete preset registry shipped with your installed version.
 
-### Tether-Aligned Presets
+### XAU₮ Borrow Preset
 
 | Operation | Preset | Target |
 |-----------|--------|--------|
-| Earn | `sky-money-usdt-savings` | sky.money USD₮ Savings |
 | Borrow | `xaut` | XAU₮ collateral |
+
+For vault operations, configure an operator-selected target after verifying its underlying asset, share token, collateral exposure, and chain. See [Explicit Targets](/sdk/lending-modules/lending-morpho-evm/configuration#explicit-targets).
 
 ## Wallet Compatibility
 
@@ -18852,11 +18903,12 @@ Example:
 ```javascript
 const morpho = new MorphoProtocolEvm(account, {
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })
 ```
+
+This example configures a borrow market. The vault examples below also require an operator-selected Ethereum mainnet USD₮ vault configured with `earnVaultAddress` and `chainId: 1`; see [Explicit Targets](/sdk/lending-modules/lending-morpho-evm/configuration#explicit-targets).
 
 ### Methods
 
@@ -19254,7 +19306,6 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 const morpho = new MorphoProtocolEvm(account, {
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })
@@ -19275,7 +19326,7 @@ The wallet account must include a provider. Read-only accounts can read position
 
 ## Presets
 
-Built-in presets target Ethereum mainnet USD₮ earn and borrow flows.
+Built-in presets target Ethereum mainnet. The `xaut` borrow preset selects a market with XAU₮ collateral.
 
 The package exports frozen preset maps. Use them as the complete registry for the installed package rather than copying a static list into your integration:
 
@@ -19289,12 +19340,11 @@ console.log(Object.keys(MORPHO_VAULT_PRESETS))
 console.log(Object.keys(MORPHO_MARKET_PRESETS))
 ```
 
-Selected Tether-family presets from version `1.0.5` are shown below. See the package's [released preset source](https://github.com/morpho-org/sdks/blob/15c622bbdfb841d5cd65d1d1ff080ecd1649437a/packages/wdk-protocol-lending-morpho-evm/src/morpho-presets.ts) for the pinned registry.
+The XAU₮ collateral preset from version `1.0.5` is shown below. See the package's [released preset source](https://github.com/morpho-org/sdks/blob/15c622bbdfb841d5cd65d1d1ff080ecd1649437a/packages/wdk-protocol-lending-morpho-evm/src/morpho-presets.ts) for the pinned registry.
 
 ```javascript title="Use built-in presets"
 const morpho = new MorphoProtocolEvm(account, {
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })
@@ -19302,17 +19352,21 @@ const morpho = new MorphoProtocolEvm(account, {
 
 | Operation | Preset | Chain ID | Target ID | Target |
 |-----------|--------|----------|-----------|--------|
-| Earn | `sky-money-usdt-savings` | `1` | `0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11` | sky.money USD₮ Savings |
 | Borrow | `xaut` | `1` | `0xb7843fe78e7e7fd3106a1b939645367967d1f986c2e45edb8932ad1896450877` | XAU₮ collateral, 77% LLTV |
 
 ## Explicit Targets
 
-Use explicit targets when you want to configure a vault address or market directly instead of selecting it by preset name.
+Use explicit targets when you want to configure a vault address or market directly instead of selecting it by preset name. Before using a vault, verify its underlying asset, share token, collateral exposure, and chain against the deployment data. For the USD₮ vault examples, set `MORPHO_EARN_VAULT_ADDRESS` to an operator-selected Ethereum mainnet Morpho Vault V2 address whose underlying asset is USD₮.
 
 ```javascript title="Use explicit Morpho targets"
+const earnVaultAddress = process.env.MORPHO_EARN_VAULT_ADDRESS
+if (!earnVaultAddress) {
+  throw new Error('Set MORPHO_EARN_VAULT_ADDRESS to your verified vault address')
+}
+
 const morpho = new MorphoProtocolEvm(account, {
   chainId: 1,
-  earnVaultAddress: '0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11',
+  earnVaultAddress,
   borrowMarketId: '0xe7e9694b754c4d4f7e21faf7223f6fa71abaeb10296a4c43a54a7977149687d2'
 })
 ```
@@ -19429,6 +19483,8 @@ If you use ERC-4337 smart accounts, also install `@tetherto/wdk-wallet-evm-erc-4
 
 ## Create the lending client
 
+For the vault examples, set `MORPHO_EARN_VAULT_ADDRESS` to an operator-selected Ethereum mainnet Morpho Vault V2 address whose underlying asset is USD₮. Verify the vault’s underlying asset, share token, collateral exposure, and chain before configuring it; see [Explicit Targets](/sdk/lending-modules/lending-morpho-evm/configuration#explicit-targets).
+
 You can attach Morpho actions to an EVM account from [`WalletAccountEvm`](/sdk/wallet-modules/wallet-evm/api-reference) with [`new MorphoProtocolEvm(account, options)`](/sdk/lending-modules/lending-morpho-evm/api-reference):
 
 ```javascript title="Create MorphoProtocolEvm"
@@ -19439,9 +19495,15 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
   provider: 'https://ethereum-rpc.publicnode.com'
 })
 
+const earnVaultAddress = process.env.MORPHO_EARN_VAULT_ADDRESS
+if (!earnVaultAddress) {
+  throw new Error('Set MORPHO_EARN_VAULT_ADDRESS to your verified vault address')
+}
+
 const morpho = new MorphoProtocolEvm(account, {
+  chainId: 1,
+  earnVaultAddress,
   presets: {
-    earn: 'sky-money-usdt-savings',
     borrow: 'xaut'
   }
 })
@@ -22960,7 +23022,7 @@ const result = await orchestra.swidge({
 
 | Field | Type | Description |
 |---|---|---|
-| `fromToken` | `string` | Source token, preferably chain-qualified such as `spark:BTC` or `bsc:USDT`. |
+| `fromToken` | `string` | Source token, preferably chain-qualified such as `spark:BTC` or `tron:USDT`. |
 | `toToken` | `string` | Destination token, preferably chain-qualified. |
 | `fromChain` | `string \| number` | Optional source-chain override. |
 | `toChain` | `string \| number` | Optional destination-chain override. |
@@ -23517,7 +23579,7 @@ const tokens = await orchestra.getSupportedTokens({
 })
 ```
 
-Use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, `bsc:USDT`, or `tron:USDT`.
+Use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, or `tron:USDT`.
 
 ## Quotes
 
@@ -23586,29 +23648,9 @@ const intent = await orchestra.prepareSwap({
 })
 ```
 
-### EVM USD₮ to Spark BTC
+### EVM token sources
 
-EVM token sources use the WDK account's `transfer({ token, recipient, amount })` path. The source account needs native gas for its chain.
-
-```javascript title="Prepare BSC USDt to Spark BTC"
-const bsc = await wdk.getAccount('bsc', 0)
-const spark = await wdk.getAccount('spark', 0)
-
-const orchestra = new Orchestra(bsc, {
-  sourceChain: 'bsc',
-  apiKey: process.env.FLASHNET_API_KEY,
-  sourceTokenAddresses: {
-    'bsc:USDT': '0x55d398326f99059ff775485246999027b3197955'
-  }
-})
-
-const intent = await orchestra.prepareSwap({
-  fromToken: 'bsc:USDT',
-  toToken: 'spark:BTC',
-  fromTokenAmount: 5000000n,
-  recipient: await spark.getAddress()
-})
-```
+EVM token sources use the WDK account's `transfer({ token, recipient, amount })` path. The source account needs native gas for its chain. Select a route from discovery and verify the source token contract and decimals before setting `sourceTokenAddresses` and an amount in base units.
 
 ### Bitcoin L1 source
 
@@ -23641,17 +23683,6 @@ const submitted = await orchestra.executeSwapIntent(intent, {
 ### Destination Lightning
 
 Orchestra supports destination Lightning routes where the live route matrix exposes them. Pass a BOLT11 invoice or Lightning Address as `recipient`, and include refund metadata required by the route.
-
-```javascript title="Prepare USDt to destination Lightning"
-const intent = await orchestra.prepareSwap({
-  fromToken: 'bsc:USDT',
-  toToken: 'lightning:BTC',
-  fromTokenAmount: 5000000n,
-  recipient: bolt11Invoice,
-  refundChain: 'bsc',
-  refundAddress: await bsc.getAddress()
-})
-```
 
 Lightning as a source is not supported through this package's standard `swidge()` or `executeSwapIntent()` flow.
 
@@ -23848,7 +23879,7 @@ console.log(chains)
 console.log(sparkToTronTokens)
 ```
 
-The returned token identifiers use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, `bsc:USDT`, or `tron:USDT`. Use the values returned by discovery when building UI route options.
+The returned token identifiers use chain-qualified asset references such as `spark:BTC`, `bitcoin:BTC`, or `tron:USDT`. Use the values returned by discovery when building UI route options.
 
 ## Quote before execution
 
@@ -28729,6 +28760,7 @@ It handles EIP-7702 authorization, UserOperation construction, UserOperation sig
 - **EOA-based EIP-7702 accounts**: `getAddress()` returns the EOA address. The account delegates execution to the configured `delegationAddress` when needed.
 - **Sponsored transactions**: Set `isSponsored: true` to use a sponsorship policy. Quotes return a zero fee in sponsored mode.
 - **Paymaster-token transactions**: Configure `paymasterToken` to pay UserOperation costs in an ERC-20 token.
+- **EntryPoint selection**: Use v0.8 by default or select v0.9 with a matching delegation implementation, bundler, and paymaster. See [configuration](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version).
 - **Provider failover**: Pass one provider or an ordered list of RPC URLs / EIP-1193 providers. Provider arrays support `retries`.
 - **UserOperation finality**: Track a UserOperation from bundler acceptance through its EVM transaction's confirmed or final state with `getTransaction()` and `waitForTransaction()`.
 - **Non-broadcasting UserOperation signing**: Build and sign a self-contained `UserOperationV8` without submitting it, then quote or send that operation separately. Construction still uses the configured provider, bundler, and paymaster services.
@@ -28743,7 +28775,7 @@ This module depends on EVM infrastructure that supports both EIP-7702 account de
 - an RPC provider for a chain where the EIP-7702 flow is available;
 - an ERC-4337 bundler URL;
 - a paymaster endpoint, either the same as `bundlerUrl` or a separate `paymasterUrl`;
-- a trusted smart-account implementation address for `delegationAddress`;
+- a trusted smart-account implementation address for `delegationAddress`, built for the configured EntryPoint version;
 - either a sponsorship policy or an ERC-20 paymaster token configuration.
 
 <Callout type="warn">
@@ -28889,6 +28921,7 @@ Treat the arrays returned through `keyPair` as read-only. Call `dispose()` when 
 
 ### Quote and Send Behavior
 
+- Owned-account quotes, signing, and sends check the configured `chainId` before proceeding, including sponsored quotes and already-signed inputs. The first successful check is cached; see [chain validation](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#chain-validation).
 - Sponsored mode returns `fee: 0n` from quote methods.
 - Paymaster-token mode returns fees in the configured paymaster token's base units.
 - `signTransaction()` returns a signed `UserOperationV8` without broadcasting it. The type comes from `abstractionkit` and is not re-exported from this package's root.
@@ -28906,7 +28939,7 @@ Treat the arrays returned through `keyPair` as read-only. Call `dispose()` when 
 - A string `nonceKey` is hashed to a deterministic 192-bit key. Numeric keys must be within the uint192 range; use bigint or string form above JavaScript's safe integer range.
 - Let the first delegation reach the chain before using concurrent lanes. Overlapping operations on the same lane can return hashes even when one can never receive a receipt.
 - A fresh `parallel` lane creates a permanent EntryPoint nonce slot. Reuse a bounded set of named lanes for sustained workloads.
-- The runtime accepts lane fields in per-call overrides for signing, sending, and transfers, but the beta.4 second-argument declarations omit them. Constructor-level lane fields are correctly typed.
+- The runtime accepts lane fields in per-call overrides for signing, sending, and transfers, but the beta.5 second-argument declarations omit them. Constructor-level lane fields are correctly typed.
 
 ### Transfer Fee Cap
 
@@ -28975,6 +29008,8 @@ Known configuration errors include:
 - missing `delegationAddress`;
 - missing `paymasterToken` when `isSponsored` is absent or `false`;
 - empty provider array;
+- unsupported `entryPointVersion` or a reference delegation address paired with the wrong version;
+- the provider chain differs from configured `chainId` during the first UserOperation chain lookup;
 - configured `paymasterAddress` does not match the paymaster returned by the RPC.
 
 ## Config Types
@@ -28984,10 +29019,12 @@ Known configuration errors include:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `provider` | `string \| Eip1193Provider \| Array\<string \| Eip1193Provider\>` | Yes | RPC endpoint, EIP-1193 provider, or provider failover list. |
+| `chainId` | `number` | No | Expected chain ID for the first UserOperation chain lookup. A successful check is cached; omission trusts the provider. |
+| `entryPointVersion` | `'0.8' \| '0.9'` | No | Selects the EntryPoint and matching account implementation. Defaults to `'0.8'`. |
 | `retries` | `number` | No | Additional retry attempts for provider arrays. Defaults to `3`. |
 | `bundlerUrl` | `string` | Yes | ERC-4337 bundler endpoint. |
 | `paymasterUrl` | `string` | No | Paymaster endpoint when different from `bundlerUrl`. |
-| `delegationAddress` | `string` | Yes | Smart-account implementation address used for EIP-7702 delegation. |
+| `delegationAddress` | `string` | Yes | Smart-account implementation address built for the configured `entryPointVersion`. |
 | `parallel` | `boolean` | No | Uses a fresh random nonce lane for each sign, send, or transfer operation unless `nonceKey` is set. |
 | `nonceKey` | `number \| bigint \| string` | No | Uses a reusable explicit uint192 nonce lane; strings are hashed deterministically. |
 
@@ -29020,7 +29057,7 @@ type Evm7702GaslessWalletConfig =
 
 The package also re-exports EVM wallet types from `@tetherto/wdk-wallet-evm`, including `FeeRates`, `KeyPair`, `EvmTransaction`, `TransactionResult`, `EvmTransferOptions`, `TransferResult`, `EvmTransactionReceipt`, `ApproveOptions`, `TypedData`, `TypedDataDomain`, and `TypedDataField`. It re-exports the shared `Finality`, `TransactionReceipt`, `WaitForTransactionTarget`, and `WaitForTransactionOptions` types from `@tetherto/wdk-wallet`.
 
-Module-specific exported types include `UserOperationReceipt`, `Evm7702GaslessTransactionDetails`, `Eip7702AuthorizationOverride`, `BuildSponsoredUserOperationOverrides`, and `SponsoredUserOperation`. `Evm7702GaslessTransactionDetails` adds `confirmations`, the native EVM `receipt`, and `userOperationReceipt` to the normalized receipt. In beta.4, `BuildSponsoredUserOperationOverrides` includes optional `nonce?: bigint` for explicitly selecting the EntryPoint nonce in lower-level builder typing; it does not expose the protected builder as a public method.
+Module-specific exported types include `UserOperationReceipt`, `Evm7702GaslessTransactionDetails`, `Eip7702AuthorizationOverride`, `BuildSponsoredUserOperationOverrides`, and `SponsoredUserOperation`. `Evm7702GaslessTransactionDetails` adds `confirmations`, the native EVM `receipt`, and `userOperationReceipt` to the normalized receipt. In beta.5, `BuildSponsoredUserOperationOverrides` includes optional `nonce?: bigint` for explicitly selecting the EntryPoint nonce in lower-level builder typing; it does not expose the protected builder as a public method.
 
 ***
 
@@ -29033,7 +29070,7 @@ Description: Configuration options for @tetherto/wdk-wallet-evm-7702-gasless.
 `WalletManagerEvm7702Gasless`, `WalletAccountEvm7702Gasless`, and `WalletAccountReadOnlyEvm7702Gasless` use the same base configuration. The account must also choose one fee mode: sponsorship policy or paymaster token.
 
 <Callout type="warn">
-Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain. The EOA delegates execution to this address.
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain and configured `entryPointVersion`. The EOA delegates execution to this address.
 </Callout>
 
 ```javascript title="Sponsored wallet configuration"
@@ -29068,7 +29105,7 @@ const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
 |-------|------|-------------|
 | `provider` | `string \| Eip1193Provider \| Array\<string \| Eip1193Provider\>` | RPC endpoint, EIP-1193 provider, or ordered failover list. |
 | `bundlerUrl` | `string` | ERC-4337 bundler endpoint used to build and submit UserOperations. |
-| `delegationAddress` | `string` | Smart-account implementation address used for EIP-7702 delegation. |
+| `delegationAddress` | `string` | Smart-account implementation address built for the configured `entryPointVersion`, used for EIP-7702 delegation. |
 
 Account constructors and per-call config overrides throw `ConfigurationError` if any required common field is missing.
 
@@ -29076,10 +29113,33 @@ Account constructors and per-call config overrides throw `ConfigurationError` if
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `chainId` | `number` | Provider-reported chain | Expected chain ID, checked before building or signing UserOperations. See [chain validation](#chain-validation) for caching and quote behavior. |
+| `entryPointVersion` | `'0.8' \| '0.9'` | `'0.8'` | Selects the EntryPoint address and matching account implementation for construction and signing. |
 | `paymasterUrl` | `string` | `bundlerUrl` | Paymaster endpoint when it differs from the bundler endpoint. |
 | `retries` | `number` | `3` | Additional retry attempts when `provider` is an array. Total attempts are `1 + retries`. |
 | `parallel` | `boolean` | `false` | Use a fresh random EntryPoint nonce lane for each sign, send, or transfer operation. Ignored when `nonceKey` is set. |
 | `nonceKey` | `number \| bigint \| string` | - | Use a reusable explicit nonce lane. Strings are hashed to a deterministic key; numeric keys must fit the uint192 range. |
+
+### EntryPoint Version
+
+Set `entryPointVersion` in the constructor to match your bundler, paymaster, and delegation implementation. Omitting it preserves EntryPoint v0.8. The selected version controls UserOperation construction, the signing domain, nonce lookup, submission, and paymaster-token queries.
+
+| `entryPointVersion` | EntryPoint address | Reference `delegationAddress` |
+|---------------------|--------------------|-------------------------------|
+| `'0.8'` (default) | `0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108` | `0xe6Cae83BdE06E4c305530e199D7217f42808555B` |
+| `'0.9'` | `0x433709009B8330FDa32311DF1C2AFA402eD8D009` | `0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5` |
+
+<Callout type="warn">
+Verify that the selected contracts are deployed on your target chain. Account creation rejects an unsupported version or a reference delegation address paired with the other version. Custom delegation addresses are accepted without verifying their EntryPoint compatibility; verify their implementation before use.
+</Callout>
+
+Configure `entryPointVersion` and `chainId` when creating the account. Per-call fee-mode overrides do not switch the account's chain or EntryPoint.
+
+### Chain Validation
+
+Set `chainId` to the expected network, for example `chainId: 1` for Ethereum mainnet. The first UserOperation chain lookup calls `eth_chainId` and throws `ConfigurationError` on a mismatch before building or signing. Owned-account quotes and sends perform this lookup too, including sponsored quotes and already-signed inputs. A read-only sponsored quote returns `0n` without checking the chain.
+
+The account caches a successful lookup. It does not detect a later network switch, so keep all failover providers on the same chain and recreate the wallet or account when changing networks. Omitting `chainId` trusts the provider-reported chain. This check does not verify the chain or EntryPoint encoded in an externally signed operation.
 
 ### Provider Failover
 
@@ -29222,7 +29282,7 @@ const result = await account.sendTransaction(tx, feeConfig)
 
 When an override is provided, the merged config is validated before the operation runs. `confirmFeeTokenAndAmount()` represents the application's explicit review of the changed fee token and quoted amount; the quote itself does not enforce `transactionMaxFee`, while the wallet-built send does.
 
-The beta.4 JavaScript runtime also reads `parallel` and `nonceKey` from per-call overrides for `signTransaction()`, `sendTransaction()`, and `transfer()`. The published second-argument TypeScript declarations include only fee-mode fields, so constructor-level lane configuration is the typed path in this release.
+The beta.5 JavaScript runtime also reads `parallel` and `nonceKey` from per-call overrides for `signTransaction()`, `sendTransaction()`, and `transfer()`. The published second-argument TypeScript declarations include only fee-mode fields, so constructor-level lane configuration is the typed path in this release.
 
 <Callout type="info">
 The two-minute quote cache key includes the transaction, sponsorship mode, paymaster token, expected paymaster address, and sponsorship policy ID. A matching operation also rechecks the current EntryPoint nonce before reuse. Changing any keyed fee-mode field causes a fresh quote.
@@ -29311,7 +29371,7 @@ npm install @tetherto/wdk-wallet-evm-7702-gasless
 ## Create a Sponsored Wallet
 
 <Callout type="warn">
-Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain. The EOA delegates execution to this address.
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain and EntryPoint v0.8, the default. To use v0.9, configure a [matching EntryPoint and delegation implementation](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version). The EOA delegates execution to this address.
 </Callout>
 
 ```javascript title="Create a sponsored EIP-7702 gasless wallet"
@@ -29319,6 +29379,7 @@ import WalletManagerEvm7702Gasless from '@tetherto/wdk-wallet-evm-7702-gasless'
 
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
+  chainId: 1,
   delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   isSponsored: true,
@@ -29340,6 +29401,7 @@ If the user pays gas with an ERC-20 paymaster token, configure `paymasterToken` 
 ```javascript title="Create a paymaster-token wallet"
 const wallet = new WalletManagerEvm7702Gasless(seedPhrase, {
   provider: 'https://rpc.mevblocker.io/fast',
+  chainId: 1,
   delegationAddress: '<VERIFIED_DELEGATION_ADDRESS>',
   bundlerUrl: 'https://api.pimlico.io/v2/1/rpc?apikey=YOUR_KEY',
   paymasterToken: {
@@ -29395,7 +29457,7 @@ try {
 }
 ```
 
-Common configuration errors include missing `provider`, `bundlerUrl`, `delegationAddress`, or `paymasterToken` when the account is not sponsored.
+Common configuration errors include missing `provider`, `bundlerUrl`, `delegationAddress`, or `paymasterToken` when the account is not sponsored. An unsupported `entryPointVersion` or a reference delegation address paired with the wrong version also fails account creation. A provider-chain mismatch throws when a UserOperation flow first checks `chainId`; review [chain validation](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#chain-validation) before retrying.
 
 ## Paymaster Token Errors
 
@@ -29549,7 +29611,7 @@ Read-only accounts do not expose `sign()`, `signTypedData()`, `signTransaction()
 
 ## Create a Read-only Account from an Address
 
-Use the verified EIP-7702 implementation address for the target chain. The placeholder below must be replaced before use.
+Use an EIP-7702 implementation address verified for the target chain and the [configured EntryPoint version](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version). The placeholder below must be replaced before use.
 
 ```javascript title="Read-only account from address"
 import { WalletAccountReadOnlyEvm7702Gasless } from '@tetherto/wdk-wallet-evm-7702-gasless'
@@ -29668,7 +29730,7 @@ console.log('Signed operation fee:', quote.fee)
 const result = await account.sendTransaction(signedUserOperation)
 ```
 
-Quoting a signed UserOperation avoids paymaster calls. Sponsorship mode returns `fee: 0n`; paymaster-token mode derives a native-gas ceiling in wei from the operation's existing gas fields rather than returning the token amount fixed when the operation was built. Sending broadcasts the supplied nonce, authorization, gas fields, and signature without rebuilding the operation or requesting another signature.
+Quoting a signed UserOperation avoids paymaster calls. Sponsorship mode returns `fee: 0n`; paymaster-token mode derives a native-gas ceiling in wei from the operation's existing gas fields rather than returning the token amount fixed when the operation was built. Sending broadcasts the supplied nonce, authorization, gas fields, and signature without rebuilding the operation or requesting another signature. Both quoting and sending still perform the account's [cached chain check](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#chain-validation). The check validates the RPC chain, not the signed payload; submission uses the account's configured EntryPoint.
 
 <Callout type="warn">
 `sendTransaction(signedUserOperation)` does not enforce `transactionMaxFee`: the module cannot reconstruct the token-denominated paymaster fee from an already-signed operation. Apply the cap while this wallet builds or signs the operation, and independently review signed operations received from elsewhere.
@@ -29749,7 +29811,7 @@ await account.sendTransaction(scheduledPayment, { nonceKey: 'scheduled-payments'
 `nonceKey` takes precedence over `parallel`. String keys are hashed into deterministic 192-bit lane keys. A number or bigint is used as the raw key and must be between `0` and `2^192 - 1`; use a bigint or string above JavaScript's safe integer range.
 
 <Callout type="warning">
-The beta.4 runtime accepts per-call `parallel` and `nonceKey`, but the published second-argument declarations omit those common fields. TypeScript object literals using the per-call form fail type checking. Configure lanes on the wallet or account constructor for typed code, or isolate an explicit local type workaround until the package declarations are corrected.
+The beta.5 runtime accepts per-call `parallel` and `nonceKey`, but the published second-argument declarations omit those common fields. TypeScript object literals using the per-call form fail type checking. Configure lanes on the wallet or account constructor for typed code, or isolate an explicit local type workaround until the package declarations are corrected.
 </Callout>
 
 Use nonce lanes with these constraints:
@@ -29893,7 +29955,7 @@ In paymaster-token mode, set `transferMaxFee` to cancel `transfer()` when the es
 This comparison is intentionally stricter than `transactionMaxFee`: a transfer fee equal to `transferMaxFee` is rejected, while an equal send/sign/approve fee is allowed by `transactionMaxFee`.
 
 <Callout type="warn">
-Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain.
+Replace `'<VERIFIED_DELEGATION_ADDRESS>'` with a smart-account implementation address that you have verified for the target chain and the [configured EntryPoint version](/sdk/wallet-modules/wallet-evm-7702-gasless/configuration#entrypoint-version).
 </Callout>
 
 ```javascript title="Cap transfer fee"
@@ -29972,7 +30034,7 @@ Get started with WDK in a Node.js environment.
 Compare WDK wallet modules across supported chains.
 </Card>
 <Card title="Configuration" href="/sdk/wallet-modules/wallet-evm-7702-gasless/configuration">
-Review fee modes, providers, nonce lanes, and per-call overrides.
+Review fee modes, providers, chain validation, EntryPoint versions, and nonce lanes.
 </Card>
 <Card title="API Reference" href="/sdk/wallet-modules/wallet-evm-7702-gasless/api-reference">
 Review classes, methods, config types, and return values.
@@ -30086,7 +30148,7 @@ new WalletManagerEvmErc4337(seed, config)
   - `chainId` (number): The blockchain's ID (e.g., 1 for Ethereum mainnet)
   - `provider` (string | Eip1193Provider | Array\<string | Eip1193Provider\>): RPC endpoint URL, EIP-1193 provider instance, or ordered failover list
   - `bundlerUrl` (string): The URL of the bundler service
-  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.17
+  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.18
 
 **Optional common config fields:**
   - `parallel` (boolean): Put each send, sign, or transfer in a fresh random 192-bit nonce-key lane
@@ -30424,7 +30486,7 @@ Sends a transaction via UserOperation through the bundler.
 - `ConfigurationError` if the override is invalid or the token paymaster address returned while building mismatches the configured address.
 - `TransactionError` with `reason: TransactionErrorReason.INSUFFICIENT_BALANCE` if the paymaster reports AA50 while building or submitting the operation.
 
-When `tx` is a signed `UserOperationV7`, WDK forwards that exact operation to the bundler. It does not rebuild or re-sign it, reapply the current `transactionMaxFee`, call the paymaster RPC, or rerun the paymaster-address check. Only submit an operation produced by the same account after verifying the intended fee-mode and paymaster configuration, and submit it before its nonce becomes stale.
+When `tx` is a signed `UserOperationV7`, WDK forwards that exact operation to the bundler without checking the provider against `chainId`. It does not rebuild or re-sign it, reapply the current `transactionMaxFee`, call the paymaster RPC, or rerun the paymaster-address check. Only submit an operation produced by the same account after verifying the intended chain, EntryPoint, fee-mode, and paymaster configuration, and submit it before its nonce becomes stale.
 
 **Example:**
 ```javascript
@@ -30910,7 +30972,6 @@ const sameAddress = WalletAccountEvmErc4337.predictSafeAddress(
 | `getTransaction(hash)` | Returns normalized UserOperation finality using its bundling transaction | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the hash is invalid or unknown |
 | `waitForTransaction(hash, options?)` | Waits for the UserOperation to reach `confirmed` or `final`, or returns `dropped` | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the wait times out |
 | `getUserOperationReceipt(hash)` | Returns a UserOperation receipt | `Promise\<UserOperationReceipt \| null\>` | - |
-| `signTypedData(typedData)` | Signs EIP-712 typed structured data | `Promise\<string\>` | - |
 | `verifyTypedData(typedData, signature)` | Verifies an EIP-712 typed data signature | `Promise\<boolean\>` | - |
 | `getTokenBalances(tokenAddresses)` | Returns balances for multiple ERC20 tokens | `Promise\<Record\<string, bigint\>\>` | - |
 
@@ -31091,40 +31152,6 @@ if (receipt) {
 }
 ```
 
-##### `signTypedData(typedData)`
-Signs EIP-712 typed structured data using the underlying EOA address.
-
-**Parameters:**
-- `typedData` (TypedData): The typed data object containing domain, types, primaryType, and message
-
-**Returns:** `Promise\<string\>` - The typed data signature
-
-**Example:**
-```javascript
-const typedData = {
-  domain: {
-    name: 'MyDApp',
-    version: '1',
-    chainId: 1,
-    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
-  },
-  types: {
-    Transfer: [
-      { name: 'to', type: 'address' },
-      { name: 'amount', type: 'uint256' }
-    ]
-  },
-  primaryType: 'Transfer',
-  message: {
-    to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
-    amount: 1000000n
-  }
-}
-
-const signature = await readOnlyAccount.signTypedData(typedData)
-console.log('Typed data signature:', signature)
-```
-
 ##### `verifyTypedData(typedData, signature)`
 Verifies an EIP-712 typed data signature against the underlying EOA address.
 
@@ -31193,6 +31220,8 @@ The package re-exports these types.
 
 ### EvmErc4337WalletConfig
 
+The constructor's `chainId` is checked against the provider's first `eth_chainId` response before building a UserOperation. A mismatch throws `ConfigurationError`; a successful lookup is cached. Sponsored quotes and already-signed operation quote/send paths do not perform this check. See [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id).
+
 The configuration is a union type combining common fields with one of three gas payment modes:
 
 ```typescript
@@ -31201,7 +31230,7 @@ interface EvmErc4337WalletCommonConfig {
   chainId: number;                          // Blockchain ID
   provider: string | Eip1193Provider | Array<string | Eip1193Provider>; // RPC provider or failover list
   bundlerUrl: string;                       // Bundler service URL
-  safeModulesVersion: string;               // Must be '0.3.0' in beta.17
+  safeModulesVersion: string;               // Must be '0.3.0' in beta.18
   parallel?: boolean;                       // Fresh random nonce-key lane per operation
   nonceKey?: number | bigint | string;      // Reusable raw or named uint192 lane key
 }
@@ -31242,7 +31271,7 @@ type EvmErc4337WalletConfig = EvmErc4337WalletCommonConfig &
 
 ### Config Override
 
-The published beta.17 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
+The published beta.18 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
 
 ```typescript
 type ConfigOverride = Partial<
@@ -31264,7 +31293,7 @@ type ConfigOverride = Partial<
 
 Overrides are shallow-merged with the account configuration, then validated. When switching modes, explicitly clear an inherited opposing flag: sponsorship requires `isSponsored: true` and `useNativeCoins: false`; native-coin mode requires `isSponsored: false` and `useNativeCoins: true`; paymaster-token mode requires both flags to be `false`. The merged configuration must also contain the URL, address, token, or policy fields required by the selected mode.
 
-At runtime, beta.17 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
+At runtime, beta.18 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
 
 In token-paymaster mode, every path that builds a UserOperation validates a non-empty paymaster address returned by the RPC against `paymasterAddress`. A case-insensitive mismatch throws `ConfigurationError` before the operation is returned or submitted.
 
@@ -31406,7 +31435,7 @@ class ConfigurationError extends ValueError {
 }
 ```
 
-`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`.
+`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`. It also reports a mismatch between the constructor's `chainId` and the provider during the first UserOperation chain lookup.
 
 ### FeeRates
 
@@ -31529,7 +31558,13 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
 
 ### Chain ID
 
-The `chainId` option specifies the blockchain network ID. **Required** for fee estimation and smart account initialization.
+The `chainId` option specifies the expected blockchain network ID. **Required** for fee estimation and smart account initialization.
+
+Before building a new UserOperation, the account reads `eth_chainId` from the provider and throws `ConfigurationError` if it differs from the constructor's `chainId`. The check happens before smart-account construction and UserOperation signing. This includes non-sponsored quotes that build an operation.
+
+The first successful chain lookup is cached. Keep all failover providers on the configured chain and recreate the wallet or account when switching networks. Per-call fee-mode overrides do not change the chain being checked.
+
+Sponsored quotes return `0n` without checking the chain. Quoting or submitting an already-signed UserOperation also bypasses this check. Verify that a signed operation was built for the intended account, chain, EntryPoint, and paymaster before forwarding it.
 
 **Type:** `number`
 **Required:** Yes
@@ -31706,12 +31741,12 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, config)
 Reusing one named lane remains sequential: wait for inclusion before submitting its next operation, or batch dependent calls into one UserOperation.
 
 <Callout type="warning">
-The beta.17 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
+The beta.18 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
 </Callout>
 
 ### Safe Modules Version
 
-The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.17 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
+The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.18 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
 
 **Type:** `string`
 **Required:** Yes
@@ -31954,7 +31989,17 @@ const plasmaConfig = {
 
 ### Sepolia Testnet (USD₮ ERC-20 mock/testnet only)
 
+Choose a six-decimal USD₮ test token supported by each paymaster on chain `11155111`. Get its address from that provider's current faucet or supported-token response, verify its contract and decimals on Sepolia, and set the corresponding environment variable below. The two providers may support different test-token contracts.
+
 ````javascript
+
+const pimlicoTestTokenAddress = process.env.PIMLICO_SEPOLIA_TEST_TOKEN_ADDRESS
+const candideTestTokenAddress = process.env.CANDIDE_SEPOLIA_TEST_TOKEN_ADDRESS
+for (const address of [pimlicoTestTokenAddress, candideTestTokenAddress]) {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(address ?? '')) {
+    throw new Error('Set both verified Sepolia test-token addresses')
+  }
+}
 
 // Pimlico
 const sepoliaConfigPimlico = {
@@ -31965,7 +32010,7 @@ const sepoliaConfigPimlico = {
   paymasterAddress: '0x777777777777AeC03fd955926DbF81597e66834C',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDt Sepolia
+    address: pimlicoTestTokenAddress
   },
   transferMaxFee: 100000 // 0.1 USDt (6 decimals)
 }
@@ -31979,7 +32024,7 @@ const sepoliaConfigCandide = {
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
   safeModulesVersion: '0.3.0',
   paymasterToken: {
-    address: '0xd077a400968890eacc75cdc901f0356c943e4fdb' // USDt Sepolia
+    address: candideTestTokenAddress
   },
   transferMaxFee: 100000
 }
@@ -31987,8 +32032,6 @@ const sepoliaConfigCandide = {
 
 **Important**
 Ethereum Sepolia is a testnet. The USD₮ tokens available at the links below are not real and do not entitle the holder to anything. In particular, they cannot be redeemed with Tether International, S.A. de C.V. ("Tether International") and are not Tether Tokens as described in [Tether International's Terms of Service](https://tether.to/en/legal). The USD₮ tokens available at the links below on this testnet are intended for testing WDK on Ethereum Sepolia. The links below are links to third-party websites and are Third-Party Information as described in Tether Operations, S.A. de [C.V.'s Website Terms](https://tether.io/terms/)
-
-**USD₮ on Sepolia contract:** [0xd077a400968890eacc75cdc901f0356c943e4fdb](https://sepolia.etherscan.io/address/0xd077a400968890eacc75cdc901f0356c943e4fdb)
 
 **Get test USD₮:**
 - [Pimlico faucet](https://dashboard.pimlico.io/test-erc20-faucet)
@@ -32063,12 +32106,12 @@ console.log('Paymaster token balance:', paymasterBalance)
 ```
 
 <Callout type="info">
-The paymaster token balance determines how many gasless transactions you can execute. Ensure the paymaster has sufficient token balance before initiating gasless operations.
+The paymaster token balance is held by the Safe account. Fund the Safe with enough of the configured token to repay the paymaster before initiating token-paid operations.
 </Callout>
 
 ## Read-Only Account Balances
 
-You can check balances for any smart account address without a seed phrase using [`WalletAccountReadOnlyEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
+You can check balances without a seed phrase by passing the owner EOA address to [`WalletAccountReadOnlyEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference). The module predicts the Safe address from that owner and the configuration:
 
 ```javascript title="Read-Only Balance"
 import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -32142,6 +32185,8 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
 To use test/mock tokens instead of real funds, see the [testnet configuration section](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#network-specific-configurations).
 </Callout>
 
+The provider must serve the configured `chainId`. A mismatch throws when the account first builds a UserOperation; account creation alone does not establish that the provider matches. Review [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id) before sending.
+
 ## 3. Get Your First Account
 
 You can retrieve a smart account at a given index using [`wallet.getAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
@@ -32170,7 +32215,7 @@ With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modu
 URL: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors
 Description: Handle errors, manage fees, and dispose of sensitive data.
 
-This guide explains how to [handle transaction errors](#transaction-errors), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), and follow [best practices](#best-practices) for fee management and memory cleanup.
+This guide explains how to [handle transaction errors](#transaction-errors), [correct a provider-chain mismatch](#provider-chain-mismatches), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), and follow [best practices](#best-practices) for fee management and memory cleanup.
 
 ## Transaction Errors
 
@@ -32200,6 +32245,12 @@ try {
   }
 }
 ```
+
+## Provider-Chain Mismatches
+
+When a new UserOperation is built, a provider that reports a different chain from the configured `chainId` throws [`ConfigurationError`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#configurationerror) before the operation is built or signed. Confirm the intended network and correct the RPC endpoint or constructor configuration before retrying.
+
+The first successful lookup is cached. Recreate the wallet or account when switching networks, and keep every failover provider on the same chain. A sponsored quote or an already-signed operation does not perform this check; see [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id).
 
 ## Transfer Errors
 
@@ -32235,7 +32286,7 @@ try {
 
 Starting in `v1.0.0-beta.15`, the shared UserOperation builder checks the configured `paymasterAddress` against a non-empty paymaster address returned by the RPC in token-paymaster mode. A case-insensitive mismatch throws the exported `ConfigurationError` before that newly built operation is returned or submitted. The error message identifies the configured address, the `paymasterUrl`, and the returned address.
 
-In beta.17, `ConfigurationError` extends `ValueError`, so a shared `ValueError` handler can catch it. Check `ConfigurationError` first when the application needs the package-specific recovery path below. Constructing a wallet with an empty provider list also throws `ValueError`; provider-required operations such as `getFeeRates()` use `ProviderRequiredError`.
+In beta.18, `ConfigurationError` extends `ValueError`, so a shared `ValueError` handler can catch it. Check `ConfigurationError` first when the application needs the package-specific recovery path below. Constructing a wallet with an empty provider list also throws `ValueError`; provider-required operations such as `getFeeRates()` use `ProviderRequiredError`.
 
 ```javascript title="Handle a Paymaster Address Mismatch"
 import { ConfigurationError } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -32404,7 +32455,7 @@ console.log('Estimated fee:', quote.fee)
 
 ## Sign, Quote, and Submit a UserOperation
 
-Use `signTransaction()` when a separate review or relay step needs a signed ERC-4337 v0.7 UserOperation. The method accepts one transaction, not a batch.
+Use `signTransaction()` when a separate review or relay step needs a signed ERC-4337 v0.7 UserOperation. The method accepts one transaction, not a batch. Building a new operation checks the provider against the configured `chainId`; see [chain validation](/sdk/wallet-modules/wallet-evm-erc-4337/configuration#chain-id).
 
 ```javascript title="Sign, Quote, and Submit"
 const tx = {
@@ -32423,6 +32474,8 @@ console.log('UserOperation hash:', result.hash)
 <Callout type="warning">
 Only submit an operation produced by the same account with the intended fee-mode configuration. WDK preserves the signed nonce and configuration, does not rebuild or re-sign the operation, and does not reapply `transactionMaxFee` during signed submission. Do not mutate the operation, and submit it before its nonce becomes stale.
 </Callout>
+
+Quoting and forwarding an already-signed UserOperation skip the provider-chain check. Verify its account, chain, EntryPoint, and paymaster configuration before submission.
 
 For signed UserOperations, sponsored mode quotes `0n`. Other modes quote a 20% buffered native-gas ceiling in wei. In paymaster-token mode, that signed-operation quote is not a token-denominated paymaster charge.
 
@@ -32496,7 +32549,7 @@ const refunds = await account.sendTransaction(txB, { nonceKey: 'refunds' })
 One lane is still sequential. Two concurrent sends using the same named or default lane can return UserOperation hashes even though one never receives a receipt. Wait for inclusion before reusing a lane. If calls depend on one another, batch them with `sendTransaction([tx1, tx2])` so they execute in order under one nonce. Different lanes are independent and can be included in either order.
 </Callout>
 
-`signTransaction()` preserves the lane chosen by the same configuration rules. In beta.17, per-call `parallel` and `nonceKey` work at runtime but are missing from the published per-call TypeScript declarations; construction-level lane configuration is typed.
+`signTransaction()` preserves the lane chosen by the same configuration rules. In beta.18, per-call `parallel` and `nonceKey` work at runtime but are missing from the published per-call TypeScript declarations; construction-level lane configuration is typed.
 
 ## Send with Custom Paymaster Token
 
@@ -32649,7 +32702,7 @@ If the estimated fee exceeds `transferMaxFee`, the transfer throws `MaximumFeeEx
 
 ## Transfer in a Nonce Lane
 
-`transfer()` follows the same beta.17 nonce-lane rules as sends. Use a stable named lane for an independent transfer stream, and wait for inclusion before reusing that lane:
+`transfer()` follows the same beta.18 nonce-lane rules as sends. Use a stable named lane for an independent transfer stream, and wait for inclusion before reusing that lane:
 
 ```javascript title="Transfer In A Named Lane"
 const result = await account.transfer({
@@ -32661,7 +32714,7 @@ const result = await account.transfer({
 })
 ```
 
-`quoteTransfer()` estimates the transfer but does not select or reserve a lane. A lane transfer rebuilds its UserOperation. The beta.17 runtime accepts lane fields per call, while the published per-call TypeScript declaration omits them; see [Use Parallel Nonce Lanes](/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions#use-parallel-nonce-lanes).
+`quoteTransfer()` estimates the transfer but does not select or reserve a lane. A lane transfer rebuilds its UserOperation. The beta.18 runtime accepts lane fields per call, while the published per-call TypeScript declaration omits them; see [Use Parallel Nonce Lanes](/sdk/wallet-modules/wallet-evm-erc-4337/guides/send-transactions#use-parallel-nonce-lanes).
 
 ## Transfer with UserOperation Gas Overrides
 
@@ -47589,9 +47642,18 @@ import { bundle } from './.wdk'
 
 Create a configuration file for your WDK setup (e.g., `src/config/wdk.ts`):
 
+Set `EXPO_PUBLIC_SEPOLIA_TEST_TOKEN_ADDRESS` to a six-decimal USD₮ test token currently supported by your configured paymaster on Sepolia. Verify the address, decimals, and paymaster support through the provider's faucet and Sepolia deployment data. The address is public configuration. Use the same value in the wallet configuration and asset used for transfers.
+
+The example uses [Expo CLI environment-variable loading](https://docs.expo.dev/guides/environment-variables/). For a bare React Native app, obtain the address through your existing public-config mechanism or replace the exported constant's value with the verified address; installing Expo modules alone does not load this environment variable.
+
 ```typescript
 // src/config/wdk.ts
 import type { WdkConfigs } from '@tetherto/wdk-react-native-core'
+
+export const sepoliaTestTokenAddress: string = process.env.EXPO_PUBLIC_SEPOLIA_TEST_TOKEN_ADDRESS ?? ''
+if (!/^0x[0-9a-fA-F]{40}$/.test(sepoliaTestTokenAddress)) {
+  throw new Error('Set EXPO_PUBLIC_SEPOLIA_TEST_TOKEN_ADDRESS to your verified test token')
+}
 
 export const wdkConfigs: WdkConfigs = {
   networks: {
@@ -47599,13 +47661,14 @@ export const wdkConfigs: WdkConfigs = {
       blockchain: 'ethereum',
       config: {
         chainId: 11155111, // Sepolia testnet
+        safeModulesVersion: '0.3.0',
         provider: 'https://rpc.sepolia.org',
         bundlerUrl: 'https://api.candide.dev/public/v3/11155111',
         paymasterUrl: 'https://api.candide.dev/public/v3/11155111',
         paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
         transferMaxFee: 5000000,
         paymasterToken: {
-          address: '0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0', // USDt on Sepolia
+          address: sepoliaTestTokenAddress,
         },
       },
     },
@@ -47615,7 +47678,7 @@ export const wdkConfigs: WdkConfigs = {
 ```
 
 <Callout type="info">
-This example uses **Sepolia testnet** with a free public RPC so you can start immediately without API keys. For production or mainnet configuration, see the [Chain Configuration Guide](/sdk/core-module/configuration).
+This example uses **Sepolia testnet**. Configure and fund the selected test token before sending. For production or mainnet configuration, see the [Chain Configuration Guide](/sdk/core-module/configuration).
 </Callout>
 
 ### Step 5: Add WdkAppProvider
@@ -47750,7 +47813,9 @@ Now that you have WDK integrated, here's what you can explore:
 Use the `useAccount()` hook to send transactions:
 
 ```tsx
+// src/screens/SendScreen.tsx
 import { useAccount, BaseAsset } from '@tetherto/wdk-react-native-core'
+import { sepoliaTestTokenAddress } from '../config/wdk'
 
 const usdt = new BaseAsset({
   id: 'usdt-ethereum',
@@ -47759,7 +47824,7 @@ const usdt = new BaseAsset({
   name: 'Tether USD',
   decimals: 6,
   isNative: false,
-  address: '0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0', // USDt on Sepolia
+  address: sepoliaTestTokenAddress,
 })
 
 function SendScreen({ recipient }: { recipient: string }) {
@@ -50307,7 +50372,7 @@ Review mirror and writer methods in the [API Reference](/tools/p2p-address-book/
 URL: https://docs.wdk.tether.io/tools/pear-wrk-wdk
 Description: HRPC and framed JSON-RPC infrastructure for running WDK inside a Bare worklet
 
-Pear Worklet WDK is the low-level transport and handler layer for running WDK inside a Bare worklet. It provides an `HRPC` client and server helper, a separate framed JSON-RPC server entrypoint for native hosts, and typed request payloads for WDK, wallet, protocol, and HRPC-only generic-module operations.
+Pear Worklet WDK is the low-level transport and handler layer for running WDK inside a Bare worklet. It provides an `HRPC` client and server helper, a separate framed JSON-RPC server entrypoint for native hosts, and request payloads for WDK, wallet, protocol, and generic-module operations.
 
 Powered by `@tetherto/pear-wrk-wdk`.
 
@@ -50317,9 +50382,10 @@ Powered by `@tetherto/pear-wrk-wdk`.
 - **Typed lifecycle requests**: Initialize WDK with `initializeWDK({ config, encryptionKey, encryptedSeed })` and tear it down with `dispose()`
 - **Selective wallet resets**: Re-register only the wallet modules listed in a new worklet `networks` config using `resetWdkWallets({ config })`
 - **Generic wallet and protocol calls**: Call account methods through `callMethod({ methodName, network, accountIndex, args, options })`, including Swidge protocols by name
-- **Opt-in method allowlists**: Restrict wallet and nested protocol calls for HRPC and JSON-RPC, plus generic-module calls for HRPC
-- **HRPC generic modules**: Construct named modules during WDK initialization, call their methods with `callModule()`, and forward declared events to the host
+- **Opt-in method allowlists**: Restrict wallet and nested protocol calls for HRPC and JSON-RPC, plus generic-module calls on both transports
+- **Generic modules on both transports**: Construct named modules during WDK initialization, call their methods with `callModule()`, and forward declared events to the host
 - **Framed JSON-RPC server**: Register a length-prefixed JSON-RPC 2.0 server through `@tetherto/pear-wrk-wdk/jsonrpc`
+- **Suspend diagnostics**: Opt in to handle snapshots during Bare suspend-to-idle transitions with `registerHandleLeakCheck()`
 - **Dynamic registration hooks**: Register additional wallets or protocols with `registerWallet()` and `registerProtocol()`
 
 ## Why this matters
@@ -50338,7 +50404,7 @@ The top-level package exports the `HRPC` runtime value. Import `registerRpcHandl
 </Callout>
 
 <Callout type="warn">
-Generic-module calls and events are HRPC-only in `v1.0.0-beta.11`; the JSON-RPC handler does not expose them. This package also does not export a pre-built WDK bundle.
+In `v1.0.0-beta.13`, a missing wallet or protocol method returns `BAD_REQUEST` even if the caller supplies `options.defaultValue`. Handle unsupported methods in the host. The package does not export a pre-built WDK bundle.
 </Callout>
 
 <Cards>
@@ -50360,7 +50426,7 @@ Review the exported class, server helper, and request shapes
 
 ## Pear Worklet WDK API Reference
 URL: https://docs.wdk.tether.io/tools/pear-wrk-wdk/api-reference
-Description: API reference for the HRPC client, registerRpcHandlers helper, and request types in @tetherto/pear-wrk-wdk
+Description: API reference for Pear Worklet HRPC, JSON-RPC, module calls, request types, and suspend diagnostics
 
 ## Package: `@tetherto/pear-wrk-wdk`
 
@@ -50428,7 +50494,7 @@ Returns:
 
 The handler requires `encryptionKey` and `encryptedSeed` to be passed together or omitted together. When a seeded WDK instance already exists, the runtime disposes it and closes its generic modules before re-registering the wallets and optional protocols in `config`.
 
-In beta.11, HRPC generic modules are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules.
+In beta.13, generic modules on either transport are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules.
 
 #### `resetWdkWallets`
 
@@ -50481,7 +50547,9 @@ A full disposal closes all generic modules and clears the WDK instance. A non-em
 
 `options.protocolType` may be `swap`, `swidge`, `bridge`, `lending`, or `fiat`. When present, the runtime requires a non-empty `options.protocolName` and resolves the protocol-specific account wrapper before invoking `methodName`. Swidge calls resolve the wrapper with `account.getSwidgeProtocol(protocolName)`.
 
-When `RpcContext.allowedMethods` defines the target surface, `methodName` must appear in its `methods` array. Account restrictions are keyed by network; protocol restrictions are nested by network, protocol type, and protocol name. Omitted surfaces remain unrestricted, while `methods: []` denies every call on that exact surface. Denied calls fail before dispatch with the runtime code `METHOD_NOT_ALLOWED` and do not use `options.defaultValue`.
+When `RpcContext.allowedMethods` defines the target surface, `methodName` must appear in its `methods` array. Account restrictions are keyed by network; protocol restrictions are nested by network, protocol type, and protocol name. Omitted surfaces remain unrestricted, while `methods: []` denies every call on that exact surface. Denied calls fail before dispatch with the runtime code `METHOD_NOT_ALLOWED`.
+
+A missing wallet or protocol method fails with `BAD_REQUEST`. Beta.13 removes the `options.defaultValue` fallback from both runtime dispatch and `CallMethodOptions`; callers must handle unsupported methods themselves.
 
 #### `registerWallet`
 
@@ -50502,19 +50570,19 @@ Returns:
 
 #### `callModule`
 
-Call one method on a configured generic module. This command is available on HRPC only.
+Call one method on a configured generic module. Both HRPC and JSON-RPC support this operation in beta.13.
 
 - `module` (`string`): Module name shared by `RpcContext.moduleManagers` and `WdkWorkletConfig.modules`.
 - `method` (`string`): Non-empty method name on the constructed module instance.
 - `args?` (`string`): Optional JSON string of arguments. Arrays are spread as positional arguments; a non-array value is passed as one argument.
 
-Returns `CallModuleResponse` with optional `result`, a JSON string. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization.
+HRPC returns `CallModuleResponse` with optional `result`, a JSON string. JSON-RPC decodes that string and returns the value at `response.result.result`. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization. Return a JSON-serializable value, or `null` for no result; an `undefined` result cannot be decoded by the JSON-RPC transport.
 
 When `RpcContext.allowedModuleMethods` defines the target module, `method` must appear in that module's `methods` array. Omitted modules remain unrestricted, while `methods: []` denies every method on that module. A denied call fails with `METHOD_NOT_ALLOWED` before instance lookup or dispatch.
 
 #### `moduleEvent`
 
-Send an HRPC module event to the host.
+Send an HRPC module event to the host. JSON-RPC forwards the same event as a `moduleEvent` notification with decoded `params.payload`; it has no request `id`.
 
 - `module` (`string`): Module name.
 - `event` (`string`): Event name.
@@ -50577,7 +50645,7 @@ Registers the host-side handler used to receive `moduleEvent()` messages.
 Import this helper from `@tetherto/pear-wrk-wdk/worklet`. It registers the package's server-side handlers on the provided RPC instance.
 
 - `rpc` (`any`): RPC server instance that supports the generated handler registration methods.
-- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. HRPC generic modules can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime` and `moduleInstances`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts HRPC generic-module dispatch.
+- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. Generic modules on either transport can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime` and `moduleInstances`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts generic-module dispatch on both transports.
 
 ### Types
 
@@ -50607,9 +50675,9 @@ interface RpcContext {
 }
 ```
 
-The four allowlist helper interfaces are exported types in beta.11. Every omitted level remains unrestricted. Use an explicit empty `methods` array to deny all dynamic calls on one exact surface.
+The four allowlist helper interfaces are exported types in beta.13. Every omitted level remains unrestricted. Use an explicit empty `methods` array to deny all dynamic calls on one exact surface.
 
-The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.11 published error-code declaration does not include that member. Treat the literal runtime code as authoritative for this release.
+The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.13 published error-code declaration does not include that member. Treat the literal runtime code as authoritative for this release.
 
 #### `WdkWorkletConfig`
 
@@ -50650,7 +50718,7 @@ interface WdkModuleManager {
 }
 ```
 
-The factory must consume `seed` synchronously rather than retain it. Module instances can optionally implement `close()`, `suspend()`, and `resume()`. The runtime calls `close()` during full disposal or reinitialization; targeted blockchain disposal and `resetWdkWallets()` leave generic modules running. Worklet Bundler-generated HRPC entrypoints forward Bare lifecycle events to `suspend()` and `resume()`; manual Pear integrations must wire those events themselves. Declared `events` are forwarded from the instance, and the injected `emit()` function can emit events directly.
+The factory must consume `seed` synchronously rather than retain it. Module instances can optionally implement `close()`, `suspend()`, and `resume()`. The runtime calls `close()` during full disposal or reinitialization; targeted blockchain disposal and `resetWdkWallets()` leave generic modules running. Manual Pear integrations must forward Bare lifecycle events to `context.moduleRuntime.suspendAll()` and `resumeAll()`; registering either transport alone does not install those listeners. Declared `events` are forwarded from the instance, and the injected `emit()` function can emit events directly.
 
 #### Module request types
 
@@ -50693,7 +50761,6 @@ enum ProtocolType {
 
 interface CallMethodOptions {
   transformResult: Function
-  defaultValue: any
   protocolType: ProtocolType
   protocolName: string
 }
@@ -50701,7 +50768,23 @@ interface CallMethodOptions {
 
 The published declarations include `ProtocolType`, but the top-level JavaScript entry does not export that enum value at runtime. Pass the corresponding string literal, such as `'swidge'`, in serialized request options.
 
-The published `CallMethodOptions` declaration marks every field as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used.
+The published `CallMethodOptions` declaration marks every remaining field as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used. `transformResult` is a function-valued internal handler option; it cannot be sent through JSON serialization. Do not place a function in serialized request options.
+
+### Diagnostic export: `registerHandleLeakCheck(options?)`
+
+Import this helper from `@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check`:
+
+```ts
+interface HandleLeakCheckOptions {
+  tickIntervalMs?: number
+}
+
+function registerHandleLeakCheck(options?: HandleLeakCheckOptions): void
+```
+
+`tickIntervalMs` is the sampling interval in milliseconds, defaulting to `1000`. The helper logs immediately on Bare `suspend`, repeats with an unreferenced timer, and stops on `idle` or `resume`. Handle records include type, native address, `isActive`, `isClosing`, and `hasRef`; it reports rather than closes handles.
+
+Register once per worklet. The helper performs no interval validation and returns without registering listeners when `bare-walk-handles` or Bare lifecycle events are unavailable. Logs use `console.warn` independently of `LOG_LEVEL`. This helper is opt-in; transport registration does not enable it.
 
 ## JSON-RPC Transport
 
@@ -50715,7 +50798,7 @@ registerJsonRpcHandlers(ipc, context)
 
 The server reads UTF-8 JSON-RPC 2.0 messages framed with a four-byte unsigned big-endian payload length. Every request requires an ID, and an ID cannot be reused while its earlier request is still in flight. Malformed frames are dropped without a response. The package does not export a JSON-RPC client or native-host helper.
 
-Beta.11 supports these JSON-RPC method names:
+Beta.13 supports these JSON-RPC method names:
 
 - `workletStart`
 - `generateEntropyAndEncrypt`
@@ -50723,16 +50806,17 @@ Beta.11 supports these JSON-RPC method names:
 - `getSeedAndEntropyFromMnemonic`
 - `initializeWDK`
 - `callMethod`
+- `callModule`
 - `registerWallet`
 - `registerProtocol`
 - `dispose`
 
-JSON-RPC does not support `resetWdkWallets`, generic-module calls, or module events in this release. Use HRPC for those operations.
+JSON-RPC does not support `resetWdkWallets` in this release. Use HRPC for selective wallet resets. Generic modules require `context.moduleManagers` and matching runtime `config.modules`; `initializeWDK` constructs them only when the request includes the encrypted seed pair.
 
-The HRPC and JSON-RPC transports share the `callMethod` handler, so both support the `swidge` protocol type and enforce `RpcContext.allowedMethods` in beta.11. JSON-RPC has no `callModule` surface, so `allowedModuleMethods` is HRPC-only.
+The transports share the wallet/protocol handler and module runtime. Both support the `swidge` protocol type, enforce `RpcContext.allowedMethods`, and enforce `allowedModuleMethods` for generic-module calls. JSON-RPC `callModule` parameters match `CallModuleRequest`, including its JSON-string `args`. Results use `response.result.result`; events arrive as `moduleEvent` notifications with `params: { module, event, payload }` and a decoded payload. See the [JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 <Callout type="warn">
-INFO-level logging can include wallet-call arguments and JSON-RPC parameters or results. Production defaults to ERROR logging; do not enable more verbose logging for requests that may contain seeds, mnemonics, keys, or other sensitive values.
+Beta.13 removes JSON-RPC parameters and results from INFO request/response logs and logs wallet-call arguments at DEBUG. Mnemonic validation errors identify invalid word positions without echoing the words. This does not provide general secret redaction: DEBUG arguments, module errors, and application logs can still contain sensitive values. Production defaults to ERROR logging; avoid sensitive values in custom logs and errors.
 </Callout>
 
 Mnemonic strings, encryption-key strings, and encrypted payload strings cannot be zeroed in JavaScript. Discard references promptly and never log them. The runtime validates imported mnemonics for 12 or 24 English BIP-39 words and clears temporary byte buffers where possible.
@@ -50749,7 +50833,7 @@ Mnemonic strings, encryption-key strings, and encrypted payload strings cannot b
 URL: https://docs.wdk.tether.io/tools/pear-wrk-wdk/configuration
 Description: Configure Pear Worklet HRPC and JSON-RPC contexts, WDK payloads, and generic modules
 
-This page explains how to [build the worklet context](#worklet-context), [shape the worklet config payload](#worklet-config-payload), [initialize WDK](#initialize-wdk), [call generic modules](#call-generic-module-methods), and [choose a transport](#json-rpc-transport).
+This page explains how to [build the worklet context](#worklet-context), [shape the worklet config payload](#worklet-config-payload), [initialize WDK](#initialize-wdk), [call generic modules](#call-generic-module-methods), [choose a transport](#json-rpc-transport), and [inspect suspend delays](#inspect-suspend-delays).
 
 ## Worklet Context
 
@@ -50831,7 +50915,7 @@ module.exports = (rpc) => {
 - `protocolManagers`: A map from protocol name to protocol manager implementation.
 - `wdkLoadError`: Any startup error captured while loading WDK. Use `null` when there is no load failure.
 
-For HRPC generic modules, `moduleManagers` optionally maps module names to `{ createModule, events? }`. The factory receives `{ seed, config, capabilities, emit }` and can return an instance or a promise. `capabilities` is an optional host-supplied object and is empty by default. The runtime manages `moduleRuntime` and `moduleInstances`; do not initialize those fields yourself. Manual integrations must forward Bare `suspend` and `resume` events as shown if module instances should receive those lifecycle calls. Worklet Bundler-generated HRPC entrypoints wire them automatically.
+For generic modules on either transport, `moduleManagers` optionally maps module names to `{ createModule, events? }`. The factory receives `{ seed, config, capabilities, emit }` and can return an instance or a promise. `capabilities` is an optional host-supplied object and is empty by default. The runtime manages `moduleRuntime` and `moduleInstances`; do not initialize those fields yourself. Manual integrations must forward Bare `suspend` and `resume` events as shown if module instances should receive those lifecycle calls. See [Worklet Bundler lifecycle behavior](/tools/worklet-bundler/configuration#suspend-and-resume-behavior) for generated entrypoints.
 
 ## Restrict Dynamic Methods
 
@@ -50864,11 +50948,11 @@ This map applies to the shared HRPC and JSON-RPC `callMethod()` handler. Restric
 - Omitting the map, a network, `protocols`, a protocol type, a protocol name, or `methods` leaves that exact surface unrestricted.
 - An explicit `methods: []` denies every call on that exact account or protocol surface.
 - Protocol calls use their nested list rather than falling back to the account list.
-- A denied method fails before account or protocol dispatch with `METHOD_NOT_ALLOWED`; `defaultValue` is not returned.
+- A denied method fails before account or protocol dispatch with `METHOD_NOT_ALLOWED`.
 
 ### Generic Module Methods
 
-`allowedModuleMethods` is keyed by the `moduleManagers` name and applies to HRPC `callModule()` only:
+`allowedModuleMethods` is keyed by the `moduleManagers` name and applies to `callModule()` on both HRPC and JSON-RPC:
 
 ```javascript title="Restrict Dynamic Module Calls"
 const context = {
@@ -50884,7 +50968,7 @@ const context = {
 Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on it.
 
 <Callout type="warn">
-These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.11 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration omits that new member; handle the literal runtime code until the declaration is corrected.
+These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.13 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration omits that new member; handle the literal runtime code until the declaration is corrected.
 </Callout>
 
 ## Worklet Config Payload
@@ -50923,12 +51007,10 @@ const workletConfig = {
 - `networks` is required and must contain at least one network entry.
 - Each network entry must include `blockchain` and an object `config`.
 - `protocols` is optional during initialization.
-- `modules` is optional and contains runtime config for named generic modules. Each key must match a `moduleManagers` key in the HRPC context and the corresponding build-time Worklet Bundler module name.
+- `modules` is optional and contains runtime config for named generic modules. Each key must match a `moduleManagers` key in the worklet context and the corresponding build-time Worklet Bundler module name.
 - `resetWdkWallets()` reads only the `networks` portion of the decoded config.
 
-<Callout type="warn">
-Generic modules are HRPC-only in beta.11. The JSON-RPC handler does not construct modules or expose module calls and events.
-</Callout>
+JSON-RPC generic modules require Pear Worklet beta.13. Supply the same `moduleManagers`, `allowedModuleMethods`, and runtime `modules` config used by HRPC. If generating the entrypoint, use Worklet Bundler beta.12 with Pear Worklet beta.13.
 
 ## Initialize WDK
 
@@ -50951,8 +51033,8 @@ await hrpc.initializeWDK({
 - Pass both `encryptionKey` and `encryptedSeed`, or omit both together.
 - On first initialization, the worklet must receive an encrypted seed pair so it can create `context.wdk`.
 - If `context.wdk` already exists, a later `initializeWDK()` call disposes the existing instance and closes its generic modules before re-registering wallets and protocols from the new config.
-- In beta.11, generic modules are constructed only when that `initializeWDK()` request includes both `encryptionKey` and `encryptedSeed`. A seedless reinitialization closes existing module instances but does not rebuild them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
-- Module `close()` is called during full disposal or reinitialization. Targeted blockchain disposal leaves generic modules running. Optional `suspend()` and `resume()` methods run only when the host forwards Bare lifecycle events; the manual context above and Worklet Bundler-generated HRPC entrypoints do so.
+- In beta.13, generic modules on either transport are constructed only when that `initializeWDK()` request includes both `encryptionKey` and `encryptedSeed`. A seedless reinitialization closes existing module instances but does not rebuild them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
+- Module `close()` is called during full disposal or reinitialization. Targeted blockchain disposal leaves generic modules running. Optional `suspend()` and `resume()` methods run only when the host forwards Bare lifecycle events; the manual context above does so.
 
 ## Reset Selected Wallets
 
@@ -51001,6 +51083,7 @@ const result = await hrpc.callMethod({
 - When `args` decodes to an object or primitive, the handler passes it as a single argument.
 - Set `options.protocolType` to `swap`, `swidge`, `bridge`, `lending`, or `fiat` to call a protocol wrapper. Every protocol call requires a non-empty `options.protocolName`.
 - When `context.allowedMethods` contains the target account or protocol surface, `methodName` must appear in that exact surface's `methods` array.
+- In beta.13, a missing wallet or protocol method fails with `BAD_REQUEST`. The removed `options.defaultValue` field no longer supplies a fallback; catch unsupported-method errors in the host.
 
 ## Call Generic Module Methods
 
@@ -51045,11 +51128,45 @@ module.exports = (ipc) => {
 
 Messages are UTF-8 JSON-RPC 2.0 objects prefixed by a four-byte unsigned big-endian payload length. Requests require an ID, and IDs must be unique while a request is in flight. The package exports no JSON-RPC host/client helper; the native host must implement framing and correlation.
 
-JSON-RPC beta.11 supports WDK initialization and disposal, secret/mnemonic operations, wallet and protocol calls, and dynamic wallet/protocol registration. Its shared `callMethod` handler supports the `swidge` protocol type and enforces `context.allowedMethods`. It does not support `resetWdkWallets`, `callModule`, `allowedModuleMethods`, or module events. See the [API reference](/tools/pear-wrk-wdk/api-reference#json-rpc-transport) for the exact method list.
+JSON-RPC beta.13 supports generic-module initialization, `callModule`, `allowedModuleMethods`, and `moduleEvent` notifications alongside wallet and protocol operations. `resetWdkWallets` remains HRPC-only. See the [API reference](/tools/pear-wrk-wdk/api-reference#json-rpc-transport) for all methods and response shapes.
+
+Send a module call as a framed JSON-RPC request; `args` remains a JSON string:
+
+```json title="Call A Module Over JSON-RPC"
+{"jsonrpc":"2.0","id":1,"method":"callModule","params":{"module":"preferences","method":"getTheme","args":"[]"}}
+```
+
+For a module that returns `'dark'`, the response contains the decoded value inside `result.result`:
+
+```json title="JSON-RPC Module Result"
+{"jsonrpc":"2.0","id":1,"result":{"result":"dark"}}
+```
+
+A declared module event arrives as a notification without an `id`; `params.payload` is already decoded:
+
+```json title="JSON-RPC Module Event"
+{"jsonrpc":"2.0","method":"moduleEvent","params":{"module":"preferences","event":"changed","payload":{"theme":"dark"}}}
+```
+
+Manual JSON-RPC entrypoints must forward Bare `suspend` and `resume` events to `context.moduleRuntime` as shown in the HRPC context example. Registering JSON-RPC handlers alone does not install those lifecycle listeners.
 
 <Callout type="warn">
-INFO-level logs can contain wallet-call arguments and JSON-RPC parameters or results. Keep production logging at its default ERROR level when requests may contain sensitive values.
+Beta.13 omits JSON-RPC parameters and results from its INFO request/response logs and moves wallet-call arguments to DEBUG. DEBUG can still expose sensitive arguments, and module errors or application logs are not generally redacted. Keep production logging at its default ERROR level and avoid sensitive values in custom logs and error messages.
 </Callout>
+
+## Inspect Suspend Delays
+
+Register the optional [`registerHandleLeakCheck()`](/tools/pear-wrk-wdk/api-reference#diagnostic-export-registerhandleleakcheckoptions) helper once in a Bare worklet entrypoint:
+
+```javascript title="Inspect Bare Handles During Suspend"
+const { registerHandleLeakCheck } = require('@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check')
+
+registerHandleLeakCheck({ tickIntervalMs: 1000 })
+```
+
+The helper logs a handle snapshot immediately on `suspend`, then repeats every `tickIntervalMs` milliseconds until `idle` or `resume`. The default interval is `1000` ms. Its timer is unreferenced so the diagnostic itself does not keep the event loop active. It reports handles; it does not close them or suspend modules.
+
+Provide a positive interval; the beta.13 helper passes the value to the timer without validating it. Registration is a no-op if the optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable. Diagnostic output uses `console.warn` regardless of `LOG_LEVEL`, so register it only when you need handle diagnostics.
 
 ***
 
@@ -54270,19 +54387,20 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 
 ## Features
 
-- **Config-driven bundle generation**: Map logical network names to wallet packages, protocol names to protocol packages, and HRPC-only generic-module names to package factories.
+- **Config-driven bundle generation**: Map logical network names to wallet packages, protocol names to protocol packages, and generic-module names to package factories.
 - **HRPC and JSON-RPC transports**: Generate an HRPC JavaScript bundle by default or a length-prefixed JSON-RPC bundle for native hosts.
 - **Generated worklet artifacts**: Produce a Bare bundle, a stable `./.wdk` host import, and generated TypeScript types.
 - **Native addon outputs**: Link iOS, macOS, and Android addons and generate `addons.yml` for JSON-RPC/native integrations.
 - **Dependency validation helpers**: Validate configured modules, detect the active package manager, and generate install or uninstall commands when dependencies are missing.
-- **Dynamic-call allowlists**: Restrict generated wallet and protocol `callMethod()` surfaces for HRPC and JSON-RPC, plus generic-module `callModule()` surfaces for HRPC.
+- **Dynamic-call allowlists**: Restrict generated wallet and protocol `callMethod()` surfaces for HRPC and JSON-RPC, plus generic-module `callModule()` surfaces on both transports.
 - **Optional peer deferral**: Defer missing peers marked optional by their package metadata, or require them at build time with `--no-defer-optional-peers`.
 - **Explicit ESM-to-CJS conversion**: Opt in for JSC, QuickJS, or another CommonJS-only Bare engine, with a matching runtime loader patch and post-conversion bundle validation.
 - **CLI workflow**: Use `init`, `validate`, `generate`, `list-modules`, and `clean` without building your own wrapper.
-- **Bare lifecycle handling**: Generated HRPC entrypoints suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare suspend, resume, and idle events.
+- **Bare lifecycle handling**: Generated entrypoints forward suspend and resume events to generic modules. HRPC entrypoints also suspend and resume both HTTP global agents.
+- **Opt-in handle diagnostics**: Use `options.handleLeakCheck` to inspect suspend-to-idle delays in generated HRPC worklets.
 
 <Callout type="info">
-`v1.0.0-beta.10` makes ESM-to-CJS conversion explicit and transport-independent. When enabled in `wdk.config.js`, the generated entrypoint installs the matching `.mjs` CommonJS loader patch and the build validates the rewritten raw or default UTF-8-wrapped bundle before succeeding. The release also exports `convertBundleEsmToCjs()` and `validateBundle()` for programmatic workflows.
+`v1.0.0-beta.12` adds generic modules and their method allowlists to JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The new `options.handleLeakCheck` diagnostic is generated only for HRPC.
 </Callout>
 
 ## Why this matters
@@ -54292,7 +54410,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - Transport-specific defaults produce a JavaScript HRPC bundle for React Native Core or native addon artifacts for JSON-RPC hosts; JavaScript-engine compatibility is configured separately.
 
 <Callout type="warn">
-Generic `modules` are generated only for HRPC through beta.11. A JSON-RPC config can currently accept a `modules` field but silently omits those modules from the generated entrypoint.
+`options.handleLeakCheck` is opt-in and reports active handles without closing them. JSON-RPC entrypoints do not enable this diagnostic in beta.12; see [configuration](/tools/worklet-bundler/configuration#configure-suspend-diagnostics) for the transport boundary.
 </Callout>
 
 <Cards>
@@ -54360,19 +54478,24 @@ interface WdkBundleConfig {
     platforms?: Array<'ios' | 'macos' | 'android'>
     swiftTarget?: string
     convertEsmToCjs?: boolean
+    handleLeakCheck?: number | true
   }
 }
 ```
 
-`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to HRPC only. These inline helper shapes are present in the config declaration but are not named exports from the beta.11 npm entrypoint.
+`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to both HRPC and JSON-RPC. These inline helper shapes are present in the config declaration but are not named exports from the beta.12 npm entrypoint.
 
-Every omitted map, level, or `methods` field remains unrestricted. An explicit `methods: []` denies every method on that exact surface. Generated HRPC contexts receive both maps; generated JSON-RPC contexts receive only `allowedMethods`.
+Every omitted map, level, or `methods` field remains unrestricted. An explicit `methods: []` denies every method on that exact surface. Both generated contexts receive `allowedMethods` and `allowedModuleMethods`.
 
-`modules` is generated only for HRPC through beta.11. JSON-RPC entry generation ignores that map. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
+Beta.12 generates `modules` for both transports. Use Pear Worklet beta.13 for JSON-RPC module calls and events. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
 
 <Callout type="warn">
-Beta.11 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
+Beta.12 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
 </Callout>
+
+`options.handleLeakCheck` is optional and applies only to generated HRPC entrypoints. Set `true` to use Pear Worklet beta.13's default `1000` ms interval, or a positive number to pass as `tickIntervalMs`. Omit it to disable diagnostics; `false`, zero, negative numbers, and strings fail `loadConfig()` validation. The interval controls repeated sampling after an immediate suspend snapshot, not a one-time delay.
+
+Generation checks whether the installed Pear Worklet diagnostic subpath resolves, warning and skipping it if unavailable. The helper logs through `console.warn` until Bare `idle` or `resume`; it does not close handles. JSON-RPC generation accepts the option but does not emit diagnostic registration in beta.12.
 
 #### `ResolvedConfig`
 
@@ -54496,7 +54619,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `silent`
 - `skipTypes`
 - `skipGeneration`: Reuse an existing generated entrypoint. If `config.options.convertEsmToCjs` changed, regenerate the entrypoint first so its `.mjs` loader behavior matches the bundle conversion.
-- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.11 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
+- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.12 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
 
 `deferOptionalPeers` is a per-run API option. It is not a `WdkBundleConfig` field and cannot be set in `wdk.config.js`.
 
@@ -54510,7 +54633,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `error?`
 - `missingModule?`
 
-In beta.11, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
+In beta.12, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
 
 ```typescript title="Generate A Bundle Programmatically"
 import { generateBundle, loadConfig } from '@tetherto/wdk-worklet-bundler'
@@ -54527,13 +54650,13 @@ Use `generateSourceFiles()` when you want the generated entrypoint without the f
 
 #### `generateEntryPoint(config, outputDir)`
 
-Use `generateEntryPoint()` when you need the generated HRPC Bare entrypoint written to a chosen output directory. This path includes configured generic modules, both method-allowlist maps, and module lifecycle/event wiring.
+Use `generateEntryPoint()` when you need the generated HRPC Bare entrypoint written to a chosen output directory. This path includes configured generic modules, both method-allowlist maps, module lifecycle/event wiring, and the optional `handleLeakCheck` diagnostic.
 
-Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.11 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.11 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
+Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.12 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.12 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
 
 #### `generateJsonRpcEntryPoint(config, outputDir)`
 
-Generate the framed JSON-RPC entrypoint used by native hosts. Through beta.11 this path includes wallet and protocol managers plus `allowedMethods`, but not generic `modules` or `allowedModuleMethods`. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
+Generate the framed JSON-RPC entrypoint used by native hosts. Beta.12 includes wallet, protocol, and generic-module managers plus both method-allowlist maps. With Pear Worklet beta.13, it supports module calls/events and forwards Bare `suspend` and `resume` to the module runtime. It does not generate HRPC's HTTP-agent lifecycle hooks or the `handleLeakCheck` diagnostic. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
 
 #### `linkAddons(config, options?)`
 
@@ -54562,11 +54685,11 @@ convertBundleEsmToCjs('./.wdk-bundle/wdk-worklet.bundle.js', {
 })
 ```
 
-The beta.11 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
+The beta.12 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
 
 This helper rewrites only the packed bundle. For `.mjs` files to load as CommonJS at runtime, generate the HRPC or JSON-RPC entrypoint with `options.convertEsmToCjs: true` before packing, or provide equivalent loader behavior yourself. Do not convert a bundle while reusing an entrypoint generated with conversion disabled.
 
-The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.11 package entrypoint.
+The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.12 package entrypoint.
 
 #### `validateBundle(bundlePath)`
 
@@ -54595,7 +54718,7 @@ The published CLI exposes these commands through `wdk-worklet-bundler`:
 For the end-to-end config workflow and transport defaults, see the [Worklet Bundler configuration guide](/tools/worklet-bundler/configuration).
 
 <Callout type="warn">
-Beta.11 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
+Beta.12 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
 </Callout>
 
 ***
@@ -54617,11 +54740,11 @@ This page shows how to install `@tetherto/wdk-worklet-bundler` and its Pear runt
 Install the bundler as a development dependency and Pear Worklet as a runtime dependency in the host project:
 
 ```bash title="Install The Bundler And Runtime"
-npm install @tetherto/pear-wrk-wdk@1.0.0-beta.12
-npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.11
+npm install @tetherto/pear-wrk-wdk@1.0.0-beta.13
+npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.12
 ```
 
-Worklet Bundler beta.11 generates entrypoints that import Pear Worklet and includes that runtime in validation and installation for both HRPC and JSON-RPC. Pear Worklet beta.12 enforces the wallet, protocol, and generic-module method allowlists documented here. The GitHub beta.8 release introduced the configuration but has no public npm artifact.
+Worklet Bundler beta.12 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
 
 ## Create `wdk.config.js`
 
@@ -54631,7 +54754,7 @@ Use `init` to create a starter config, or write the file yourself:
 npx wdk-worklet-bundler init
 ```
 
-The published config surface accepts `networks`, optional `protocols`, HRPC-only generic `modules`, dynamic-call allowlists, `transport`, `preloadModules`, `output`, and `options`:
+The published config surface accepts `networks`, optional `protocols`, generic `modules`, dynamic-call allowlists, `transport`, `preloadModules`, `output`, and `options`:
 
 ```javascript title="Example wdk.config.js"
 module.exports = {
@@ -54754,9 +54877,9 @@ Restrictions are opt-in per exact surface:
 This configuration is not default-deny. List every wallet and protocol surface exposed to an untrusted host, and use an explicit empty list when that surface should accept no dynamic calls.
 </Callout>
 
-### `allowedModuleMethods` (optional, HRPC only)
+### `allowedModuleMethods` (optional)
 
-Use `allowedModuleMethods` to restrict HRPC `callModule()` dispatch. Keys must match the names under `modules`:
+Use `allowedModuleMethods` to restrict `callModule()` dispatch on both HRPC and JSON-RPC. Keys must match the names under `modules`:
 
 ```javascript title="Restrict Generic Module Calls"
 module.exports = {
@@ -54773,9 +54896,9 @@ module.exports = {
 }
 ```
 
-Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on that module. JSON-RPC worklets do not generate generic modules or receive `allowedModuleMethods`.
+Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on that module. Both generated transports receive this map.
 
-### `modules` (optional, HRPC only)
+### `modules` (optional)
 
 Use `modules` for named generic packages that expose a module factory. Each entry supports:
 
@@ -54785,13 +54908,11 @@ Use `modules` for named generic packages that expose a module factory. Each entr
 
 The factory receives `{ seed, config, capabilities, emit }` and can return the module instance or a promise for it. A module that needs the seed must consume it synchronously rather than retain it. The build-time name, such as `preferences`, must match the key in the host's runtime module config.
 
-<Callout type="warn">
-Through beta.11, generic modules are included only in generated HRPC entrypoints. Do not configure `modules` with `transport: 'jsonrpc'`; the current schema accepts the field, but JSON-RPC generation ignores it.
-</Callout>
+Beta.12 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 ### `transport` (optional)
 
-Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.11, ESM-to-CJS conversion is an independent, explicit option for both transports.
+Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.12, ESM-to-CJS conversion is an independent, explicit option for both transports.
 
 ### `preloadModules` (optional)
 
@@ -54802,7 +54923,7 @@ Use `preloadModules` for native addons or other modules that must be required be
 Supported output fields are:
 
 - `bundle`: Bundle path. Defaults to `./.wdk-bundle/wdk-worklet.bundle.js` for HRPC and `./.wdk-bundle/wdk-worklet.bundle` for JSON-RPC.
-- `types`: Declared in the beta.11 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
+- `types`: Declared in the beta.12 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
 - `addons.ios`, `addons.macos`, `addons.android`: Platform addon directories. Defaults are `./ios-addons`, `./mac-addons`, and `./android-addons`.
 - `addonsYml`: BareKit Swift dependency file. Defaults to `./ios-addons/addons.yml` and is generated when iOS addons are linked.
 
@@ -54810,13 +54931,38 @@ Supported output fields are:
 
 The published config type supports these build options:
 
-- `minify` (`boolean`): Declared in the beta.11 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
-- `sourceMaps` (`boolean`): Declared in the beta.11 config type but not read by the bundle path, so it does not produce source maps.
+- `minify` (`boolean`): Declared in the beta.12 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
+- `sourceMaps` (`boolean`): Declared in the beta.12 config type but not read by the bundle path, so it does not produce source maps.
 - `targets` (`string[]`): Override the default Bare build hosts. The shipped defaults cover iOS arm64 and simulator targets plus Android arm, arm64, ia32, and x64 hosts.
 - `linkAddons` (`boolean`): Link native addons with `bare-link`. Defaults to `true` for JSON-RPC and `false` for HRPC.
 - `platforms` (`('ios' | 'macos' | 'android')[]`): Addon platforms. Defaults to all three when addon linking is active.
 - `swiftTarget` (`string`): Xcode target written to `addons.yml`. Defaults to `app`.
+- `handleLeakCheck` (`number | true`, HRPC only): Opt in to repeated handle snapshots while suspended. `true` uses Pear Worklet beta.13's default `1000` ms interval; a positive number sets the interval in milliseconds. Omit the field to disable it. `false`, zero, negative numbers, and strings fail config validation.
 - `convertEsmToCjs` (`boolean`): Convert the bundle for a Bare port whose JavaScript engine cannot load ES modules, such as JSC or QuickJS. Defaults to `false` for both transports. Leave it off only when every target uses an ESM-capable engine such as V8.
+
+### Configure suspend diagnostics
+
+Set `options.handleLeakCheck` to inspect handles that remain active after an HRPC worklet suspends:
+
+```javascript title="Sample Handles During Suspend"
+module.exports = {
+  networks: {
+    ethereum: { package: '@tetherto/wdk-wallet-evm' }
+  },
+  transport: 'hrpc',
+  options: {
+    handleLeakCheck: 5000
+  }
+}
+```
+
+This emits `registerHandleLeakCheck({ tickIntervalMs: 5000 })`. The diagnostic logs immediately on `suspend` and every five seconds until `idle` or `resume`. It uses an unreferenced timer and `console.warn` independently of `LOG_LEVEL`; it does not close handles or replace module lifecycle handling.
+
+If the installed Pear Worklet package does not expose `@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check`, generation warns and omits the diagnostic. If the export exists but its optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable, the runtime helper does nothing.
+
+<Callout type="warn">
+Beta.12 emits this diagnostic only for HRPC. Setting `options.handleLeakCheck` in a JSON-RPC config passes validation but does not emit diagnostic registration. Custom JSON-RPC entrypoints can register the [Pear Worklet helper](/tools/pear-wrk-wdk/configuration#inspect-suspend-delays) themselves.
+</Callout>
 
 ### Configure ESM-to-CJS conversion
 
@@ -54833,14 +54979,14 @@ module.exports = {
 }
 ```
 
-In the normal `generate` or `generateBundle()` path, beta.11 uses one flag for both build-time conversion and the generated runtime loader:
+In the normal `generate` or `generateBundle()` path, beta.12 uses one flag for both build-time conversion and the generated runtime loader:
 
 - After `bare-pack`, it converts `.js`, `.mjs`, and `.cjs` files to CommonJS, lowers dynamic `import()`, removes `"type": "module"` from bundled package manifests, and rebuilds bundle offsets with `bare-bundle`.
 - It preserves raw bundles and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by supported `bare-pack` output suffixes. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported.
 - It validates the rewritten file map, offsets, lengths, CommonJS syntax, entrypoint, package manifests, and absence of dynamic imports before generation succeeds.
 - The generated HRPC or JSON-RPC entrypoint routes `.mjs` files through the CommonJS loader only when conversion is enabled.
 
-There is no beta.11 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
+There is no beta.12 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
 
 ## Configure JSON-RPC and native addons
 
@@ -54882,11 +55028,11 @@ npx wdk-worklet-bundler validate
 
 ## Handle peer dependencies
 
-Worklet Bundler beta.11 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
+Worklet Bundler beta.12 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
 
 - During bundle generation, missing required peers are offered for installation. In a non-interactive environment without `--install`, the CLI prints the exact manual install command and continues; `bare-pack` can still fail if the bundle needs that peer. The peer scan is skipped by `--source-only`.
 - Missing optional peers are not prompted for or installed. By default, the bundler passes each one to `bare-pack --defer`, so an unused optional feature does not block the build.
-- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.11 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
+- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.12 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
 
 Use `--no-defer-optional-peers` when the app uses an optional feature and you want a missing peer to fail during the build:
 
@@ -54908,25 +55054,25 @@ Use `generate` to build the worklet artifact:
 npx wdk-worklet-bundler generate --install
 ```
 
-`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.11, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
+`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.12, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
 
 Use `--source-only` when you want the generated `.wdk/wdk-worklet.generated.js` entrypoint and related artifacts without running `bare-pack`. This mode also skips bundle conversion. If `options.convertEsmToCjs` is `true` and you run `bare-pack` yourself, convert the packed bundle with `convertBundleEsmToCjs()` before deployment; the source-only entrypoint already contains the matching `.mjs` loader patch. Keep the same conversion setting when generating the entrypoint and converting the bundle.
 
-The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.11, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
+The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.12, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
 
 `--skip-generation` reuses an existing generated entrypoint. If `options.convertEsmToCjs` changed since that entrypoint was created, regenerate without `--skip-generation` before building so the runtime `.mjs` loader matches the bundle conversion setting.
 
 ## Suspend and resume behavior
 
-Generated HRPC worklet entrypoints register Bare lifecycle handlers for `suspend` and `resume`, then apply those handlers to both the `bare-http1` and `bare-https` global agents. No config flag is required for this behavior. Beta.11 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events.
+Generated HRPC and JSON-RPC entrypoints forward Bare `suspend` and `resume` events to the configured generic modules' optional lifecycle methods. Pear Worklet closes modules during full disposal or reinitialization; targeted wallet disposal leaves them running.
 
-This matters when a generated HRPC worklet performs HTTPS-backed fetches. Starting in beta.3, those generated entrypoints suspend and resume both agents together.
+HRPC entrypoints additionally suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare `suspend`, `resume`, and `idle` events. JSON-RPC beta.12 does not include that HTTP-agent handling. These lifecycle hooks require no diagnostic flag; `options.handleLeakCheck` only adds HRPC handle reporting.
 
 ## Troubleshooting
 
 - If `loadConfig()` cannot find a config file, run `npx wdk-worklet-bundler init` or pass `--config \<path\>`.
 - If `validate` or `generate` reports missing modules, use `generate --install` or inspect the install command from the exported helper APIs in the [API Reference](/tools/worklet-bundler/api-reference).
-- When `bare-pack` reports an unresolved package subpath, beta.11 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
+- When `bare-pack` reports an unresolved package subpath, beta.12 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
 - If you need to inspect generated source before bundling, use `generate --source-only` and review the files in `.wdk/`. For a CommonJS-only target, pack and convert that source as described above before running it.
 
 ***

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -5873,6 +5873,23 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### September 08, 2026
+
+**What's New**
+- **wallet-evm-erc-4337** ([v1.0.0-beta.19](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.19)): Monitor a known Safe address with `WalletAccountReadOnlyEvmErc4337.fromSafeAddress()` without its owner address or a seed phrase. Address validation now reports malformed owner inputs with `ValueError`.
+- **wdk-utils** ([v1.0.0-beta.12](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.12)): Add `validateTonAddress()` and `ton` dispatch for raw and checksum-validated user-friendly TON addresses. Require percent-encoded non-ASCII query text in BIP-21 and EIP-681 parsers, and fix key derivation with custom scrypt parameters above the default memory budget.
+
+**Changes**
+- **wdk-core** ([v1.0.0-beta.17](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.17)): [Breaking] Govern public account and protocol methods outside an explicit exclusion set, replacing the fixed operation list. Add method-name rules, `DEFAULT_POLICY_EXCLUSIONS`, constructor `policyExclusions`, and `getPolicyExclusions()`. Previously ungoverned calls can now require an `ALLOW` rule; rules naming excluded methods are rejected.
+- **lending-aave-evm** ([v1.0.0-beta.7](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.7)): Accept shared writable and read-only wallet-account interfaces and use callable account methods instead of concrete ERC-4337 class checks. Pass one transaction object to the account while preserving per-call configuration forwarding. Supply and repayment continue to require a separate token approval to the Pool.
+- **swap-velora-evm** ([v1.0.0-beta.8](https://github.com/tetherto/wdk-protocol-swap-velora-evm/releases/tag/v1.0.0-beta.8)): Forward one swap transaction and the per-call configuration to compatible accounts. Apply per-call `swapMaxFee` to standard EVM accounts as well as ERC-4337 accounts, in the account's quoted fee units. A fee equal to or above the cap is rejected. Input-token approval remains caller-owned.
+- **worklet-bundler** ([v1.0.0-beta.13](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.13)): Publish a maintenance release with an updated CLI version. The bundled runtime and public declarations are unchanged apart from the CLI's reported version.
+
+**Fixes**
+- **react-native-core** ([v1.0.0-beta.19](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.19)): Load Zod's compiler through a side-effect import for Metro and update Zod to `^4.5.4`. Public schemas and peer requirements are unchanged. The npm artifact still omits its declared default `dist` entrypoints; use the React Native source condition.
+
+---
+
 ### September 03, 2026
 
 **What's New**
@@ -5899,7 +5916,7 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 **Fixes**
 - **wallet-evm-erc-4337** ([v1.0.0-beta.17](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.17)): Allow a quoted or submitted fee equal to the configured maximum, classify AA50 prefund failures as insufficient-balance transaction errors, and add typed validation for configuration, providers, fee caps, and nonce ranges. The published per-call declarations still omit the runtime-supported `parallel` and `nonceKey` fields.
-- **lending-aave-evm** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.6)): Forward each operation's optional second `config` argument to the account's quote or send method. ERC-4337 accounts consume the gas-payment override; standard EVM accounts accept and silently ignore it.
+- **lending-aave-evm** ([v1.0.0-beta.6](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.6)): Forward each operation's optional `config` argument to the account's quote or send method. ERC-4337 accounts consume the gas-payment override; standard EVM accounts accept and silently ignore it.
 - **worklet-bundler** ([v1.0.0-beta.11](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.11)): Include `@tetherto/pear-wrk-wdk` in dependency validation and `generate --install` for both transports. When `bare-pack` reports an unresolved package subpath, the CLI now suggests the installable package root with the detected npm, Yarn, or pnpm command; the package-root normalization helper is internal to the CLI bundle and is not a public export.
 
 **Changes**
@@ -13097,9 +13114,9 @@ new WDK(seed, options?)
 
 **Parameters:**
 - `seed` (string | Uint8Array): BIP-39 mnemonic seed phrase or seed bytes
-- `options` (`WdkOptions`, optional): Instance settings. `maxConditionTimeoutMs` is a finite positive number that caps every policy condition timeout on this WDK instance and defaults to `30000` milliseconds.
+- `options` (`WdkOptions`, optional): Instance settings. `maxConditionTimeoutMs` is a finite positive number that caps every policy condition timeout on this WDK instance and defaults to `30000` milliseconds. `policyExclusions?: string[]` appends non-empty method names to the default policy exclusions.
 
-**Throws:** `Error` if the seed is invalid. Throws `PolicyConfigurationError` if `options` fails the published options schema, such as an array or primitive value, or if `maxConditionTimeoutMs` is not a finite positive number.
+**Throws:** `Error` if the seed is invalid. Throws `PolicyConfigurationError` if `options` fails the published options schema, such as an array or primitive value, if `maxConditionTimeoutMs` is not a finite positive number, or if `policyExclusions` is not an array of non-empty strings.
 
 **Example:**
 ```javascript title="Initialize WDK"
@@ -13125,13 +13142,14 @@ const policyWdk = new WDK(seedBytes, {
 | `registerWallet(blockchain, wallet, config)` | Registers a new wallet manager for a blockchain | `WDK` | If a wallet is already registered for that blockchain |
 | `registerProtocol(blockchain, label, protocol, config)` | Registers a protocol globally for a blockchain | `WDK` | - |
 | `registerMiddleware(blockchain, middleware)` | Registers middleware for account decoration | `WDK` | - |
-| `registerPolicy(policies, options?)` | Registers local transaction policies for wallet account and protocol write methods | `WDK` | If policy configuration is invalid |
+| `getPolicyExclusions()` | Returns the resolved method names that bypass policy evaluation | `readonly string[]` | - |
+| `registerPolicy(policies, options?)` | Registers local transaction policies for governed wallet account and protocol methods | `WDK` | If policy configuration is invalid |
 | `getAccount(blockchain, index?)` | Returns a wallet account for a blockchain and index | `Promise<WdkAccount>` | If wallet not registered |
 | `getAccountByPath(blockchain, path)` | Returns a wallet account for a blockchain and derivation path | `Promise<WdkAccount>` | If wallet not registered |
 | `getFeeRates(blockchain)` | Returns current fee rates for a registered blockchain | `Promise<FeeRates>` | If wallet not registered |
 | `dispose(blockchains?)` | Disposes all registered wallets, or only the named blockchains, and clears keys and account state managed by WDK | `void` | - |
 
-##### `registerWallet(blockchain, wallet, config)`
+#### `registerWallet(blockchain, wallet, config)`
 Registers a new wallet manager for a specific blockchain.
 
 **Type Parameters:**
@@ -13171,7 +13189,7 @@ const wdk2 = new WDK(seedPhrase)
   .registerWallet('ton', WalletManagerTon, tonWalletConfig)
 ```
 
-##### `registerProtocol(blockchain, label, protocol, config)`
+#### `registerProtocol(blockchain, label, protocol, config)`
 Registers a protocol globally for all accounts of a specific blockchain.
 
 For swidge or Smart Deposit Address (SDA) integrations, pass a concrete provider class that extends the corresponding base class from `@tetherto/wdk-wallet/protocols`.
@@ -13214,7 +13232,7 @@ const wdk2 = new WDK(seedPhrase)
   .registerProtocol('ethereum', 'velora', veloraProtocolEvm, veloraProtocolConfig)
 ```
 
-##### `registerMiddleware(blockchain, middleware)`
+#### `registerMiddleware(blockchain, middleware)`
 Registers middleware for account decoration and enhanced functionality.
 
 **Parameters:**
@@ -13248,10 +13266,25 @@ const wdk2 = new WDK(seedPhrase)
   })
 ```
 
-##### `registerPolicy(policies, options?)`
+#### `getPolicyExclusions()`
+
+Returns a frozen array containing [`DEFAULT_POLICY_EXCLUSIONS`](#default-policy-exclusions) followed by any additional `policyExclusions` passed to the constructor, with duplicate names removed. Names match globally across accounts and protocols on this instance; they are not scoped by wallet or protocol label.
+
+**Parameters:** None.
+
+**Returns:** `readonly string[]`. The returned array cannot be mutated, and it is not a setter for the engine's exclusions. Defaults remain present even when the constructor receives an empty array.
+
+You can check whether a named method bypasses policy evaluation:
+
+```javascript title="Inspect Policy Exclusions"
+const excludedMethods = wdk.getPolicyExclusions()
+console.log(excludedMethods.includes('getBalance')) // true
+```
+
+#### `registerPolicy(policies, options?)`
 Registers one or more local transaction policies on the WDK instance.
 
-Policies are evaluated before wrapped account and protocol write methods execute. Matching `DENY` rules and governed-account default-deny outcomes throw `PolicyViolationError`; matching `ALLOW` rules permit the call only when no higher-priority `DENY` rule applies. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
+Policies are evaluated before governed account and protocol methods execute. In beta.17, the proxy discovers public string-named methods on the account or protocol and its prototype chain, then wraps those absent from the resolved exclusion set. This replaces the earlier fixed write-method list; see [coverage and limits](/sdk/core-module/guides/transaction-policies#supported-operations). Matching `DENY` rules and governed-account default-deny outcomes throw `PolicyViolationError`; matching `ALLOW` rules permit the call only when no higher-priority `DENY` rule applies. Governed runtime accounts also expose `account.simulate.<method>(...)` mirrors so you can dry-run policy evaluation without sending, signing, or broadcasting.
 
 Evaluation order:
 
@@ -13273,7 +13306,7 @@ Distinct policy IDs keep their original per-registration timeouts. A repeated ID
 
 **Returns:** `WDK` - The WDK instance (supports method chaining)
 
-**Throws:** `PolicyConfigurationError` if a policy or option fails validation, if an account-scoped policy omits its account binding, or if a policy references a wallet identifier that has not been registered. Governed write calls also throw `PolicyConfigurationError` when WDK cannot snapshot a method argument safely.
+**Throws:** `PolicyConfigurationError` if a policy or option fails validation, if an account-scoped policy omits its account binding, if a policy references a wallet identifier that has not been registered, or if a rule names an excluded method. Governed calls also throw `PolicyConfigurationError` when WDK cannot snapshot a method argument safely.
 
 **Example:**
 ```typescript title="Register A Send Policy"
@@ -13333,13 +13366,11 @@ try {
 }
 ```
 
-Supported `PolicyOperation` values are `sendTransaction`, `signTransaction`, `transfer`, `approve`, `sign`, `signTypedData`, `signAuthorization`, `delegate`, `revokeDelegation`, `swap`, `bridge`, `supply`, `withdraw`, `borrow`, `repay`, `buy`, `sell`, `swidge`, `createDepositAddress`, `renewDepositAddress`, `recoverDepositAddress`, `disableDepositAddress`, and `*`.
+`PolicyOperation` is a string. A rule accepts one non-empty method name, a non-empty array of names, or `*` for all governed methods. Use the method's exact spelling: an unknown name registers but never matches a different method. Explicitly naming an excluded method fails registration; a wildcard does not include excluded methods.
 
-Use `sign` for message-style signing in this release. `signMessage` and `signHash` are not valid policy operation names.
+Governed methods return Promises, including methods whose underlying implementation is synchronous. Pass plain data arguments; object arguments are cloned before evaluation and execution, which can change class-instance semantics. See [argument handling and runtime caveats](/sdk/core-module/guides/transaction-policies#runtime-caveats) before governing callback-based or custom methods.
 
-Policy-enforced calls snapshot method arguments before evaluation and forward the same approved values to the wallet method. Pass structured-cloneable values such as primitives, plain objects, arrays, `bigint`, and typed arrays. Non-cloneable governed arguments fail closed with `PolicyConfigurationError`.
-
-##### `getAccount(blockchain, index?)`
+#### `getAccount(blockchain, index?)`
 Returns a wallet account for a specific blockchain and index using BIP-44 derivation.
 
 **Parameters:**
@@ -13369,7 +13400,7 @@ try {
 }
 ```
 
-##### `getAccountByPath(blockchain, path)`
+#### `getAccountByPath(blockchain, path)`
 Returns a wallet account for a specific blockchain and BIP-44 derivation path.
 
 **Parameters:**
@@ -13389,7 +13420,7 @@ const account = await wdk.getAccountByPath('ethereum', "0'/0/1")
 const customAccount = await wdk.getAccountByPath('ton', "1'/2/3")
 ```
 
-##### `getFeeRates(blockchain)`
+#### `getFeeRates(blockchain)`
 Returns current fee rates for a registered blockchain.
 
 **Parameters:**
@@ -13405,7 +13436,7 @@ const feeRates = await wdk.getFeeRates('ethereum')
 console.log('Fee rates:', feeRates)
 ```
 
-##### `dispose(blockchains?)`
+#### `dispose(blockchains?)`
 Disposes all registered wallets when called without arguments, or only the wallets for the named blockchains when you pass a string array.
 
 This clears keys and account state managed by WDK, including private keys held by registered wallets. It does not mutate or zero the seed value passed to `new WDK(seed)`. See [Seed Lifecycle](/sdk/core-module/guides/error-handling#seed-lifecycle) for the recommended cleanup pattern.
@@ -13429,7 +13460,7 @@ wdk.dispose(['ethereum'])
 | `getRandomSeedPhrase(wordCount?)` | Returns a random BIP-39 seed phrase (12 or 24 words) | `string` |
 | `isValidSeed(seed)` | Checks if a seed phrase or seed bytes value is valid | `boolean` |
 
-##### `getRandomSeedPhrase(wordCount?)`
+#### `getRandomSeedPhrase(wordCount?)`
 Returns a random BIP-39 seed phrase. Supports both 12-word (128-bit entropy) and 24-word (256-bit entropy) seed phrases.
 
 **Parameters:**
@@ -13450,7 +13481,7 @@ await presentSeedPhraseForSecureBackup(seedPhrase24)
 
 `presentSeedPhraseForSecureBackup()` represents an application-owned, non-logging backup flow. Never send a generated seed phrase to console output, telemetry, crash reports, or a remote service.
 
-##### `isValidSeed(seed)`
+#### `isValidSeed(seed)`
 Checks if a seed phrase or seed bytes value is valid.
 
 **Parameters:**
@@ -13466,6 +13497,20 @@ console.log('Seed phrase valid:', isValid) // true
 const isInvalid = WDK.isValidSeed('invalid seed phrase')
 console.log('Seed phrase valid:', isInvalid) // false
 ```
+
+### Default Policy Exclusions
+
+A root export with type `readonly string[]`. This frozen array lists method names that bypass policy evaluation by default, including `getBalance`, `quoteSendTransaction`, `dispose`, and `toReadOnlyAccount`.
+
+You can inspect the defaults without creating a wallet:
+
+```javascript title="Inspect Default Policy Exclusions"
+import { DEFAULT_POLICY_EXCLUSIONS } from '@tetherto/wdk'
+
+console.log(DEFAULT_POLICY_EXCLUSIONS.includes('getBalance')) // true
+```
+
+The list matches exact names, not prefixes: a new `get*` or `quote*` method is not automatically excluded. Use [`getPolicyExclusions()`](#getpolicyexclusions) to include the instance's custom additions. See [configuration](/sdk/core-module/configuration#policy-method-exclusions) before adding exclusions.
 
 ## IWalletAccount
 
@@ -14032,35 +14077,13 @@ type MiddlewareFunction = <A extends IWalletAccount>(
 ```typescript title="Types: Policy Engine"
 interface WdkOptions {
   maxConditionTimeoutMs?: number
+  policyExclusions?: string[]
 }
 
 type PolicyAction = 'ALLOW' | 'DENY'
 type PolicyScope = 'project' | 'account'
 
-type PolicyOperation =
-  | 'sendTransaction'
-  | 'signTransaction'
-  | 'transfer'
-  | 'approve'
-  | 'sign'
-  | 'signTypedData'
-  | 'signAuthorization'
-  | 'delegate'
-  | 'revokeDelegation'
-  | 'swap'
-  | 'bridge'
-  | 'supply'
-  | 'withdraw'
-  | 'borrow'
-  | 'repay'
-  | 'buy'
-  | 'sell'
-  | 'swidge'
-  | 'createDepositAddress'
-  | 'renewDepositAddress'
-  | 'recoverDepositAddress'
-  | 'disableDepositAddress'
-  | '*'
+type PolicyOperation = string
 
 type PolicyCondition = (context: PolicyContext) => boolean | Promise<boolean>
 
@@ -14254,7 +14277,7 @@ import WDK from '@tetherto/wdk'
 const wdk = new WDK(seedPhrase)
 ```
 
-The WDK Manager requires a seed phrase or seed bytes. Its optional second argument sets instance-level policy limits; wallet and protocol configuration remains registration-based.
+The WDK Manager requires a seed phrase or seed bytes. Its optional second argument sets instance-level policy limits and method exclusions; wallet and protocol configuration remains registration-based.
 
 ### Policy Condition Timeout Ceiling
 
@@ -14265,6 +14288,28 @@ const wdk = new WDK(seedPhrase, {
 ```
 
 `maxConditionTimeoutMs` is the maximum time any one policy condition can receive through `registerPolicy(..., { conditionTimeoutMs })`. It defaults to `30000` milliseconds and must be a finite positive number. A policy that requests a larger timeout is capped to this ceiling rather than rejected. Each `registerPolicy()` call applies its requested timeout only to the policies registered by that call.
+
+### Policy Method Exclusions
+
+Starting in `@tetherto/wdk` v1.0.0-beta.17, `policyExclusions` optionally adds method names that bypass policy evaluation on this WDK instance. It accepts an array of non-empty strings. The resolved set always includes [`DEFAULT_POLICY_EXCLUSIONS`](/sdk/core-module/api-reference#default-policy-exclusions); passing `[]` does not remove the defaults.
+
+An exclusion applies to the exact method name across every governed account and protocol on the instance. Review the method's behavior on each applicable module before excluding it. To permit a write while retaining evaluation and simulation, register an `ALLOW` rule instead.
+
+You can opt out of evaluating Spark's local balance synchronization using the constructor option:
+
+```javascript title="Configure A Method Exclusion"
+import WDK from '@tetherto/wdk'
+
+const wdk = new WDK(seedPhrase, {
+  policyExclusions: ['syncWalletBalance']
+})
+```
+
+This configuration bypasses evaluation for `syncWalletBalance`, which is governed by default. It does not grant permission to other Spark methods. Wallet and policy registration still happen separately.
+
+Inspect the resolved names with [`getPolicyExclusions()`](/sdk/core-module/api-reference#getpolicyexclusions). Duplicate names appear once, and the returned array is frozen. Names that no installed account exposes are accepted without an existence check. Exclusions are fixed when the WDK instance is created; mutating the input array later does not change them.
+
+`registerPolicy()` rejects a rule that explicitly names an excluded method, including a name inside an operation array. Remove the ineffective rule, or omit that method from your custom exclusions when creating the instance. Default exclusions cannot be removed. See [Transaction Policies](/sdk/core-module/guides/transaction-policies#supported-operations) for migration guidance.
 
 ## Wallet Registration Configuration
 
@@ -15014,7 +15059,9 @@ Learn how to [configure middleware](/sdk/core-module/guides/middleware) to add l
 URL: https://docs.wdk.tether.io/sdk/core-module/guides/transaction-policies
 Description: Register local ALLOW and DENY rules for WDK account and protocol write methods.
 
-Local transaction policies let a WDK app evaluate rules before account or protocol write methods execute. Use them for local approval limits, account-level exceptions, preflight checks, or UI flows that need a dry-run verdict before calling a wallet method.
+Use local transaction policies to evaluate account and protocol calls before execution. This guide covers [registering policies](#register-policies), [method coverage and migration](#supported-operations), and [simulating calls](#simulate-before-execution).
+
+Use `@tetherto/wdk` v1.0.0-beta.17 or later for method exclusions and coverage beyond the earlier fixed operation list. The examples assume you have loaded an app-owned `seedPhrase` and registered the relevant wallet modules.
 
 <Callout type="warn">
 Transaction policies are local pre-execution controls. They do not enforce rules on-chain, replace smart-contract permissions, or validate live token metadata, balances, prices, or contract state.
@@ -15022,15 +15069,15 @@ Transaction policies are local pre-execution controls. They do not enforce rules
 
 ## Policy Structure
 
-A transaction policy is a named local configuration object registered with `wdk.registerPolicy()`. Each policy chooses where it applies, then evaluates its ordered `rules` array before a governed account or protocol write method runs.
+A transaction policy is a named local configuration object registered with `wdk.registerPolicy()`. Each policy chooses where it applies, then evaluates its ordered `rules` array before a governed account or protocol method runs.
 
 | Concept | What you configure |
 | --- | --- |
 | Scope | `scope: 'project'` for project or wallet-level rules, or `scope: 'account'` for selected account indices or derivation paths |
 | Wallet | Optional `wallet` bindings for project policies, required `wallet` bindings for account policies |
-| Rules | Ordered `rules` array evaluated before a governed account or protocol write method runs |
+| Rules | Ordered `rules` array evaluated before a governed account or protocol method runs |
 | Action | `ALLOW` to permit a matching governed call, or `DENY` to block it with `PolicyViolationError` |
-| Operation | The wallet or protocol write operation a rule addresses, such as `sendTransaction`, `transfer`, `swap`, or `*` |
+| Operation | The wallet or protocol method a rule addresses, such as `sendTransaction`, `transfer`, `swap`, or `*` |
 | Conditions | Functions that receive `PolicyContext` and return truthy when the rule should match |
 
 Use `scope: 'project'` for rules that apply across all wallets or selected wallet identifiers. Use `scope: 'account'` with `wallet` and `accounts` for rules that apply only to specific account indices or derivation paths.
@@ -15043,9 +15090,17 @@ WDK does not manage durable policy state for you. Conditions can inspect the cur
 
 ## Register Policies
 
-Register wallets before policies. `wdk.registerPolicy()` validates wallet bindings synchronously and throws `PolicyConfigurationError` if a policy references a wallet identifier that has not been registered.
+Register wallets before policies. [`wdk.registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options) validates wallet bindings synchronously and throws `PolicyConfigurationError` if a policy references a wallet identifier that has not been registered.
 
-The example below allows normal operations, then denies ETH sends above a local approval limit. The wildcard `ALLOW` rule is intentional: once a policy governs an account, wrapped write operations are default-denied unless a matching `ALLOW` permits them.
+The example allows all governed operations, then denies ETH sends above a local approval limit. Its wildcard `ALLOW` deliberately permits other methods, including newly discovered methods after an upgrade. Use explicit method names instead when your app needs a narrow permission set.
+
+To register and exercise the send limit:
+
+1. Register the Ethereum wallet with its reviewed configuration.
+2. Register the rules through [`wdk.registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options).
+3. Attempt the over-limit send and handle its policy denial.
+
+You can enforce this local limit before [`sendTransaction()`](/sdk/core-module/api-reference#iwalletaccount) reaches the wallet:
 
 ```typescript title="Register A Local Send Limit"
 import WDK, { PolicyViolationError } from '@tetherto/wdk'
@@ -15112,7 +15167,7 @@ Account entries can be non-negative account indices or derivation-path strings. 
 WDK evaluates policies in this order:
 
 1. If no registered policy applies to the account, WDK returns the original account. No policy proxy or `simulate` mirror is added.
-2. If at least one policy applies, the account is governed. WDK wraps every supported write or signing operation that exists on that account, plus registered protocol write methods.
+2. If at least one policy applies, the account is governed. WDK wraps its discovered public methods and registered protocol methods unless their names are in the exclusion set. See [Supported Operations](#supported-operations) for the discovery boundary.
 3. If no rule addresses the attempted operation, WDK blocks the call with `PolicyViolationError` and `reason: 'no-applicable-rule'`.
 4. Account-scoped policies run before project-scoped policies. Within each scope, policies and rules run in registration order.
 5. A matching account-scoped `DENY` blocks immediately. A matching account-scoped `ALLOW` is recorded unless it has `override_broader_scope: true`.
@@ -15183,7 +15238,7 @@ In the example above, the treasury account can send up to `0.01 ETH` because the
 
 ## Supported Operations
 
-Use these operation names in `PolicyRule.operation`:
+In beta.17, `PolicyRule.operation` accepts any non-empty method-name string, an array of names, or `*`. The following are examples, not a closed list:
 
 | Operation | Method family |
 | --- | --- |
@@ -15202,9 +15257,29 @@ Use these operation names in `PolicyRule.operation`:
 | `buy`, `sell` | Fiat protocol writes |
 | `swidge` | Combined swap and bridge route execution |
 | `createDepositAddress`, `renewDepositAddress`, `recoverDepositAddress`, `disableDepositAddress` | Smart Deposit Address writes |
-| `*` | Wildcard rule for all wrapped write operations |
+| `*` | Wildcard rule for all governed methods |
 
-Use `sign` for message-style signing in this release. `signMessage` and `signHash` are not valid `PolicyOperation` values.
+Use the exact method name implemented by your wallet or protocol. For example, a rule for `payLightningInvoice` can now govern that Spark method. [`waitForTransaction()`](/sdk/core-module/api-reference#waitfortransactionhash-options) is also governed by default, so transaction polling needs a matching `ALLOW` rule on a governed account. A name that matches nothing still registers, but cannot allow the real call; a typo can leave that call denied. `signMessage` and `signHash` are accepted strings, but only affect methods with those names.
+
+Coverage comes from public string-named methods declared directly on the object or inherited from its class. The proxy skips names in [`getPolicyExclusions()`](/sdk/core-module/api-reference#getpolicyexclusions), `constructor`, protected members, symbol-named methods, and `Object.prototype` methods. Accessor-only properties are not intercepted; defining a getter does not add a governed method. An unfamiliar method is governed even when its name starts with `get` or `quote`. Governed methods return Promises; always `await` them even when the original method is synchronous.
+
+### Migrate From The Fixed Operation List
+
+Default-deny evaluation already existed before beta.17. This release expands which methods reach it. A call that previously bypassed evaluation can now fail with `reason: 'no-applicable-rule'`.
+
+1. Compare the methods your app calls with the resolved exclusions from [`getPolicyExclusions()`](/sdk/core-module/api-reference#getpolicyexclusions).
+2. Register an explicit `ALLOW` rule for each additional operation your app intends to permit, then verify its simulation and denial cases.
+3. For a method that should bypass evaluation, review its behavior across every applicable wallet and protocol before adding a [constructor exclusion](/sdk/core-module/configuration#policy-method-exclusions). Exclusions apply globally by name and also remove policy simulation for that method.
+
+You can inspect the resolved exclusions on an existing WDK instance:
+
+```javascript title="Inspect Method Coverage"
+const exclusions = wdk.getPolicyExclusions()
+console.log(exclusions.includes('getBalance')) // true by default
+console.log(exclusions.includes('payLightningInvoice')) // false by default
+```
+
+Default exclusions cannot be removed. [`registerPolicy()`](/sdk/core-module/api-reference#registerpolicypolicies-options) rejects rules naming an excluded method because those rules could never run. Adding a wildcard `ALLOW` permits every governed method and is not a substitute for reviewing the expanded method surface.
 
 ## Common Policy Patterns
 
@@ -15341,9 +15416,9 @@ Conditions receive a frozen `PolicyContext`:
 | `operation` | The operation being evaluated |
 | `wallet` | The wallet identifier bound to the account |
 | `account` | Read-only account view exposed by the wallet module |
-| `args` | Frozen array containing a snapshot of every argument passed to the wrapped method, in signature order |
+| `args` | Frozen array of arguments in signature order; object values are cloned for evaluation |
 
-For governed write calls, WDK snapshots the method arguments once before policy evaluation. Conditions see that snapshot, and WDK forwards the same approved values to the underlying wallet method. This prevents a caller from mutating a transaction object while an asynchronous policy condition is running.
+For governed calls, WDK clones object arguments before policy evaluation, then gives conditions a separate clone of that snapshot. The wallet receives the original snapshot, so later mutations to the caller's transaction object or the condition's copy do not change the forwarded values. The context and `args` array are frozen shallowly; nested objects are not frozen. Keep conditions free of mutations because conditions share their evaluation context.
 
 <Callout type="warn">
 `PolicyContext.params` was removed in `@tetherto/wdk` v1.0.0-beta.16. Replace `params` with `args[0]`. For multi-argument methods, use the actual signature position and check optional arguments before reading their fields. For example, a `swidge(options, config?)` condition reads `options` from `args[0]` and `config` from `args[1]`.
@@ -15355,7 +15430,7 @@ Set `maxConditionTimeoutMs` in the WDK constructor to cap every per-policy timeo
 
 ## Simulate Before Execution
 
-When a policy applies to an account, WDK adds runtime `simulate` mirrors for wrapped account and protocol write methods. Simulation returns the policy verdict and does not call the underlying wallet or protocol method.
+When a policy applies to an account, WDK adds runtime `simulate` mirrors for governed account and protocol methods, including methods outside the earlier fixed operation list. Simulation returns the policy verdict and does not call the underlying wallet or protocol method.
 
 You can dry-run a governed account method through the runtime `simulate` mirror:
 
@@ -15378,18 +15453,19 @@ In this beta, `simulate` is added at runtime but is not typed on the account ret
 
 ## Handle Errors
 
-`PolicyConfigurationError` means WDK rejected the policy setup or could not safely evaluate a governed call. Common causes include invalid scopes, actions, operation names, condition functions, timeout options, missing account bindings, wallet identifiers that have not been registered, or governed method arguments that are not structured-cloneable.
+`PolicyConfigurationError` means WDK rejected the policy setup or could not safely evaluate a governed call. Common causes include invalid scopes, actions, empty or non-string operation names, rules naming excluded methods, invalid condition functions or timeout options, missing account bindings, unknown wallet identifiers, or object arguments that cannot be cloned.
 
-`PolicyViolationError` means an enforced write call was blocked by a matching `DENY` rule or by default-deny when no `ALLOW` rule matched. Catch it around the write call and surface the `reason` to the user or approval workflow.
+`PolicyViolationError` means a governed call was blocked by a matching `DENY` rule or by default-deny when no `ALLOW` rule matched. Catch it around the write call and surface the `reason` to the user or approval workflow.
 
 ## Runtime Caveats
 
 - Policies wrap the WDK account/protocol proxy surface. On governed proxies, `keyPair` and string members beginning with `_` are absent from direct property access, membership checks, own-property descriptors, and own-key enumeration. The proxy also refuses `Object.preventExtensions()` and `Object.freeze()` with `TypeError` so those hiding rules remain valid.
 - This is not a complete sandbox. Prototype inspection, separately retained raw account or protocol references, and nested calls made inside a module remain outside the proxy interception path.
-- Quote and read methods are not wrapped. Policies apply to write methods such as sends, signs, swaps, bridges, lending writes, fiat writes, swidge execution, and SDA address creation, renewal, recovery, or disablement.
+- The default exclusions contain specific read, quote, and lifecycle method names. A read or quote method absent from that list is governed until you explicitly exclude it; a `get` or `quote` prefix does not change coverage.
 - Policy conditions receive local method arguments. WDK does not decode calldata, fetch prices, validate token metadata, or calculate fiat value unless your condition function does that work.
 - Wallet accounts must expose a read-only account view when a policy applies, otherwise `getAccount()` fails with `PolicyConfigurationError`.
-- Governed write-call arguments must be structured-cloneable, such as primitives, plain objects, arrays, `bigint`, and typed arrays. Functions, live class instances, and other non-cloneable values fail closed with `PolicyConfigurationError` instead of being forwarded unsafely.
+- Pass plain data to governed methods. An object that cannot be structured-cloned, such as a plain object containing a callback, fails with `PolicyConfigurationError`. Class instances can become plain objects and lose their methods. A top-level function argument passes through unchanged in this release, so do not treat the snapshot as isolation for callback-driven state or side effects.
+- Method discovery is not a live monitor of account changes. Add module methods before obtaining a governed account; do not rely on mutating an account or its prototype after wrapping to update policy coverage.
 - Engine-managed state hooks are not active in this beta. The schema accepts `state` and `onSuccess`, but WDK does not pass `state` into conditions, update it after execution, persist it, or call `onSuccess`. Conditions can still use app-owned state through closures or external stores; keep that state outside `rule.state`, and have your app own durability, concurrency, and rollback behavior.
 
 ## Next Steps
@@ -18100,6 +18176,8 @@ Works on supported Aave V3 EVM networks, including Ethereum, Arbitrum, Optimism,
 - **ERC‑4337 Smart Accounts**: `@tetherto/wdk-wallet-evm-erc-4337`
 - **Read‑Only Accounts**: For quoting and reading account data without sending transactions
 
+Beta.7 accepts the shared wallet interfaces and checks for a callable `sendTransaction()` before each write. The account must still expose the EVM provider and account methods the selected operation needs. See [account configuration](/sdk/lending-modules/lending-aave-evm/configuration#account-configuration) for wrapper requirements. Supply and repayment require a separate token approval to the Aave Pool.
+
 ## Key Components
 
 - **Aave V3 Integration**: Supply, withdraw, borrow, repay primitives
@@ -18139,11 +18217,16 @@ new AaveProtocolEvm(account)
 ```
 
 Parameters:
-- `account`: `WalletAccountEvm | WalletAccountReadOnlyEvm | WalletAccountEvmErc4337 | WalletAccountReadOnlyEvmErc4337`
+- `account`: `IWalletAccount | IWalletAccountReadOnly` from `@tetherto/wdk-wallet`
+
+Since beta.7, write methods check for a callable `sendTransaction()` rather than a concrete account class. The implementation still reads `account._config.provider`; supply an EVM-compatible JSON-RPC URL or EIP-1193 provider for a supported Aave deployment. Shared interfaces alone do not make another chain's account compatible. The selected operation also needs its account methods, such as `getAddress()`, `getTokenBalance()`, and `quoteSendTransaction()`.
+
+Before supplying or repaying, grant the Aave Pool enough token allowance through the account's approval API and wait for approval confirmation. The lending module does not approve or reset allowances automatically. Use the Pool and token addresses for the same chain. The examples below use 1 USD₮ on Ethereum, whose contract is `0xdAC17F958D2ee523a2206206994597C13D831ec7` with 6 decimals.
 
 Example:
 
 ```javascript
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 const aave = new AaveProtocolEvm(account)
 ```
 
@@ -18151,7 +18234,7 @@ const aave = new AaveProtocolEvm(account)
 
 | Method | Description | Returns |
 |--------|-------------|---------|
-| `supply(options, config?)` | Add tokens to the pool | `Promise<{hash: string, fee: bigint, approveHash?: string, resetAllowanceHash?: string}>` |
+| `supply(options, config?)` | Add tokens to the pool | `Promise<{hash: string, fee: bigint}>` |
 | `quoteSupply(options, config?)` | Estimate cost to add tokens | `Promise<{fee: bigint}>` |
 | `withdraw(options, config?)` | Remove tokens from the pool | `Promise<{hash: string, fee: bigint}>` |
 | `quoteWithdraw(options, config?)` | Estimate cost to withdraw | `Promise<{fee: bigint}>` |
@@ -18167,9 +18250,9 @@ const aave = new AaveProtocolEvm(account)
 
 When `AaveProtocolEvm` is initialized with an ERC‑4337 smart account, the optional `config` argument on mutating and quote methods accepts the same gas-payment override families documented in [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference): paymaster token, sponsorship policy, and native coins.
 
-Standard (non‑ERC‑4337) accounts silently ignore this optional ERC‑4337 configuration and use their normal EVM transaction path.
+The protocol forwards `config` to the account's send or quote method. Standard WDK EVM accounts ignore ERC-4337 gas-payment fields; compatible wrappers determine their own handling. Fees retain the account's denomination, which can be native wei, paymaster-token base units, or zero for sponsorship.
 
-### `supply(options, config?)`
+#### `supply(options, config?)`
 Add tokens to the pool.
 
 Options:
@@ -18178,26 +18261,26 @@ Options:
 - `onBehalfOf` (`string`, optional)
 
 Returns:
-- May include `approveHash` and `resetAllowanceHash` for standard accounts (e.g., USD₮ allowance reset on Ethereum mainnet)
+- The account's transaction result, including `hash` and `fee`. The protocol does not add approval transaction hashes.
 
 Example:
 
 ```javascript
-const res = await aave.supply({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const res = await aave.supply({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `quoteSupply(options, config?)`
+#### `quoteSupply(options, config?)`
 Estimate fee to add tokens.
 
 ```javascript
-const q = await aave.quoteSupply({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteSupply({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `withdraw(options, config?)`
+#### `withdraw(options, config?)`
 Remove tokens from the pool.
 
 Options:
@@ -18206,21 +18289,21 @@ Options:
 - `to` (`string`, optional)
 
 ```javascript
-const tx = await aave.withdraw({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const tx = await aave.withdraw({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `quoteWithdraw(options, config?)`
+#### `quoteWithdraw(options, config?)`
 Estimate fee to withdraw tokens.
 
 ```javascript
-const q = await aave.quoteWithdraw({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteWithdraw({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `borrow(options, config?)`
+#### `borrow(options, config?)`
 Borrow tokens.
 
 Options:
@@ -18229,21 +18312,21 @@ Options:
 - `onBehalfOf` (`string`, optional)
 
 ```javascript
-const tx = await aave.borrow({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const tx = await aave.borrow({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `quoteBorrow(options, config?)`
+#### `quoteBorrow(options, config?)`
 Estimate fee to borrow tokens.
 
 ```javascript
-const q = await aave.quoteBorrow({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteBorrow({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `repay(options, config?)`
+#### `repay(options, config?)`
 Repay borrowed tokens.
 
 Options:
@@ -18252,33 +18335,33 @@ Options:
 - `onBehalfOf` (`string`, optional)
 
 ```javascript
-const tx = await aave.repay({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const tx = await aave.repay({ token: USDT, amount: 1000000n })
 ```
 
 Returns:
-- For standard accounts, may include `approveHash` / `resetAllowanceHash` when applicable.
+- The account's transaction result, including `hash` and `fee`. Required approvals are separate operations.
 
 ---
 
-### `quoteRepay(options, config?)`
+#### `quoteRepay(options, config?)`
 Estimate fee to repay borrowed tokens.
 
 ```javascript
-const q = await aave.quoteRepay({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+const q = await aave.quoteRepay({ token: USDT, amount: 1000000n })
 ```
 
 ---
 
-### `setUseReserveAsCollateral(token, use, config?)`
+#### `setUseReserveAsCollateral(token, use, config?)`
 Toggle token as collateral for the user.
 
 ```javascript
-const tx = await aave.setUseReserveAsCollateral('TOKEN_ADDRESS', true)
+const tx = await aave.setUseReserveAsCollateral(USDT, true)
 ```
 
 ---
 
-### `setUserEMode(categoryId, config?)`
+#### `setUserEMode(categoryId, config?)`
 Set user eMode category.
 
 ```javascript
@@ -18287,7 +18370,7 @@ const tx = await aave.setUserEMode(1)
 
 ---
 
-### `getAccountData(account?)`
+#### `getAccountData(account?)`
 Read account stats like total collateral, debt, and health.
 
 ```javascript
@@ -18382,7 +18465,9 @@ const aave = new AaveProtocolEvm(account)
 
 ## Account Configuration
 
-The service uses the wallet account configuration to connect to the target network and sign transactions.
+The constructor accepts `IWalletAccount` or `IWalletAccountReadOnly`. The implementation reads `account._config.provider` and expects an EVM-compatible JSON-RPC URL or EIP-1193 provider. Compatible account wrappers must expose this configuration plus the methods required by the chosen operation. Every write checks for a callable `sendTransaction()`; quotes call `quoteSendTransaction()` without requiring write capability. The wider interfaces do not add support for non-EVM chains.
+
+For accounts governed by WDK transaction policies, use [`wdk.registerProtocol()`](/sdk/core-module/api-reference#registerprotocolblockchain-label-protocol-config) and the account's protocol getter. Do not pass the governed account proxy directly to this constructor: that proxy hides `_config`.
 
 ```javascript
 import { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
@@ -18393,7 +18478,7 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 })
 
 // Read-only account (quotes, reads)
-const readOnly = new WalletAccountReadOnlyEvm('0xYourAddress', {
+const readOnly = new WalletAccountReadOnlyEvm(await account.getAddress(), {
   provider: 'https://ethereum-rpc.publicnode.com'
 })
 
@@ -18402,7 +18487,7 @@ const aave = new AaveProtocolEvm(account)
 
 ## ERC‑4337 (Account Abstraction)
 
-When using ERC‑4337 smart accounts, every mutating method and quote helper accepts an optional `config` override. In `v1.0.0-beta.6`, that override matches the three gas-payment families exposed by [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins. Standard (non‑ERC‑4337) accounts silently ignore this optional ERC‑4337 configuration.
+Every mutating method and quote helper forwards its optional `config` argument to the account. The declared gas-payment families match [`@tetherto/wdk-wallet-evm-erc-4337`](/sdk/wallet-modules/wallet-evm-erc-4337/configuration): paymaster token, sponsorship policy, or native coins. Standard WDK EVM accounts ignore these wallet fields. Fees keep the account's denomination; a token-paymaster quote is not a native-wei quote.
 
 Use the fields that match the gas-payment mode you want for that call. For the full field-level definitions, see the [`@tetherto/wdk-wallet-evm-erc-4337` configuration docs](/sdk/wallet-modules/wallet-evm-erc-4337/configuration) and [`Config Override`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) reference.
 
@@ -18453,20 +18538,22 @@ const arb = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 ## Operation Options
 
-Each operation accepts a simple options object:
+Each operation accepts an options object. Before supplying or repaying, confirm the account's token allowance to the [Aave Pool for the selected network](https://github.com/bgd-labs/aave-address-book) and send any required approval separately. The lending module does not add approval or allowance-reset transactions. To change an existing nonzero Ethereum USD₮ allowance to another nonzero amount, first approve zero and wait for confirmation, then approve the new amount and wait again. These examples use 1 USD₮ on Ethereum (6 decimals):
 
 ```javascript
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDt on Ethereum
+
 // Supply
-await aave.supply({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.supply({ token: USDT, amount: 1000000n })
 
 // Withdraw
-await aave.withdraw({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.withdraw({ token: USDT, amount: 1000000n })
 
 // Borrow
-await aave.borrow({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.borrow({ token: USDT, amount: 1000000n })
 
 // Repay
-await aave.repay({ token: 'TOKEN_ADDRESS', amount: 1000000n })
+await aave.repay({ token: USDT, amount: 1000000n })
 ```
 
 ### Common Parameters
@@ -18575,7 +18662,7 @@ try {
     token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
     amount: 1000000n
   })
-  console.log('Borrow fee (wei):', q.fee)
+  console.log('Borrow fee (account units):', q.fee)
 } catch (e) {
   console.error('Quote failed:', e.message)
 }
@@ -18618,6 +18705,8 @@ This guide walks through [supply](#supply), [withdraw](#withdraw), [borrow](#bor
 
 ## Supply
 
+Before supplying, confirm sufficient token allowance to the Aave Pool for your chain. Send any required approval through the wallet account and wait for confirmation. The lending module does not approve or reset allowances automatically.
+
 You can deposit reserves into the pool using [`supply()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Supply USDt"
@@ -18651,6 +18740,8 @@ console.log('Borrow tx hash:', tx.hash)
 
 ## Repay
 
+Repayment also requires sufficient token allowance to the Aave Pool. Complete any approval before calling `repay()`; it is a separate transaction from repayment.
+
 You can pay down debt using [`repay()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Repay USDt"
@@ -18662,13 +18753,15 @@ console.log('Repay tx hash:', tx.hash)
 
 ## Quotes before sending
 
+Quote fees use the wallet account's fee denomination: native wei for standard EVM/native-coin fees, paymaster-token base units for token-paid fees, or zero for sponsored quotes. Supply and repayment quotes assume any required approval is already in place; they do not include a separate approval's cost.
+
 You can estimate the supply fee with [`quoteSupply()`](/sdk/lending-modules/lending-aave-evm/api-reference):
 
 ```javascript title="Quote supply fee"
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const supplyQuote = await aave.quoteSupply({ token: USDT, amount: 1000000n })
-console.log('Supply fee (wei):', supplyQuote.fee)
+console.log('Supply fee (account units):', supplyQuote.fee)
 ```
 
 You can estimate the withdraw fee with [`quoteWithdraw()`](/sdk/lending-modules/lending-aave-evm/api-reference):
@@ -18677,7 +18770,7 @@ You can estimate the withdraw fee with [`quoteWithdraw()`](/sdk/lending-modules/
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const withdrawQuote = await aave.quoteWithdraw({ token: USDT, amount: 1000000n })
-console.log('Withdraw fee (wei):', withdrawQuote.fee)
+console.log('Withdraw fee (account units):', withdrawQuote.fee)
 ```
 
 You can estimate the borrow fee with [`quoteBorrow()`](/sdk/lending-modules/lending-aave-evm/api-reference):
@@ -18686,7 +18779,7 @@ You can estimate the borrow fee with [`quoteBorrow()`](/sdk/lending-modules/lend
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const borrowQuote = await aave.quoteBorrow({ token: USDT, amount: 1000000n })
-console.log('Borrow fee (wei):', borrowQuote.fee)
+console.log('Borrow fee (account units):', borrowQuote.fee)
 ```
 
 You can estimate the repay fee with [`quoteRepay()`](/sdk/lending-modules/lending-aave-evm/api-reference):
@@ -18695,7 +18788,7 @@ You can estimate the repay fee with [`quoteRepay()`](/sdk/lending-modules/lendin
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 const repayQuote = await aave.quoteRepay({ token: USDT, amount: 1000000n })
-console.log('Repay fee (wei):', repayQuote.fee)
+console.log('Repay fee (account units):', repayQuote.fee)
 ```
 
 <Callout type="warn">
@@ -18704,7 +18797,7 @@ Health factor and collateralization limits still apply. A quote does not guarant
 
 ## ERC-4337 smart accounts
 
-You can run the same methods through [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and pass a second `config` argument to override per-call gas payment settings. In `v1.0.0-beta.6`, the lending methods accept the same override families as the wallet module: paymaster token, sponsorship policy, and native coins. Standard (non‑ERC‑4337) accounts silently ignore this optional configuration. See the [ERC-4337 config override](/sdk/lending-modules/lending-aave-evm/api-reference) section for the full field list.
+You can run the same methods through [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) and pass the optional `config` argument to override per-call gas payment settings. The lending methods accept the same override families as the wallet module: paymaster token, sponsorship policy, and native coins. Standard WDK EVM accounts ignore these wallet fields; compatible wrappers determine their own handling. See the [ERC-4337 config override](/sdk/lending-modules/lending-aave-evm/api-reference) section for the full field list.
 
 ```javascript title="Supply with paymaster"
 import { WalletAccountEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -18716,7 +18809,10 @@ const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   bundlerUrl: process.env.BUNDLER_URL,
   paymasterUrl: process.env.PAYMASTER_URL,
   paymasterAddress: process.env.PAYMASTER_ADDRESS,
-  safeModulesVersion: '0.3.0'
+  safeModulesVersion: '0.3.0',
+  paymasterToken: {
+    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+  }
 })
 
 const aaveAA = new AaveProtocolEvm(aa)
@@ -20765,7 +20861,7 @@ Use the Velora swap module to quote and execute token swaps on EVM chains. It wo
 
 - **Token Swapping**: Execute token swaps through velora on supported EVM networks
 - **Account Abstraction**: Compatible with standard EVM accounts and ERC‑4337 smart accounts
-- **Fee Controls**: Optional `swapMaxFee` to cap gas costs
+- **Fee Controls**: Constructor and per-call `swapMaxFee` for standard and smart accounts, in the account quote's fee units
 - **Approval-aware swaps**: Approve input tokens with the wallet account before swapping when allowance is required
 - **Provider Flexibility**: Works with JSON‑RPC URLs and EIP‑1193 providers
 - **TypeScript Support**: Full TypeScript definitions included
@@ -20782,11 +20878,13 @@ The swap service supports multiple EVM wallet types:
 - **ERC‑4337 Smart Accounts**: `@tetherto/wdk-wallet-evm-erc-4337` accounts with bundler/paymaster
 - **Read‑Only Accounts**: For quoting swaps without sending transactions
 
+The constructor accepts shared wallet interfaces, while the implementation requires an EVM provider in `account._config.provider`. Compatible wrappers must also expose the account methods used for quotes and execution. A callable `sendTransaction()` establishes writability; it does not establish chain or provider compatibility.
+
 ## Key Components
 
 - **velora Integration**: Uses velora aggregator for routing and quotes
 - **Quote System**: Pre‑transaction fee and amount estimation via `quoteSwap`
-- **AA Integration**: Optional paymaster, sponsorship, native-fee, and fee-cap overrides when using ERC‑4337
+- **AA Integration**: Forward paymaster, sponsorship, and native-fee overrides to compatible ERC‑4337 accounts
 - **Read-only quoting**: Quote swaps from read-only EVM and ERC‑4337 accounts
 
 ## Next Steps
@@ -20831,9 +20929,9 @@ new VeloraProtocolEvm(account, config?)
 Parameters:
 - `account`: `IWalletAccount | IWalletAccountReadOnly` from `@tetherto/wdk-wallet`
 - `config` (optional):
-  - `swapMaxFee` (`bigint`): maximum total gas fee allowed (wei)
+  - `swapMaxFee` (`bigint`): exclusive cap in the fee units returned by the account's quote
 
-The beta.7 declarations accept the generic wallet interfaces, but this package still requires an EVM-compatible account with a configured JSON-RPC URL or EIP-1193 provider. Use an EVM account from WDK's EVM wallet modules; the wider interfaces do not add support for arbitrary or non-EVM accounts.
+The declarations accept the shared wallet interfaces. The implementation also reads `account._config.provider` and requires an EVM-compatible JSON-RPC URL or EIP-1193 provider. An interface match alone does not establish compatibility. Quoting needs `getAddress()` and `quoteSendTransaction()`; execution additionally requires a callable `sendTransaction()`.
 
 Example:
 
@@ -20850,7 +20948,7 @@ const swap = new VeloraProtocolEvm(account, { swapMaxFee: 200000000000000n })
 
 ---
 
-### `swap(options, config?)`
+#### `swap(options, config?)`
 Execute a swap via velora.
 
 Options:
@@ -20860,14 +20958,16 @@ Options:
 - `tokenOutAmount` (`bigint`, optional): Exact output amount (base units)
 - `to` (`string`, optional): Recipient address (defaults to account address)
 
-Config (ERC‑4337 only):
+Config (optional; wallet gas-payment fields depend on the account):
 - `paymasterToken` (`{ address: string }`, optional): Paymaster token override for this swap
 - `isSponsored` (`true`, optional): Use sponsorship mode for this swap
 - `sponsorshipPolicyId` (`string`, optional): Sponsorship policy override
 - `useNativeCoins` (`true`, optional): Pay fees in the chain's native token
-- `swapMaxFee` (`bigint`, optional): Per‑swap fee cap (wei)
+- `swapMaxFee` (`bigint`, optional): Per-swap exclusive fee cap, in the account quote's units
 
-These per-swap overrides are applied only when the protocol uses a concrete `WalletAccountEvmErc4337`. With another writable EVM account, `swap()` sends one EVM transaction and does not apply the ERC‑4337 config object.
+Since beta.8, `swap()` passes one transaction object and the same `config` to the account's `quoteSendTransaction()` and `sendTransaction()`. It does not select the path by concrete account class. Standard WDK EVM accounts ignore wallet paymaster/sponsorship fields, but the protocol applies a per-call `swapMaxFee` for these accounts too.
+
+The per-call cap overrides the constructor cap. A quote equal to or above that cap rejects the swap before sending. Match the cap to the quote's denomination: native wei for standard EVM/native-coin fees, paymaster-token base units for token-paid fees, or zero for sponsored quotes. A zero cap rejects even a zero-fee quote. `quoteSwap()` itself does not enforce the cap.
 
 Returns:
 - Standard account: `{ hash, fee, tokenInAmount, tokenOutAmount }`
@@ -20881,15 +20981,15 @@ Example:
 
 ```javascript
 const tx = await swap.swap({
-  tokenIn: '0xdAC17F...ec7',      // USDt
-  tokenOut: '0xC02a...6Cc2',      // WETH
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n
 })
 ```
 
 ---
 
-### `quoteSwap(options, config?)`
+#### `quoteSwap(options, config?)`
 Get estimated fee and token in/out amounts.
 
 Options are the same as `swap`.
@@ -20902,7 +21002,7 @@ Config (ERC‑4337 only):
 - `sponsorshipPolicyId` (`string`, optional): Sponsorship policy override
 - `useNativeCoins` (`true`, optional): Estimate fees in the chain's native token
 
-These per-call overrides are applied only when the protocol uses a concrete `WalletAccountReadOnlyEvmErc4337`. Other accounts use the ordinary single-transaction quote path and do not apply the ERC‑4337 config object.
+The protocol forwards one transaction object and `config` to any compatible account's `quoteSendTransaction()`. The account determines which wallet options apply; standard WDK EVM accounts ignore the ERC-4337 fields. The returned fee keeps the account's denomination. Quoting does not enforce `swapMaxFee` or reserve a route for later execution.
 
 Works with read‑only accounts.
 
@@ -20910,8 +21010,8 @@ Example:
 
 ```javascript
 const quote = await swap.quoteSwap({
-  tokenIn: '0xdAC17F...ec7',      // USDt
-  tokenOut: '0xC02a...6Cc2',      // WETH
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenOutAmount: 500000000000000000n // 0.5 WETH
 })
 ```
@@ -20922,7 +21022,7 @@ const quote = await swap.quoteSwap({
 
 Common errors include:
 - Insufficient liquidity / no route for pair
-- Fee exceeds `swapMaxFee`
+- Quoted fee is equal to or greater than `swapMaxFee`
 - Read‑only account cannot send swaps
 - Provider/RPC errors (invalid endpoint, network mismatch)
 
@@ -20930,7 +21030,7 @@ Common errors include:
 
 ## Types
 
-- `swapMaxFee: bigint` — Upper bound for gas fees (wei)
+- `swapMaxFee: bigint`: Exclusive cap in the account quote's fee units
 - `tokenInAmount/tokenOutAmount: bigint` — ERC‑20 base units
 - `paymasterToken: { address: string }` — ERC‑4337 paymaster token override
 
@@ -20973,13 +21073,15 @@ const account = new WalletAccountEvm(seedPhrase, "0'/0/0", {
 
 // Create swap service with configuration
 const swapProtocol = new VeloraProtocolEvm(account, {
-  swapMaxFee: 200000000000000n // Optional: Max swap fee in wei
+  swapMaxFee: 200000000000000n // Optional: Exclusive fee cap in wei for this EVM account
 })
 ```
 
 ## Account Configuration
 
-The swap service uses the wallet account configuration for network access and signing. The account must expose an EVM-compatible JSON-RPC URL or EIP-1193 provider; a generic interface type does not make a non-EVM account compatible with this module:
+The swap service reads `account._config.provider` for network access. The account must expose an EVM-compatible JSON-RPC URL or EIP-1193 provider, plus `getAddress()` and `quoteSendTransaction()`. Execution also requires a callable `sendTransaction()`. A shared interface type alone does not make a non-EVM account compatible.
+
+For accounts governed by WDK transaction policies, use [`wdk.registerProtocol()`](/sdk/core-module/api-reference#registerprotocolblockchain-label-protocol-config) and the account's protocol getter. Do not pass the governed account proxy directly to this constructor: that proxy hides `_config`.
 
 ```javascript
 import { WalletAccountEvm, WalletAccountReadOnlyEvm } from '@tetherto/wdk-wallet-evm'
@@ -20995,7 +21097,7 @@ const account = new WalletAccountEvm(
 
 // Read-only account (quotes only)
 const readOnly = new WalletAccountReadOnlyEvm(
-  '0xYourAddress',
+  await account.getAddress(),
   {
     provider: 'https://ethereum-rpc.publicnode.com'
   }
@@ -21011,29 +21113,26 @@ const swapProtocol = new VeloraProtocolEvm(account, {
 
 ### Swap Max Fee
 
-The `swapMaxFee` option sets an upper bound for total gas costs to prevent excessive fees.
+The `swapMaxFee` option rejects execution when the account's quoted fee is equal to or greater than the cap. Since beta.8, the second argument to `swap()` can override this cap for standard EVM accounts as well as smart accounts. `quoteSwap()` does not enforce it.
 
 **Type:** `bigint` (optional)
-**Unit:** Wei
+**Unit:** The account quote's fee units: native wei for standard EVM or native-coin fees, paymaster-token base units for token-paid fees, or zero for sponsored quotes. Choose a cap for the selected gas-payment mode; a zero cap rejects a zero-fee sponsored quote.
 
 **Examples:**
 
 ```javascript
-const config = {
-  // Cap total gas fee to 0.0002 ETH (in wei)
-  swapMaxFee: 200000000000000n,
-}
-
-// Usage example
+// Ethereum standard EVM account; input allowance must already be sufficient
 try {
   const result = await swapProtocol.swap({
     tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt (6 decimals)
     tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH (18 decimals)
     tokenInAmount: 1000000n
-  })
+  }, { swapMaxFee: 200000000000000n }) // Exclusive cap of 0.0002 ETH
 } catch (error) {
-  if (error.message.includes('max fee')) {
+  if (error.message === 'Exceeded maximum fee cost for swap operation.') {
     console.error('Swap stopped: Fee too high')
+  } else {
+    throw error
   }
 }
 ```
@@ -21050,30 +21149,32 @@ const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   provider: 'https://ethereum-rpc.publicnode.com',
   bundlerUrl: 'YOUR_BUNDLER_URL',
   paymasterUrl: 'YOUR_PAYMASTER_URL',
-  paymasterAddress: 'YOUR_PAYMASTER_ADDRESS',
+  paymasterAddress: process.env.PAYMASTER_ADDRESS,
   safeModulesVersion: '0.3.0',
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   }
 })
 
-const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 200000000000000n })
+const swapAA = new VeloraProtocolEvm(aa)
 
 const result = await swapAA.swap({
-  tokenIn: '0xTokenIn',
-  tokenOut: '0xTokenOut',
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n
 }, {
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  swapMaxFee: 200000000000000n // Per‑swap override
+  swapMaxFee: 10000n // Exclusive cap of 0.01 USDt for this token-paid quote
 })
 ```
 
 ### Per-call ERC‑4337 Config
 
-The second argument to `swap()` and `quoteSwap()` accepts ERC‑4337 wallet config overrides only when the protocol uses the concrete `WalletAccountEvmErc4337` or `WalletAccountReadOnlyEvmErc4337` class, respectively. Use it to switch paymaster token, sponsorship policy, or native-coin fee behavior for a single call. `swap()` also accepts `swapMaxFee` as a per-swap fee cap. Standard EVM accounts use one ordinary EVM transaction and do not apply these per-call ERC‑4337 overrides.
+The protocol passes the second argument to the account's quote and send methods without a concrete-class check. Compatible ERC-4337 accounts use it to select paymaster-token, sponsorship, or native-coin behavior. Standard WDK EVM accounts ignore those wallet fields, but the protocol still applies `swapMaxFee` from the second argument to `swap()`. Quote and execution receive one transaction object, not an ERC-4337-specific array.
+
+The paymaster service must support the chosen chain and token. Configure its own endpoint and contract address; `PAYMASTER_ADDRESS` is deployment-specific. Approve the swap's input token for the current Velora spender before executing. The module does not create that approval for you. To change a nonzero Ethereum USD₮ allowance to another nonzero amount, first approve zero and wait for confirmation, then approve the new amount and wait again.
 
 **Type:** partial ERC‑4337 wallet config (optional)
 
@@ -21081,14 +21182,14 @@ The second argument to `swap()` and `quoteSwap()` accepts ERC‑4337 wallet conf
 
 ```javascript
 const result = await swapAA.swap({
-  tokenIn: '0xdAC17F...ec7',
-  tokenOut: '0xC02a...6Cc2', // WETH
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n
 }, {
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  swapMaxFee: 200000000000000n
+  swapMaxFee: 10000n // Exclusive cap of 0.01 USDt for this token-paid quote
 })
 ```
 
@@ -21114,12 +21215,12 @@ When calling `swap`, provide the swap parameters:
 
 ```javascript
 const swapOptions = {
-  tokenIn: '0xTokenIn',          // ERC‑20 to sell
-  tokenOut: '0xTokenOut',        // ERC‑20 to buy
+  tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDt on Ethereum
+  tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH on Ethereum
   tokenInAmount: 1000000n,       // exact input (base units)
   // OR
-  // tokenOutAmount: 1000000n,   // exact output (base units)
-  to: '0xRecipient'              // optional recipient (defaults to your address)
+  // tokenOutAmount: 1000000000000000n, // Alternative: exact output of 0.001 WETH
+  to: await account.getAddress() // Optional recipient; defaults to this account
 }
 
 const result = await swapProtocol.swap(swapOptions)
@@ -21162,7 +21263,7 @@ Description: Run exact-input swaps, exact-output swaps, and swaps with ERC-4337 
 This guide explains how to run a [basic exact-input swap](#basic-exact-input-swap), an [exact-output swap](#exact-output-swap), and a [swap from an ERC-4337 smart account](#swap-with-erc-4337). You should already have a [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) instance.
 
 <Callout type="warn">
-Swaps spend tokens and gas on-chain. Use amounts you control and an RPC you trust.
+Swaps spend tokens and gas on-chain. Before execution, approve the input token for the current Velora spender on the account's chain. The module does not submit approvals or reset allowances. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for approval and fee prerequisites.
 </Callout>
 
 ## Basic exact-input swap
@@ -21177,7 +21278,7 @@ const result = await swapProtocol.swap({
 })
 
 console.log('Swap transaction hash:', result.hash)
-console.log('Total fee (wei):', result.fee)
+console.log('Total fee (account units):', result.fee)
 console.log('Tokens sold (base units):', result.tokenInAmount)
 console.log('Tokens bought (base units):', result.tokenOutAmount)
 ```
@@ -21218,7 +21319,8 @@ const aa = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
   }
 })
 
-const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 200000000000000n })
+// Exclusive cap: 0.01 USDt with this six-decimal paymaster token.
+const swapAA = new VeloraProtocolEvm(aa, { swapMaxFee: 10000n })
 
 const result = await swapAA.swap({
   tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -21228,11 +21330,11 @@ const result = await swapAA.swap({
   paymasterToken: {
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
   },
-  swapMaxFee: 200000000000000n
+  swapMaxFee: 10000n
 })
 
 console.log('Swap hash:', result.hash)
-console.log('Total fee (wei):', result.fee)
+console.log('Total fee (USDt base units):', result.fee)
 ```
 
 <Callout type="info">
@@ -21282,7 +21384,7 @@ const swapProtocol = new VeloraProtocolEvm(account, {
 })
 ```
 
-Optional `swapMaxFee` caps the total gas fee in wei for swaps. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for environment-specific settings.
+Optional `swapMaxFee` is an exclusive cap in the account's quoted fee units: wei for the standard EVM account above. A fee equal to or above the cap rejects the swap. See [configuration](/sdk/swap-modules/swap-velora-evm/configuration) for paymaster fee units and approval prerequisites.
 
 ## Supported networks
 
@@ -21313,7 +21415,7 @@ const quote = await swapProtocol.quoteSwap({
   tokenInAmount: 1000000n
 })
 
-console.log('Estimated fee (wei):', quote.fee)
+console.log('Estimated fee (account units):', quote.fee)
 console.log('Tokens in (base units):', quote.tokenInAmount)
 console.log('Tokens out (base units):', quote.tokenOutAmount)
 ```
@@ -21327,7 +21429,7 @@ const quote = await swapProtocol.quoteSwap({
   tokenOutAmount: 500000000000000000n
 })
 
-console.log('Estimated fee (wei):', quote.fee)
+console.log('Estimated fee (account units):', quote.fee)
 console.log('Required token in (base units):', quote.tokenInAmount)
 ```
 
@@ -21347,7 +21449,9 @@ const quote = await swapAA.quoteSwap({
 
 ## Fee estimation
 
-You can read `quote.fee` from [`quoteSwap()`](/sdk/swap-modules/swap-velora-evm/api-reference) as the estimated total swap fee in wei before calling [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference):
+Read `quote.fee` in the account's fee units: native wei for a standard EVM account, token base units for token-paymaster fees, or zero for sponsorship. The quote excludes any separate input-token approval. `quoteSwap()` does not enforce `swapMaxFee`.
+
+The following examples use a standard EVM account, so the cap is in wei:
 
 ```javascript title="Quote fee before deciding"
 const quote = await swapProtocol.quoteSwap({
@@ -21360,7 +21464,7 @@ const maxFee = 200000000000000n
 console.log('Quoted fee (wei):', quote.fee, 'cap:', maxFee)
 ```
 
-You can compare that estimate to `swapMaxFee` on [`VeloraProtocolEvm`](/sdk/swap-modules/swap-velora-evm/api-reference) and only then call [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference) when the quote is within your cap:
+Compare the estimate with an exclusive cap and pass the same cap to [`swap()`](/sdk/swap-modules/swap-velora-evm/api-reference). Execution obtains a fresh fee quote and rejects a fee equal to or above `swapMaxFee`:
 
 ```javascript title="Swap when fee is under cap"
 const maxFee = 200000000000000n
@@ -21370,12 +21474,12 @@ const quote = await swapProtocol.quoteSwap({
   tokenInAmount: 1000000n
 })
 
-if (quote.fee <= maxFee) {
+if (quote.fee < maxFee) {
   const result = await swapProtocol.swap({
     tokenIn: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
     tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
     tokenInAmount: 1000000n
-  })
+  }, { swapMaxFee: maxFee })
   console.log('Swap hash:', result.hash)
 }
 ```
@@ -21416,8 +21520,8 @@ try {
   if (error.message.includes('liquidity')) {
     console.log('No route or insufficient liquidity for this pair')
   }
-  if (error.message.includes('max fee')) {
-    console.log('Swap fee exceeds swapMaxFee')
+  if (error.message === 'Exceeded maximum fee cost for swap operation.') {
+    console.log('Swap fee is equal to or above swapMaxFee')
   }
   if (error.message.includes('read-only')) {
     console.log('Read-only account cannot swap')
@@ -21440,13 +21544,13 @@ try {
     tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
     tokenInAmount: 1000000n
   })
-  console.log('Quoted fee (wei):', quote.fee)
+  console.log('Quoted fee (account units):', quote.fee)
 } catch (error) {
   console.error('Quote failed:', error.message)
 }
 ```
 
-Common causes are listed under [Errors](/sdk/swap-modules/swap-velora-evm/api-reference) in the API reference (liquidity, fee cap, read-only send attempts, RPC issues).
+Quotes can fail because of routing, liquidity, or provider errors. Fee-cap enforcement and read-only send rejection occur in `swap()`, not `quoteSwap()`. See [Errors](/sdk/swap-modules/swap-velora-evm/api-reference) in the API reference.
 
 ## Best Practices
 
@@ -30059,6 +30163,7 @@ Use the ERC-4337 wallet module when your app needs EVM smart accounts, UserOpera
 
 - **BIP-39 Seed Phrase Support**: Generate and validate BIP-39 mnemonic seed phrases
 - **EVM Derivation Paths**: Support for BIP-44 standard derivation paths for Ethereum (m/44'/60')
+- **Known-Safe Monitoring**: [Read an existing Safe address](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address) without its owner address or a seed phrase
 - **Multi-Account Management**: Create and manage multiple account abstraction wallets from a single seed phrase
 - **ERC-4337 Support**: Full implementation of ERC-4337 account abstraction standard
 - **UserOperation Management**: Create and send UserOperations through bundlers
@@ -30117,7 +30222,7 @@ Description: Complete API documentation for @tetherto/wdk-wallet-evm-erc-4337
 | Class | Description | Methods |
 |-------|-------------|---------|
 | [WalletManagerEvmErc4337](#walletmanagerevmerc4337) | Main class for managing ERC-4337 EVM wallets. Extends `WalletManager` from `@tetherto/wdk-wallet`. | [Constructor](#constructor), [Methods](#methods) |
-| [WalletAccountEvmErc4337](#walletaccountevmerc4337) | Individual ERC-4337 wallet account implementation. Extends `WalletAccountReadOnlyEvmErc4337` and implements `IWalletAccount`. | [Constructor](#constructor-1), [Methods](#methods-1), [Properties](#properties) |
+| [WalletAccountEvmErc4337](#walletaccountevmerc4337) | Individual ERC-4337 wallet account implementation. Extends `WalletAccountReadOnlyEvmErc4337` and implements `IWalletAccount`. | [Constructor](#constructor-1), [Methods](#methods-1), [Properties](#properties-1) |
 | [WalletAccountReadOnlyEvmErc4337](#walletaccountreadonlyevmerc4337) | Read-only ERC-4337 wallet account. Extends `WalletAccountReadOnly` from `@tetherto/wdk-wallet`. | [Constructor](#constructor-2), [Methods](#methods-2) |
 | [ConfigurationError](#configurationerror) | Error thrown for invalid or incomplete wallet configuration, including an unexpected token paymaster address returned by the RPC. | - |
 
@@ -30148,7 +30253,7 @@ new WalletManagerEvmErc4337(seed, config)
   - `chainId` (number): The blockchain's ID (e.g., 1 for Ethereum mainnet)
   - `provider` (string | Eip1193Provider | Array\<string | Eip1193Provider\>): RPC endpoint URL, EIP-1193 provider instance, or ordered failover list
   - `bundlerUrl` (string): The URL of the bundler service
-  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.18
+  - `safeModulesVersion` (string): Must be `'0.3.0'`, the only Safe modules version supported by beta.19
 
 **Optional common config fields:**
   - `parallel` (boolean): Put each send, sign, or transfer in a fresh random 192-bit nonce-key lane
@@ -30239,12 +30344,6 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
 | `getFeeRates()` | Returns current fee rates for transactions | `Promise\<{normal: bigint, fast: bigint}\>` | `ProviderRequiredError` if no provider |
 | `dispose()` | Disposes all wallet accounts, clearing private keys from memory | `void` | - |
 
-### Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `seed` | `Uint8Array` | The wallet's seed phrase as bytes |
-
 #### `getRandomSeedPhrase(wordCount?)` (static)
 Returns a random BIP-39 seed phrase.
 
@@ -30330,6 +30429,12 @@ Disposes all wallet accounts, clearing private keys from memory.
 wallet.dispose()
 ```
 
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `seed` | `Uint8Array` | The wallet's seed phrase as bytes |
+
 ## WalletAccountEvmErc4337
 
 Represents an individual ERC-4337 wallet account. Extends `WalletAccountReadOnlyEvmErc4337` and implements `IWalletAccount`.
@@ -30375,7 +30480,8 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 
 | Method | Description | Returns | Throws |
 |--------|-------------|---------|--------|
-| `predictSafeAddress(owner, config)` | (static) Predicts the Safe address for a given owner | `string` | - |
+| `predictSafeAddress(owner, config)` | (static) Predicts the Safe address for a given owner | `string` | `ValueError` for a malformed owner address |
+| `fromSafeAddress(safeAddress, config)` | (static) Unsupported on the writable class | `never` | Always `UnsupportedOperationError` |
 | `getAddress()` | Returns the Safe account's address | `Promise\<string\>` | - |
 | `sign(message)` | Signs a message using the account's private key | `Promise\<string\>` | - |
 | `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
@@ -30384,10 +30490,10 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 | `quoteSendTransaction(tx, config?)` | Estimates the fee for transactions or a signed UserOperation | `Promise\<{fee: bigint}\>` | If a newly built operation's token paymaster address mismatches |
 | `transfer(options, config?, txOverrides?)` | Transfers ERC20 tokens via UserOperation | `Promise\<{hash: string, fee: bigint}\>` | If fee exceeds max, or the token paymaster address mismatches |
 | `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If the token paymaster address mismatches |
-| `approve(options, txOverrides?)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | `ProviderRequiredError`, or `ValueError` when Ethereum USD₮ allowance must be reset |
 | `getBalance()` | Returns the native token balance (in wei) | `Promise\<bigint\>` | - |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific ERC20 token | `Promise\<bigint\>` | - |
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
+| `approve(options, txOverrides?)` | Approves a spender to spend ERC20 tokens | `Promise\<{hash: string, fee: bigint}\>` | `ProviderRequiredError`, or `ValueError` when Ethereum USD₮ allowance must be reset |
 | `getAllowance(token, spender)` | Returns current token allowance for a spender | `Promise\<bigint\>` | - |
 | `getTransactionReceipt(hash)` | Maps a UserOperation hash to a native EVM receipt; deprecated in favor of `getTransaction()` | `Promise\<EvmTransactionReceipt \| null\>` | - |
 | `getTransaction(hash)` | Returns normalized UserOperation finality using its bundling transaction | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the hash is invalid or unknown |
@@ -30399,7 +30505,15 @@ const account = new WalletAccountEvmErc4337(seedPhrase, "0'/0/0", {
 | `toReadOnlyAccount()` | Returns a read-only copy of the account | `Promise\<WalletAccountReadOnlyEvmErc4337\>` | - |
 | `dispose()` | Disposes the wallet account, clearing private keys from memory | `void` | - |
 
-##### `getAddress()`
+#### `predictSafeAddress(owner, config)` (static)
+
+Inherits the [read-only address predictor](#predictsafeaddressowner-config-static-1). It accepts an owner EOA address and `Pick<EvmErc4337WalletConfig, 'safeModulesVersion' | 'onChainIdentifier'>`, and returns a counterfactual Safe address as a `string`. A malformed owner address throws `ValueError`.
+
+#### `fromSafeAddress(safeAddress, config)` (static)
+
+Always throws `UnsupportedOperationError` and returns `never`. A Safe address alone cannot create a signing account. Use the [read-only factory](#fromsafeaddresssafeaddress-config-static-1) instead. Its parameters are `safeAddress: string` and `config: Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`.
+
+#### `getAddress()`
 Returns the Safe smart contract wallet address (not the underlying EOA address).
 
 **Returns:** `Promise\<string\>` - The Safe account's address
@@ -30410,7 +30524,7 @@ const address = await account.getAddress()
 console.log('Safe account address:', address) // 0x... (Smart contract address)
 ```
 
-##### `sign(message)`
+#### `sign(message)`
 Signs a message using the underlying EOA private key.
 
 **Parameters:**
@@ -30425,7 +30539,7 @@ const signature = await account.sign(message)
 console.log('Signature:', signature)
 ```
 
-##### `verify(message, signature)`
+#### `verify(message, signature)`
 Verifies a message signature against the underlying EOA address.
 
 **Parameters:**
@@ -30440,7 +30554,7 @@ const isValid = await account.verify(message, signature)
 console.log('Signature valid:', isValid)
 ```
 
-##### `signTransaction(tx, config?)`
+#### `signTransaction(tx, config?)`
 Builds and signs one ERC-4337 v0.7 UserOperation without submitting it to the bundler.
 
 **Parameters:**
@@ -30466,7 +30580,7 @@ const signedUserOperation = await account.signTransaction({
 The returned operation contains the selected nonce lane and fee-mode configuration used while building it. Submit it promptly through the same account and do not mutate it.
 </Callout>
 
-##### `sendTransaction(tx, config?)`
+#### `sendTransaction(tx, config?)`
 Sends a transaction via UserOperation through the bundler.
 
 **Parameters:**
@@ -30524,7 +30638,7 @@ const fastResult = await account.sendTransaction({
 
 Beta.17 does not reserve sequential nonces locally. With no lane option, sends use the default key-0 lane and must not overlap. `parallel: true` creates a new random lane; `nonceKey` selects a reusable named or raw lane and takes precedence. Operations sharing a lane remain sequential, so wait for inclusion before reusing it. Distinct lanes are unordered; batch dependent transactions into one UserOperation.
 
-##### `quoteSendTransaction(tx, config?)`
+#### `quoteSendTransaction(tx, config?)`
 Estimates the fee for a UserOperation without sending it.
 
 Default-lane, non-sponsored UserOperations built while quoting transaction inputs can be cached internally for up to 2 minutes. When a later default-lane `sendTransaction()` or `signTransaction()` matches, the account performs a lightweight on-chain nonce check before reuse and rebuilds if the nonce has moved. Sponsored quotes do not cache a built operation. A supplied signed UserOperation is evaluated directly rather than rebuilt.
@@ -30556,7 +30670,7 @@ const quote = await account.quoteSendTransaction({
 console.log('Estimated fee:', quote.fee)
 ```
 
-##### `transfer(options, config?, txOverrides?)`
+#### `transfer(options, config?, txOverrides?)`
 Transfers ERC20 tokens via UserOperation.
 
 **Parameters:**
@@ -30592,7 +30706,7 @@ console.log('Transfer UserOperation hash:', result.hash)
 console.log('Transfer fee:', result.fee)
 ```
 
-##### `quoteTransfer(options, config?, txOverrides?)`
+#### `quoteTransfer(options, config?, txOverrides?)`
 Estimates the fee for an ERC20 token transfer.
 
 This method does not resolve or reserve a nonce lane. A later transfer using `parallel` or `nonceKey` rebuilds in that lane.
@@ -30618,7 +30732,7 @@ const quote = await account.quoteTransfer({
 console.log('Transfer fee estimate:', quote.fee)
 ```
 
-##### `getBalance()`
+#### `getBalance()`
 Returns the Safe account's native token balance.
 
 **Returns:** `Promise\<bigint\>` - Balance in wei
@@ -30629,7 +30743,7 @@ const balance = await account.getBalance()
 console.log('Native balance:', balance, 'wei')
 ```
 
-##### `getTokenBalance(tokenAddress)`
+#### `getTokenBalance(tokenAddress)`
 Returns the balance of a specific ERC20 token in the Safe account.
 
 **Parameters:**
@@ -30643,7 +30757,7 @@ const tokenBalance = await account.getTokenBalance('0xdAC17F958D2ee523a220620699
 console.log('USDt balance:', tokenBalance) // In 6 decimal units
 ```
 
-##### `getPaymasterTokenBalance()`
+#### `getPaymasterTokenBalance()`
 Returns the balance of the configured paymaster token used for paying fees.
 
 **Returns:** `Promise\<bigint\>` - Paymaster token balance in base units
@@ -30659,7 +30773,7 @@ if (paymasterBalance < 10000n) {
 }
 ```
 
-##### `approve(options, txOverrides?)`
+#### `approve(options, txOverrides?)`
 Approves a spender to spend ERC20 tokens on behalf of the Safe account.
 
 **Parameters:**
@@ -30690,7 +30804,7 @@ const result = await account.approve({
 console.log('Approval hash:', result.hash)
 ```
 
-##### `getAllowance(token, spender)`
+#### `getAllowance(token, spender)`
 Returns the current token allowance for the given spender.
 
 **Parameters:**
@@ -30708,7 +30822,7 @@ const allowance = await account.getAllowance(
 console.log('Current allowance:', allowance)
 ```
 
-##### `getTransactionReceipt(hash)`
+#### `getTransactionReceipt(hash)`
 Maps a UserOperation hash to its native EVM bundling-transaction receipt. This method is deprecated; use `getTransaction()` and read its `receipt` and `userOperationReceipt` fields.
 
 **Parameters:**
@@ -30724,7 +30838,7 @@ if (receipt) {
 }
 ```
 
-##### `getTransaction(hash)`
+#### `getTransaction(hash)`
 
 Returns normalized status for an exact 32-byte UserOperation hash. Before the bundler assigns an EVM transaction hash, the result is `pending` with zero confirmations and both native receipt fields set to `null`. After inclusion, finality and confirmations come from the EVM bundling transaction, while `success` and `fee` come from the UserOperation receipt when available.
 
@@ -30741,7 +30855,7 @@ console.log(receipt.userOperationReceipt) // Raw bundler receipt
 
 An invalid hash throws `ValueError`; a well-formed hash unknown to the bundler throws `NoSuchElementError`. A settled `confirmed` or `final` receipt can still have `success: false`, so always inspect execution success.
 
-##### `waitForTransaction(hash, options?)`
+#### `waitForTransaction(hash, options?)`
 
 Polls by UserOperation hash until the requested finality target is reached or the underlying EVM transaction is classified as `dropped`. The default target is `confirmed`, the interval is four seconds, and the ERC-4337 timeout is 180 seconds.
 
@@ -30758,7 +30872,7 @@ if (receipt.finality !== 'dropped' && receipt.success === false) {
 }
 ```
 
-##### `getUserOperationReceipt(hash)`
+#### `getUserOperationReceipt(hash)`
 Returns a UserOperation receipt by hash.
 
 **Parameters:**
@@ -30774,7 +30888,7 @@ if (receipt) {
 }
 ```
 
-##### `signTypedData(typedData)`
+#### `signTypedData(typedData)`
 Signs EIP-712 typed structured data using the underlying EOA private key.
 
 **Parameters:**
@@ -30808,7 +30922,7 @@ const signature = await account.signTypedData(typedData)
 console.log('Typed data signature:', signature)
 ```
 
-##### `verifyTypedData(typedData, signature)`
+#### `verifyTypedData(typedData, signature)`
 Verifies an EIP-712 typed data signature against the underlying EOA address.
 
 **Parameters:**
@@ -30823,7 +30937,7 @@ const isValid = await account.verifyTypedData(typedData, signature)
 console.log('Typed data signature valid:', isValid)
 ```
 
-##### `getTokenBalances(tokenAddresses)`
+#### `getTokenBalances(tokenAddresses)`
 Returns balances for multiple ERC20 tokens in a single call.
 
 **Parameters:**
@@ -30842,8 +30956,8 @@ for (const [address, balance] of Object.entries(balances)) {
 }
 ```
 
-##### `toReadOnlyAccount()`
-Creates a read-only copy of the account with the same Safe address and configuration.
+#### `toReadOnlyAccount()`
+Creates a read-only copy with the same Safe address, configuration, and owner EOA address. Unlike an account created by `fromSafeAddress()`, this copy can verify the owner's message and typed-data signatures.
 
 **Returns:** `Promise\<WalletAccountReadOnlyEvmErc4337\>` - Read-only account instance
 
@@ -30856,7 +30970,7 @@ const balance = await readOnlyAccount.getBalance()
 // readOnlyAccount.sendTransaction() // Would not be available
 ```
 
-##### `dispose()`
+#### `dispose()`
 Disposes the wallet account, clearing private keys from memory.
 
 **Example:**
@@ -30886,7 +31000,7 @@ console.log('Private key length:', privateKey?.length) // 32 bytes (null after d
 ⚠️ **Security Note**: The `keyPair` property contains sensitive cryptographic material. Never log, display, or expose the private key.
 
 ## WalletAccountReadOnlyEvmErc4337
-Represents a read-only ERC-4337 wallet account that can query balances and estimate fees but cannot send transactions.
+Represents a read-only ERC-4337 wallet account that can query balances and allowances but cannot sign or send transactions. Choose the owner-based constructor to predict a Safe address, or the [known-Safe factory](#fromsafeaddresssafeaddress-config-static-1) to use a supplied Safe address directly. Non-sponsored fee estimates for a known-Safe account require deployment.
 
 ### Constants
 
@@ -30906,12 +31020,12 @@ new WalletAccountReadOnlyEvmErc4337(address, config)
 ```
 
 **Parameters:**
-- `address` (string): The EOA address (owner address)
+- `address` (string): The owner EOA address, not the Safe address. The account predicts the counterfactual Safe from this owner and the configuration.
 - `config` (`Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`): Configuration object without send-only fee caps
 
 **Example:**
 ```javascript
-const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
+const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x405005C7c4422390F4B334F64Cf20E0b767131d0', {
   chainId: 1,
   provider: 'https://rpc.mevblocker.io/fast',
   bundlerUrl: 'https://api.candide.dev/public/v3/1',
@@ -30924,58 +31038,88 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
 })
 ```
 
+**Throws:** `ValueError` for a malformed owner address or an empty provider list; `ConfigurationError` for an unsupported `safeModulesVersion`.
+
+The example owner above is a derivation fixture. Constructing an account does not deploy or fund its predicted Safe.
+
 ### Static Methods
 
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `predictSafeAddress(owner, config)` | Predicts the Safe address for a given owner without instantiating an account | `string` |
+| `fromSafeAddress(safeAddress, config)` | Creates a read-only account for a supplied Safe address without its owner | `WalletAccountReadOnlyEvmErc4337` |
 
 #### `predictSafeAddress(owner, config)` (static)
 Predicts the address of a Safe account.
 
 **Parameters:**
 - `owner` (string): The Safe owner's EOA address
-- `config` (object): Configuration with:
-  - `chainId` (number): The blockchain ID
-  - `safeModulesVersion` (string): The Safe modules version
+- `config` (`Pick<EvmErc4337WalletConfig, 'safeModulesVersion' | 'onChainIdentifier'>`): Safe derivation configuration. Set `safeModulesVersion` to `'0.3.0'`. The type also accepts the optional `onChainIdentifier` field from the account configuration.
 
 **Returns:** `string` - The predicted Safe address
 
 **Example:**
 ```javascript
 const safeAddress = WalletAccountReadOnlyEvmErc4337.predictSafeAddress(
-  '0xOwnerEOA...',
-  { chainId: 1, safeModulesVersion: '0.3.0' }
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0',
+  { safeModulesVersion: '0.3.0' }
 )
 console.log('Predicted Safe address:', safeAddress)
 
 // Also available on WalletAccountEvmErc4337 (inherited)
 const sameAddress = WalletAccountEvmErc4337.predictSafeAddress(
-  '0xOwnerEOA...',
-  { chainId: 1, safeModulesVersion: '0.3.0' }
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0',
+  { safeModulesVersion: '0.3.0' }
 )
 ```
+
+**Throws:** `ValueError` for a malformed owner address, including an invalid mixed-case checksum.
+
+#### `fromSafeAddress(safeAddress, config)` (static)
+
+Creates a read-only account whose own address is the supplied Safe address. Unlike the constructor, it does not derive a new address from an owner.
+
+**Parameters:**
+- `safeAddress` (`string`): A well-formed EVM address. Lowercase addresses are accepted and normalized to checksum form; invalid mixed-case checksums are rejected.
+- `config` (`Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`): Read-only configuration, including the network, provider, bundler URL, Safe modules version and selected gas-payment mode.
+
+**Returns:** `WalletAccountReadOnlyEvmErc4337` synchronously, not a Promise.
+
+**Throws:**
+- `ValueError` for a malformed Safe address, an invalid mixed-case checksum, or an empty provider list.
+- `ConfigurationError` for an unsupported `safeModulesVersion`.
+
+Use the factory with a Safe address already held by your application:
+
+```javascript
+const readOnlyAccount = WalletAccountReadOnlyEvmErc4337.fromSafeAddress(safeAddress, config)
+console.log('Safe address:', await readOnlyAccount.getAddress())
+```
+
+See [Read a Known Safe Address](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address) for a complete setup example. The factory performs no network lookup: it does not confirm deployment, discover an owner, or check that the address is a Safe contract. Balance and allowance queries use this address directly, including before deployment.
+
+The owner is unknown, so `verify()` and `verifyTypedData()` throw `UnsupportedOperationError`. There is no signing or transaction-submission capability. A non-sponsored quote that builds a UserOperation throws `ConfigurationError` if the Safe is undeployed, because deployment requires the owner address. Sponsored quotes return `{ fee: 0n }` before checking deployment or chain identity; that result does not confirm sponsorship eligibility or transaction executability.
 
 ### Methods
 
 | Method | Description | Returns | Throws |
 |--------|-------------|---------|--------|
 | `getAddress()` | Returns the Safe account's address | `Promise\<string\>` | - |
-| `verify(message, signature)` | Verifies a message signature | `Promise\<boolean\>` | - |
+| `verify(message, signature)` | Verifies a message signature against a known owner | `Promise\<boolean\>` | `UnsupportedOperationError` for an account created from a Safe address |
 | `getBalance()` | Returns the native token balance (in wei) | `Promise\<bigint\>` | - |
 | `getTokenBalance(tokenAddress)` | Returns the balance of a specific ERC20 token | `Promise\<bigint\>` | - |
 | `getPaymasterTokenBalance()` | Returns the paymaster token balance | `Promise\<bigint\>` | - |
 | `getAllowance(token, spender)` | Returns current token allowance for a spender | `Promise\<bigint\>` | - |
-| `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | If simulation fails or the token paymaster address mismatches |
-| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails or the token paymaster address mismatches |
+| `quoteSendTransaction(tx, config?)` | Estimates the fee for a UserOperation | `Promise\<{fee: bigint}\>` | If simulation fails, the token paymaster address mismatches, or a non-sponsored known-Safe quote requires deployment |
+| `quoteTransfer(options, config?, txOverrides?)` | Estimates the fee for an ERC20 transfer | `Promise\<{fee: bigint}\>` | If simulation fails, the token paymaster address mismatches, or a non-sponsored known-Safe quote requires deployment |
 | `getTransactionReceipt(hash)` | Maps a UserOperation hash to a native EVM receipt; deprecated in favor of `getTransaction()` | `Promise\<EvmTransactionReceipt \| null\>` | - |
 | `getTransaction(hash)` | Returns normalized UserOperation finality using its bundling transaction | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the hash is invalid or unknown |
 | `waitForTransaction(hash, options?)` | Waits for the UserOperation to reach `confirmed` or `final`, or returns `dropped` | `Promise\<TransactionReceipt & EvmErc4337TransactionDetails\>` | If the wait times out |
 | `getUserOperationReceipt(hash)` | Returns a UserOperation receipt | `Promise\<UserOperationReceipt \| null\>` | - |
-| `verifyTypedData(typedData, signature)` | Verifies an EIP-712 typed data signature | `Promise\<boolean\>` | - |
+| `verifyTypedData(typedData, signature)` | Verifies typed data against a known owner | `Promise\<boolean\>` | `UnsupportedOperationError` for an account created from a Safe address |
 | `getTokenBalances(tokenAddresses)` | Returns balances for multiple ERC20 tokens | `Promise\<Record\<string, bigint\>\>` | - |
 
-##### `getAddress()`
+#### `getAddress()`
 Returns the Safe smart contract wallet address.
 
 **Returns:** `Promise\<string\>` - The Safe account's address
@@ -30986,8 +31130,8 @@ const address = await readOnlyAccount.getAddress()
 console.log('Safe address:', address)
 ```
 
-##### `verify(message, signature)`
-Verifies a message signature against the underlying EOA address.
+#### `verify(message, signature)`
+Verifies a message signature against the known owner EOA address. Throws `UnsupportedOperationError` if this account was created with `fromSafeAddress()`, because its owner is unknown.
 
 **Parameters:**
 - `message` (string): The original message
@@ -31001,7 +31145,7 @@ const isValid = await readOnlyAccount.verify(message, signature)
 console.log('Signature valid:', isValid)
 ```
 
-##### `getBalance()`
+#### `getBalance()`
 Returns the Safe account's native token balance.
 
 **Returns:** `Promise\<bigint\>` - Balance in wei
@@ -31012,7 +31156,7 @@ const balance = await readOnlyAccount.getBalance()
 console.log('Balance:', balance, 'wei')
 ```
 
-##### `getTokenBalance(tokenAddress)`
+#### `getTokenBalance(tokenAddress)`
 Returns the balance of a specific ERC20 token.
 
 **Parameters:**
@@ -31026,7 +31170,7 @@ const tokenBalance = await readOnlyAccount.getTokenBalance('0xdAC17F958D2ee523a2
 console.log('USDt balance:', tokenBalance)
 ```
 
-##### `getPaymasterTokenBalance()`
+#### `getPaymasterTokenBalance()`
 Returns the balance of the configured paymaster token.
 
 **Returns:** `Promise\<bigint\>` - Paymaster token balance in base units
@@ -31037,7 +31181,7 @@ const paymasterBalance = await readOnlyAccount.getPaymasterTokenBalance()
 console.log('Paymaster token balance:', paymasterBalance)
 ```
 
-##### `getAllowance(token, spender)`
+#### `getAllowance(token, spender)`
 Returns the current token allowance for the given spender.
 
 **Parameters:**
@@ -31055,8 +31199,8 @@ const allowance = await readOnlyAccount.getAllowance(
 console.log('Allowance:', allowance)
 ```
 
-##### `quoteSendTransaction(tx, config?)`
-Estimates the fee for a UserOperation.
+#### `quoteSendTransaction(tx, config?)`
+Estimates the fee for a UserOperation. For an account created with `fromSafeAddress()`, a non-sponsored quote requires a deployed Safe. Sponsored quotes return `{ fee: 0n }` without checking deployment or chain identity; they do not confirm sponsorship eligibility.
 
 **Parameters:**
 - `tx` (EvmErc4337Transaction | EvmErc4337Transaction[]): Transaction object or array
@@ -31065,6 +31209,7 @@ Estimates the fee for a UserOperation.
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
 **Throws:**
+- `ConfigurationError` if a non-sponsored quote for an account created with `fromSafeAddress()` finds the Safe is undeployed
 - Error if simulation fails
 - `ConfigurationError` in token-paymaster mode when the RPC returns a non-empty paymaster address that differs from the configured `paymasterAddress` (case-insensitive comparison)
 - `TransactionError` with `reason: TransactionErrorReason.INSUFFICIENT_BALANCE` if the paymaster reports AA50
@@ -31089,8 +31234,8 @@ try {
 }
 ```
 
-##### `quoteTransfer(options, config?, txOverrides?)`
-Estimates the fee for an ERC20 token transfer.
+#### `quoteTransfer(options, config?, txOverrides?)`
+Estimates the fee for an ERC20 token transfer through `quoteSendTransaction()`. Its known-Safe deployment restriction and sponsored-quote exception also apply here.
 
 **Parameters:**
 - `options` (TransferOptions): Transfer options
@@ -31100,6 +31245,7 @@ Estimates the fee for an ERC20 token transfer.
 **Returns:** `Promise\<{fee: bigint}\>` - Fee estimate
 
 **Throws:**
+- `ConfigurationError` if a non-sponsored quote for an account created with `fromSafeAddress()` finds the Safe is undeployed.
 - `ConfigurationError` in token-paymaster mode when the RPC returns a non-empty paymaster address that differs from the configured `paymasterAddress` (case-insensitive comparison).
 - `TransactionError` with `reason: TransactionErrorReason.INSUFFICIENT_BALANCE` if the paymaster reports AA50.
 
@@ -31113,7 +31259,7 @@ const quote = await readOnlyAccount.quoteTransfer({
 console.log('Transfer fee estimate:', quote.fee)
 ```
 
-##### `getTransactionReceipt(hash)`
+#### `getTransactionReceipt(hash)`
 Maps a UserOperation hash to its native EVM bundling-transaction receipt. This method is deprecated; use `getTransaction()` for normalized finality.
 
 **Parameters:**
@@ -31132,11 +31278,15 @@ if (receipt) {
 }
 ```
 
-##### `getTransaction(hash)` and `waitForTransaction(hash, options?)`
+#### `getTransaction(hash)`
 
-Read-only accounts expose the same UserOperation-hash semantics as owned accounts. `getTransaction()` retains the UserOperation hash in `receipt.hash`, derives finality from the bundling transaction, and exposes both the EVM receipt and raw UserOperation receipt. `waitForTransaction()` defaults to a four-second interval and 180-second timeout. Inspect `success` after inclusion.
+Read-only accounts expose the same UserOperation-hash semantics as owned accounts. `getTransaction()` retains the UserOperation hash in `receipt.hash`, derives finality from the bundling transaction, and exposes both the EVM receipt and raw UserOperation receipt.
 
-##### `getUserOperationReceipt(hash)`
+#### `waitForTransaction(hash, options?)`
+
+Waits for the requested UserOperation finality with a four-second default interval and 180-second default timeout. Inspect `success` after inclusion. See the [owned-account method](#waitfortransactionhash-options) for options and return details.
+
+#### `getUserOperationReceipt(hash)`
 Returns a UserOperation receipt by hash.
 
 **Parameters:**
@@ -31152,8 +31302,8 @@ if (receipt) {
 }
 ```
 
-##### `verifyTypedData(typedData, signature)`
-Verifies an EIP-712 typed data signature against the underlying EOA address.
+#### `verifyTypedData(typedData, signature)`
+Verifies an EIP-712 typed data signature against the known owner EOA address. Throws `UnsupportedOperationError` if this account was created with `fromSafeAddress()`, because its owner is unknown.
 
 **Parameters:**
 - `typedData` (TypedData): The original typed data object
@@ -31167,7 +31317,7 @@ const isValid = await readOnlyAccount.verifyTypedData(typedData, signature)
 console.log('Typed data signature valid:', isValid)
 ```
 
-##### `getTokenBalances(tokenAddresses)`
+#### `getTokenBalances(tokenAddresses)`
 Returns balances for multiple ERC20 tokens in a single call.
 
 **Parameters:**
@@ -31230,7 +31380,7 @@ interface EvmErc4337WalletCommonConfig {
   chainId: number;                          // Blockchain ID
   provider: string | Eip1193Provider | Array<string | Eip1193Provider>; // RPC provider or failover list
   bundlerUrl: string;                       // Bundler service URL
-  safeModulesVersion: string;               // Must be '0.3.0' in beta.18
+  safeModulesVersion: string;               // Must be '0.3.0' in beta.19
   parallel?: boolean;                       // Fresh random nonce-key lane per operation
   nonceKey?: number | bigint | string;      // Reusable raw or named uint192 lane key
 }
@@ -31271,7 +31421,7 @@ type EvmErc4337WalletConfig = EvmErc4337WalletCommonConfig &
 
 ### Config Override
 
-The published beta.18 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
+The published beta.19 `config` parameter type on `sendTransaction`, `signTransaction`, `quoteSendTransaction`, `transfer`, and `quoteTransfer` allows per-call overrides of gas payment settings:
 
 ```typescript
 type ConfigOverride = Partial<
@@ -31293,7 +31443,7 @@ type ConfigOverride = Partial<
 
 Overrides are shallow-merged with the account configuration, then validated. When switching modes, explicitly clear an inherited opposing flag: sponsorship requires `isSponsored: true` and `useNativeCoins: false`; native-coin mode requires `isSponsored: false` and `useNativeCoins: true`; paymaster-token mode requires both flags to be `false`. The merged configuration must also contain the URL, address, token, or policy fields required by the selected mode.
 
-At runtime, beta.18 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
+At runtime, beta.19 additionally honors `parallel` and `nonceKey` per call for `signTransaction()`, `sendTransaction()`, and `transfer()`. Those two fields are missing from the published per-call declarations, so object literals containing them fail TypeScript excess-property checks even though JavaScript calls work. Construction-level `EvmErc4337WalletCommonConfig` includes both fields and is the typed path in this release. `quoteSendTransaction()` and `quoteTransfer()` do not select a lane.
 
 In token-paymaster mode, every path that builds a UserOperation validates a non-empty paymaster address returned by the RPC against `paymasterAddress`. A case-insensitive mismatch throws `ConfigurationError` before the operation is returned or submitted.
 
@@ -31435,7 +31585,7 @@ class ConfigurationError extends ValueError {
 }
 ```
 
-`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`. It also reports a mismatch between the constructor's `chainId` and the provider during the first UserOperation chain lookup.
+`ConfigurationError` is part of the shared WDK error taxonomy and can also be caught as `ValueError`. For an account created with `fromSafeAddress()`, it also reports an undeployed Safe when a non-sponsored quote builds a UserOperation. It also reports a mismatch between the constructor's `chainId` and the provider during the first UserOperation chain lookup.
 
 ### FeeRates
 
@@ -31524,7 +31674,7 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, config)
 
 ## Account Configuration
 
-Both `WalletAccountEvmErc4337` and `WalletAccountReadOnlyEvmErc4337` use the same configuration structure:
+The writable account uses `EvmErc4337WalletConfig`. The read-only constructor and [`fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) use `Omit<EvmErc4337WalletConfig, 'transferMaxFee' | 'transactionMaxFee'>`, with the same network, provider, bundler, Safe modules and gas-payment settings. Use the constructor with an owner EOA address; use the factory with a known Safe address.
 
 ```javascript
 import { WalletAccountEvmErc4337, WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
@@ -31538,7 +31688,7 @@ const account = new WalletAccountEvmErc4337(
 
 // Read-only account (fee caps for sending are not needed)
 const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
-  '0x...', // Owner EOA address; the module predicts the Safe address
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0', // Test owner for address derivation
   {
     chainId: 1,
     provider: 'https://rpc.mevblocker.io/fast',
@@ -31553,6 +31703,8 @@ const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337(
   }
 )
 ```
+
+The read-only example uses a test owner to derive a counterfactual Safe; it does not deploy or fund that account. For an address your application already knows, follow [Read a Known Safe Address](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address). The factory validates address syntax, the supported Safe modules version, and a nonempty provider list without verifying deployment or ownership.
 
 ## Configuration Options
 
@@ -31587,7 +31739,7 @@ const config = { chainId: 43114 }
 
 ### Provider
 
-The `provider` option specifies the RPC endpoint or EIP-1193 provider instance for blockchain interactions. **Required** for all operations. You can also pass an array of endpoints or providers to enable automatic failover: when a request to one provider fails, the wallet retries the next provider in the list.
+The `provider` option specifies the RPC endpoint or EIP-1193 provider instance for blockchain interactions. **Required** by the configuration type and used for network operations. Creating a read-only account or calling `getAddress()` does not make an RPC request. You can also pass an array of endpoints or providers to enable automatic failover: when a request to one provider fails, the wallet retries the next provider in the list.
 
 **Type:** `string | Eip1193Provider | Array<string | Eip1193Provider>`
 **Required:** Yes
@@ -31604,10 +31756,13 @@ const config = {
   provider: window.ethereum
 }
 
-// Using custom ethers provider
+// Adapt an ethers provider to EIP-1193
 import { JsonRpcProvider } from 'ethers'
+const rpc = new JsonRpcProvider('https://rpc.mevblocker.io/fast')
 const config = {
-  provider: new JsonRpcProvider('https://rpc.mevblocker.io/fast')
+  provider: {
+    request: ({ method, params }) => rpc.send(method, params ?? [])
+  }
 }
 
 // Using multiple providers for automatic failover
@@ -31741,12 +31896,12 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, config)
 Reusing one named lane remains sequential: wait for inclusion before submitting its next operation, or batch dependent calls into one UserOperation.
 
 <Callout type="warning">
-The beta.18 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
+The beta.19 runtime also honors `parallel` and `nonceKey` in the per-call config for `signTransaction()`, `sendTransaction()`, and `transfer()`, but the published per-call TypeScript declarations omit both fields. Construction-level configuration is typed; JavaScript per-call usage works at runtime.
 </Callout>
 
 ### Safe Modules Version
 
-The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.18 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
+The `safeModulesVersion` option specifies the Safe modules version for smart contract wallet implementation. Beta.19 supports only `0.3.0`; other values, including `0.2.0`, throw `ConfigurationError`. **Required** for smart account initialization.
 
 **Type:** `string`
 **Required:** Yes
@@ -32111,26 +32266,16 @@ The paymaster token balance is held by the Safe account. Fund the Safe with enou
 
 ## Read-Only Account Balances
 
-You can check balances without a seed phrase by passing the owner EOA address to [`WalletAccountReadOnlyEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference). The module predicts the Safe address from that owner and the configuration:
+Create the read-only account with the [known-Safe workflow](/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address), then use [`getBalance()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#getbalance-1) to query that Safe's native balance:
 
 ```javascript title="Read-Only Balance"
-import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
-
-const readOnlyAccount = new WalletAccountReadOnlyEvmErc4337('0x...', {
-  chainId: 1,
-  provider: 'https://rpc.mevblocker.io/fast',
-  bundlerUrl: 'https://api.candide.dev/public/v3/1',
-  paymasterUrl: 'https://api.candide.dev/public/v3/1',
-  paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
-  safeModulesVersion: '0.3.0',
-  paymasterToken: {
-    address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'
-  }
-})
-
 const balance = await readOnlyAccount.getBalance()
-console.log('Read-only account balance:', balance, 'wei')
+console.log('Read-only Safe balance:', balance, 'wei')
 ```
+
+The same account supports the token and allowance queries listed in the [API reference](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#methods-2). Balance reads do not require the Safe to be deployed. Reading the configured paymaster token balance requires a `paymasterToken` configuration.
+
+If you have the owner EOA address instead, use the [read-only constructor](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#constructor-2). Passing a Safe address to that constructor predicts a different account; use the [factory](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) to read the supplied Safe directly.
 
 ## Next Steps
 
@@ -32215,7 +32360,7 @@ With your wallet ready, learn how to [manage multiple accounts](/sdk/wallet-modu
 URL: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors
 Description: Handle errors, manage fees, and dispose of sensitive data.
 
-This guide explains how to [handle transaction errors](#transaction-errors), [correct a provider-chain mismatch](#provider-chain-mismatches), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), and follow [best practices](#best-practices) for fee management and memory cleanup.
+This guide explains how to [handle transaction errors](#transaction-errors), [correct a provider-chain mismatch](#provider-chain-mismatches), [handle transfer errors](#transfer-errors), [verify paymaster address mismatches](#paymaster-address-mismatches), [diagnose nonce-lane failures](#nonce-lane-failures), [handle known-Safe address errors](#known-safe-address-errors), and follow [best practices](#best-practices) for fee management and memory cleanup.
 
 ## Transaction Errors
 
@@ -32323,6 +32468,14 @@ Treat a returned hash as submission evidence, not inclusion. Pass the UserOperat
 
 `getTransaction()` throws `ValueError` for a malformed UserOperation hash and `NoSuchElementError` when the bundler does not know a well-formed hash. During `waitForTransaction()`, an unknown hash is treated as transient while the operation propagates. A `TimeoutError` means the requested finality was not reached in time; a returned `dropped` receipt means the underlying EVM transaction's nonce was replaced or otherwise consumed. A `confirmed` or `final` receipt can still have `success: false`.
 
+## Known-Safe Address Errors
+
+[`fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) throws `ValueError` for a malformed Safe address, an invalid mixed-case checksum, or an empty provider list. It throws [`ConfigurationError`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#configurationerror) for an unsupported `safeModulesVersion`. The owner-based constructor and [`predictSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#predictsafeaddressowner-config-static-1) also reject malformed owner addresses with `ValueError`.
+
+A known-Safe account has no owner or signing key. Its verification methods throw `UnsupportedOperationError`, and calling the factory on the writable [`WalletAccountEvmErc4337`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#walletaccountevmerc4337) class always throws that error. Import `ValueError` and `UnsupportedOperationError` from `@tetherto/wdk-wallet`.
+
+For a non-sponsored quote, an undeployed known Safe throws `ConfigurationError` because building its deployment operation requires the owner address. Confirm the network and address, then use an owner-backed signing flow to deploy the Safe if needed. Do not treat a different address or a sponsored zero-fee quote as a deployment fix: sponsored quotes skip deployment and chain checks and do not prove sponsorship eligibility.
+
 ## Best Practices
 
 ### Fee Management
@@ -32360,9 +32513,9 @@ Always call [`dispose()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference)
 
 ## Manage Accounts
 URL: https://docs.wdk.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts
-Description: Work with multiple smart accounts and custom derivation paths.
+Description: Work with multiple smart accounts, custom derivation paths, and known Safe addresses.
 
-This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-index) and [use custom derivation paths](#retrieve-account-by-custom-derivation-path).
+This guide explains how to [retrieve accounts by index](#retrieve-accounts-by-index), [use custom derivation paths](#retrieve-account-by-custom-derivation-path), and [read a known Safe address](#read-a-known-safe-address).
 
 ## Retrieve Accounts by Index
 
@@ -32387,6 +32540,43 @@ const customAccount = await wallet.getAccountByPath("0'/0/5")
 const customAddress = await customAccount.getAddress()
 console.log('Custom account address:', customAddress)
 ```
+
+## Read a Known Safe Address
+
+Use [`WalletAccountReadOnlyEvmErc4337.fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) when your app already has the Safe address. It does not need a seed phrase or owner address. The ordinary [read-only constructor](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#constructor-2) instead takes an owner EOA address and predicts a Safe address from it.
+
+1. Obtain the Safe address from your application and select its network configuration.
+2. Pass that address and configuration to the read-only factory.
+3. Confirm that [`getAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#getaddress-1) returns the supplied address in checksummed form.
+
+The example below derives a counterfactual Safe from an upstream test owner to demonstrate the factory. It does not deploy or fund the Safe; use your application's known Safe address for actual balance monitoring.
+
+```javascript title="Read a Known Safe Address"
+import { WalletAccountReadOnlyEvmErc4337 } from '@tetherto/wdk-wallet-evm-erc-4337'
+
+const config = {
+  chainId: 1,
+  provider: 'https://rpc.mevblocker.io/fast',
+  bundlerUrl: 'https://api.candide.dev/public/v3/1',
+  safeModulesVersion: '0.3.0',
+  useNativeCoins: true
+}
+
+// Derivation fixture only; this does not prove the Safe is deployed.
+const safeAddress = WalletAccountReadOnlyEvmErc4337.predictSafeAddress(
+  '0x405005C7c4422390F4B334F64Cf20E0b767131d0',
+  { safeModulesVersion: '0.3.0' }
+)
+const readOnlyAccount = WalletAccountReadOnlyEvmErc4337.fromSafeAddress(
+  safeAddress,
+  config
+)
+console.log('Safe address:', await readOnlyAccount.getAddress())
+```
+
+The factory returns an account synchronously and does not check deployment, discover the owner, or validate that the supplied address is a Safe contract. It can [read balances](/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances#read-only-account-balances) and allowances, but cannot sign or send transactions. Its owner is unknown, so [signature verification](/sdk/wallet-modules/wallet-evm-erc-4337/guides/sign-verify-messages#verify-a-signature) is unavailable.
+
+Non-sponsored quotes require this Safe to be deployed before the module can build a UserOperation. A sponsored quote returns a zero fee without checking deployment or sponsorship eligibility; see [known-Safe errors](/sdk/wallet-modules/wallet-evm-erc-4337/guides/handle-errors#known-safe-address-errors).
 
 ## Next Steps
 
@@ -32597,13 +32787,15 @@ console.log('Signature:', signature)
 
 ## Verify a Signature
 
-You can verify a signature using a read-only account. Use [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) to create one, then call [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
+You can verify a signature using a read-only account that retains the owner EOA address. Use [`account.toReadOnlyAccount()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference) to create one, then call [`readOnlyAccount.verify()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference):
 
 ```javascript title="Verify Signature"
 const readOnlyAccount = await account.toReadOnlyAccount()
 const isValid = await readOnlyAccount.verify('Hello, ERC-4337!', signature)
 console.log('Signature valid:', isValid)
 ```
+
+Accounts created with [`fromSafeAddress()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#fromsafeaddresssafeaddress-config-static-1) do not know the owner. Their [`verify()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#verifymessage-signature-1) and [`verifyTypedData()`](/sdk/wallet-modules/wallet-evm-erc-4337/api-reference#verifytypeddatatypeddata-signature-1) methods throw `UnsupportedOperationError`; they do not perform Safe contract signature verification. Use an owner-based read-only account when you need to verify that owner's signature.
 
 ## Sign Typed Data (EIP-712)
 
@@ -32761,7 +32953,7 @@ The `@tetherto/wdk-wallet-evm-erc-4337` module provides account abstraction wall
 Install the package and create your first smart account.
 </Card>
 <Card title="Manage Accounts" href="/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts">
-Work with multiple smart accounts and custom derivation paths.
+Work with derived smart accounts or monitor a known Safe address.
 </Card>
 <Card title="Check Balances" href="/sdk/wallet-modules/wallet-evm-erc-4337/guides/check-balances">
 Query native, ERC-20, and paymaster token balances.
@@ -47551,15 +47743,15 @@ Integrate WDK into your existing React Native or Expo project using `@tetherto/w
 ### Step 1: Install
 
 ```bash
-npm install @tetherto/wdk-react-native-core@1.0.0-beta.18 react-native-bare-kit
+npm install @tetherto/wdk-react-native-core@1.0.0-beta.19 react-native-bare-kit
 npx expo install expo-crypto
 ```
 
 <Callout type="warn">
-The `v1.0.0-beta.18` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
+The `v1.0.0-beta.19` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
 </Callout>
 
-Beta.18 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is both inside the package range and compatible with the app's Expo SDK. If the SDK requires a version outside that range, do not force the peer installation; use compatible releases instead. Bare React Native apps must [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
+Beta.19 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is both inside the package range and compatible with the app's Expo SDK. If the SDK requires a version outside that range, do not force the peer installation; use compatible releases instead. Bare React Native apps must [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
 
 ### Step 2: Configure Android minSdkVersion
 
@@ -47926,7 +48118,7 @@ Ensure your component is rendered inside `WdkAppProvider`. The provider must be 
 
 **No biometric prompt appears before a wallet operation**
 
-React Native Core beta.18 does not enforce biometrics and does not accept a `requireBiometrics` provider prop. Run your app's biometric, passcode, or other authentication flow before calling `createWallet()`, `restoreWallet()`, `unlock()`, `switchWallet()`, or key-access methods.
+React Native Core beta.19 does not enforce biometrics and does not accept a `requireBiometrics` provider prop. Run your app's biometric, passcode, or other authentication flow before calling `createWallet()`, `restoreWallet()`, `unlock()`, `switchWallet()`, or key-access methods.
 
 For background locking, revoke the app's authenticated UI state synchronously, then call and catch `lock()`. The lifecycle mutex rejects instead of queuing when another guarded operation is running, so track a pending lock and retry it after the in-flight guarded operation settles. Require authentication again on foreground and do not treat the SDK session as locked until a retry succeeds.
 
@@ -47942,7 +48134,7 @@ npx react-native start --reset-cache
 
 **TypeScript cannot resolve React Native Core**
 
-Beta.18's published `default` and `types` export targets are absent. Configure TypeScript to select the included React Native source export:
+Beta.19's published `default` and `types` export targets are absent. Configure TypeScript to select the included React Native source export:
 
 ```json
 {
@@ -47953,7 +48145,7 @@ Beta.18's published `default` and `types` export targets are absent. Configure T
 }
 ```
 
-Use a current React Native or Expo Metro configuration that honors package exports and retains the `react-native` condition. `skipLibCheck` can suppress checks inside declarations after resolution; it cannot repair the missing beta.18 export targets.
+Use a current React Native or Expo Metro configuration that honors package exports and retains the `react-native` condition. `skipLibCheck` can suppress checks inside declarations after resolution; it cannot repair the missing beta.19 export targets.
 
 ### Complete Setup Checklist
 
@@ -51529,7 +51721,7 @@ Starting in `v1.0.0-beta.17`, wallet identity is caller-owned and the library no
 </Callout>
 
 <Callout type="warn">
-The `v1.0.0-beta.18` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
+The `v1.0.0-beta.19` npm artifact includes the React Native source entry at `src/index.ts`, but it does not include the declared default JavaScript or type declaration files under `dist/`. TypeScript must use `moduleResolution: "bundler"` with `customConditions: ["react-native"]`, and Metro must retain the `react-native` export condition. Resolvers that select `default` or `types` target files that are not present in this artifact.
 </Callout>
 
 ## Quick Start
@@ -51537,11 +51729,11 @@ The `v1.0.0-beta.18` npm artifact includes the React Native source entry at `src
 ### 1. Install
 
 ```bash
-npm install @tetherto/wdk-react-native-core@1.0.0-beta.18 react-native-bare-kit
+npm install @tetherto/wdk-react-native-core@1.0.0-beta.19 react-native-bare-kit
 npx expo install expo-crypto
 ```
 
-Beta.18 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is inside the package range and matches the app's Expo SDK. If the SDK requires a version outside the range, do not force the peer installation; use compatible releases instead. In a bare React Native app, [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
+Beta.19 requires `expo-crypto` `>=55.0.0 <57.0.0` and `react-native-bare-kit` `>=0.14.5` as peer dependencies. Confirm that the version selected by `npx expo install` is inside the package range and matches the app's Expo SDK. If the SDK requires a version outside the range, do not force the peer installation; use compatible releases instead. In a bare React Native app, [install and configure Expo modules](https://docs.expo.dev/bare/installing-expo-modules/) before installing `expo-crypto`.
 
 ### 2. Wrap Your App
 
@@ -51743,7 +51935,7 @@ Must be placed at the root of your component tree. All hooks in this library req
 | `children` | `React.ReactNode` | **required** | Child components |
 
 <Callout type="warn">
-Starting in `v1.0.0-beta.17`, `enableAutoInitialization`, `currentUserId`, and `clearSensitiveDataOnBackground` are no longer provider props. `requireBiometrics`, which was removed earlier, is also not accepted by beta.18. The app owns wallet identity, background-locking behavior, and biometric or other authentication checks.
+Starting in `v1.0.0-beta.17`, `enableAutoInitialization`, `currentUserId`, and `clearSensitiveDataOnBackground` are no longer provider props. `requireBiometrics`, which was removed earlier, is also not accepted by beta.19. The app owns wallet identity, background-locking behavior, and biometric or other authentication checks.
 </Callout>
 
 ### Example
@@ -51876,15 +52068,15 @@ Hook for wallet lifecycle operations: create, restore, lock, unlock, delete, and
 Only one wallet can be active. Call and await `lock()` before creating or restoring a different identity. To select a wallet that is already stored, use `switchWallet()` or lock and then unlock that wallet explicitly. `createWallet()`, `restoreWallet()`, `lock()`, `unlock()`, `switchWallet()`, and `createTemporaryWallet()` use a fail-fast mutex, so an overlapping guarded call rejects instead of queuing. The mutex timeout does not cancel an already-running underlying operation. `switchWallet()` is serialized, but it is not transactional: it locks first and does not restore the previous wallet if the new unlock fails.
 
 <Callout type="error">
-`deleteWallet()` and `clearTemporaryWallet()` are not protected by that mutex in beta.18. Deleting even an inactive wallet resets shared local worklet lifecycle state, while the Bare worklet and IPC remain running; this is not remote key cleanup or memory zeroization. The underlying secure-storage deletion can also be partially completed if individual storage operations fail. Authenticate and explicitly confirm destructive deletion, verify another recovery path first, serialize it against every lifecycle operation in the app, call and await `lock()` before deleting the active wallet, and verify the stored wallet inventory afterward.
+`deleteWallet()` and `clearTemporaryWallet()` are not protected by that mutex in beta.19. Deleting even an inactive wallet resets shared local worklet lifecycle state, while the Bare worklet and IPC remain running; this is not remote key cleanup or memory zeroization. The underlying secure-storage deletion can also be partially completed if individual storage operations fail. Authenticate and explicitly confirm destructive deletion, verify another recovery path first, serialize it against every lifecycle operation in the app, call and await `lock()` before deleting the active wallet, and verify the stored wallet inventory afterward.
 </Callout>
 
 <Callout type="error">
-`lock()` is an application-state boundary, not a zeroization guarantee. Beta.18 clears the active ID, local addresses, and local initialization flags, but it does not terminate the Bare worklet or send a remote cleanup request. Do not claim that calling it proves seeds or keys were erased from worklet memory.
+`lock()` is an application-state boundary, not a zeroization guarantee. Beta.19 clears the active ID, local addresses, and local initialization flags, but it does not terminate the Bare worklet or send a remote cleanup request. Do not claim that calling it proves seeds or keys were erased from worklet memory.
 </Callout>
 
 <Callout type="warn">
-React Native Core beta.18 does not enforce biometrics before wallet lifecycle or key-access methods. Authenticate in the app before invoking these methods. For app-background locking, close the authenticated UI boundary immediately and retry `lock()` after any in-flight guarded operation settles; a mutex rejection does not queue or cancel that operation.
+React Native Core beta.19 does not enforce biometrics before wallet lifecycle or key-access methods. Authenticate in the app before invoking these methods. For app-background locking, close the authenticated UI boundary immediately and retry `lock()` after any in-flight guarded operation settles; a mutex rejection does not queue or cancel that operation.
 </Callout>
 
 #### Advanced Crypto Methods
@@ -53233,12 +53425,12 @@ sm.dispose()
 URL: https://docs.wdk.tether.io/tools/wdk-utils
 Description: Chain-aware address validation, mnemonic sharing, seed encryption, deterministic key derivation, and payment-request helpers for @tetherto/wdk-utils
 
-WDK Utils provides CAIP-2-aware and chain-specific validation helpers for Bitcoin, EVM, Lightning, Solana, Spark, Tron, and UMA identifiers, Shamir-based mnemonic sharing, passphrase-based seed encryption, deterministic HKDF-SHA256 and Ed25519 key derivation, BIP-21 Bitcoin payment URI helpers, BOLT11 invoice helpers, and EIP-681 request parsing for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
+WDK Utils provides CAIP-2-aware and chain-specific validation helpers for Bitcoin, EVM, Lightning, Solana, Spark, TON, Tron, and UMA identifiers, Shamir-based mnemonic sharing, passphrase-based seed encryption, deterministic HKDF-SHA256 and Ed25519 key derivation, BIP-21 Bitcoin payment URI helpers, BOLT11 invoice helpers, and EIP-681 request parsing for token transfer deep links. Powered by [`@tetherto/wdk-utils`](https://github.com/tetherto/wdk-utils).
 
 ## Features
 
-- **Chain-aware address validation**: Dispatch to Bitcoin, EVM, Solana, Spark, or Tron validation with a CAIP-2 chain ID, including network checks for Bitcoin and Spark.
-- **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Solana, Spark, Tron, and UMA inputs before you hand them to a wallet flow.
+- **Chain-aware address validation**: Dispatch to Bitcoin, EVM, Solana, Spark, TON, or Tron validation with a CAIP-2 chain ID, including network checks for Bitcoin and Spark.
+- **Address validation helpers**: Validate Bitcoin, EVM, Lightning invoice, LNURL, Lightning address, Solana, Spark, TON, Tron, and UMA inputs before you hand them to a wallet flow.
 - **Mnemonic sharing helpers**: Split an English BIP-39 mnemonic into threshold-based Shamir shares and combine enough shares to recover it.
 - **BIP-21 payment URI helpers**: Detect, parse, and encode `bitcoin:` payment URIs with optional amount, label, and message fields.
 - **Seed encryption helpers**: Encrypt and decrypt seed phrases or other strings with AES-256-GCM and scrypt-derived keys.
@@ -53309,13 +53501,14 @@ Description: Validation, encryption, mnemonic sharing, BIP-21, BOLT11, and EIP-6
 | `decodeLnurl(address)` | Decode an LNURL string into its original URL. | `LnurlDecodingResult` |
 | `validateLightningAddress(address)` | Validate a Lightning Address in `user@domain.tld` form. | `LightningAddressValidationResult` |
 | `validateSparkAddress(address)` | Validate a Spark address or a Bitcoin L1 deposit address accepted by Spark flows. | `SparkAddressValidationResult` |
+| `validateTonAddress(address)` | Validate raw TON address structure or a user-friendly address and its checksum. | `TonAddressValidationResult` |
 | `validateTronAddress(address)` | Validate a Tron Base58Check address and prefix byte. | `TronAddressValidationResult` |
 | `validateUmaAddress(address)` | Validate a Universal Money Address. | `UmaAddressValidationResult` |
 | `resolveUmaUsername(uma)` | Split a valid UMA string into `localPart`, `domain`, and `lightningAddress`. | Parsed UMA details or `null`. |
 
 #### `validateAddress(chainId, address)`
 
-Validate an address with the chain-specific validator selected by a CAIP-2 chain ID or a bare namespace accepted by WDK Utils. The supported namespaces are `bip122`, `eip155`, `solana`, `spark`, and `tron`.
+Validate an address with the chain-specific validator selected by a CAIP-2 chain ID or a bare namespace accepted by WDK Utils. The supported namespaces are `bip122`, `eip155`, `solana`, `spark`, `ton`, and `tron`.
 
 ```javascript title="Validate An Address For A CAIP-2 Chain"
 import { validateAddress } from '@tetherto/wdk-utils'
@@ -53339,7 +53532,7 @@ For `bip122` and `spark`, the reference selects the expected network. Other supp
 
 Validate a Base58Check Bitcoin address and identify whether it matches a supported P2PKH or P2SH network version byte.
 
-The current beta.11 type declaration includes an internal `{ decoded: Uint8Array }` branch in this return type. The shipped runtime returns validation results rather than exposing that intermediate decode object.
+The beta.12 type declaration includes an internal `{ decoded: Uint8Array }` branch in this return type. The shipped runtime returns validation results rather than exposing that intermediate decode object.
 
 ```javascript title="Validate A Base58 Bitcoin Address"
 import { validateBase58 } from '@tetherto/wdk-utils'
@@ -53584,6 +53777,35 @@ const l1Deposit = validateSparkAddress(
 
 Bitcoin L1 deposit-address formats can be shared by Spark testnet/signet or regtest/local, so the compatibility array can contain two networks.
 
+#### `validateTonAddress(address)`
+
+Validate a required string `address` in raw `<workchain>:<64 hex characters>` form or user-friendly base64/base64url form. The synchronous signature is `validateTonAddress(address: string): TonAddressValidationResult`.
+
+```javascript title="Validate A TON Address"
+import { validateTonAddress } from '@tetherto/wdk-utils'
+
+const result = validateTonAddress(
+  'EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF'
+)
+// { success: true, type: 'ton' }
+```
+
+The package root exports these types:
+
+- `TonAddressValidationSuccess`: `{ success: true, type: 'ton' }`.
+- `TonAddressValidationFailure`: the shared failure shape, `{ success: false, reason: string }`.
+- `TonAddressValidationResult`: the union of those success and failure types. `ValidateAddressResult` also includes it when `validateAddress()` dispatches the `ton` namespace.
+
+The validator trims surrounding whitespace. Raw addresses receive a structure check for a signed integer workchain ID and 64 hexadecimal characters; they have no checksum. User-friendly addresses must have 48 characters, decode to the expected size, carry a bounceable or non-bounceable tag, and pass the CRC16-CCITT checksum. Standard base64 and URL-safe base64 are accepted.
+
+Runtime failure reasons are:
+
+- `EMPTY_ADDRESS`: the string is empty after trimming.
+- `INVALID_FORMAT`: the input is not a string or its structure, encoding, decoded size, or tag is invalid.
+- `INVALID_CHECKSUM`: the user-friendly address checksum does not match.
+
+Success does not establish account existence, ownership, or whether a workchain is supported. Test-only user-friendly addresses are accepted, and the result does not identify their network. `validateAddress()` also does not enforce the TON reference against the address's test-only flag; apply the intended network and recipient policy separately.
+
 #### `validateTronAddress(address)`
 
 Validate a Tron Base58Check address. The helper checks the `T` prefix, the 34-character address length, the Tron prefix byte, and the checksum.
@@ -53689,6 +53911,10 @@ import { decryptWithKey } from '@tetherto/wdk-utils'
 const plaintext = decryptWithKey(encrypted, key)
 ```
 
+#### `DEFAULT_SCRYPT_PARAMS`
+
+The exported default cost parameters are `{ N: 65536, r: 8, p: 1 }`. The encryption helpers use these values for omitted scrypt parameters.
+
 ### Seed Key Derivation Helpers
 
 Derive deterministic, domain-separated key material from high-entropy seed bytes.
@@ -53771,7 +53997,7 @@ const shares = await splitMnemonic(seedPhrase, {
 - The returned shares are unencrypted lowercase hex strings.
 - The package-specific share strings are not SLIP-39 mnemonic shares. They do not include the recovery threshold or a format-version marker, so retain that metadata separately.
 - Invalid BIP-39 words, word counts, and checksums are rejected.
-- Node.js uses the dependency's `node:crypto` implementation. Browser and React Native paths must provide secure `crypto.getRandomValues`; React Native apps may need to load `react-native-get-random-values` before importing WDK Utils. In Bare, import from the package root so the Bare entrypoint provides the Node-compatible crypto path; do not load the React Native polyfill. The dependency versions currently resolved for a fresh beta.11 installation require Bare `1.28.0` or later.
+- Node.js uses the dependency's `node:crypto` implementation. Browser and React Native paths must provide secure `crypto.getRandomValues`; React Native apps may need to load `react-native-get-random-values` before importing WDK Utils. In Bare, import from the package root so the Bare entrypoint provides the Node-compatible crypto path; do not load the React Native polyfill. With `bare-module` 6.4.0, the beta.12 dependency tree requires Bare `1.29.4` or later.
 
 #### `combineMnemonic(shares)`
 
@@ -53819,11 +54045,13 @@ const looksLikeRequest = isBip21Request(
 
 Parse a BIP-21 Bitcoin payment URI. The helper validates the Bitcoin address, accepts optional `amount`, `label`, and `message` parameters, rejects unsupported `req-` parameters, and returns machine-readable failure reasons.
 
+Raw non-ASCII characters in the query return `INVALID_FORMAT`. Percent-encode query text: `label=Caf%C3%A9` is accepted and decoded to `Café`, while `label=Café` is rejected. `isBip21Request()` checks the request shape and does not perform this validation.
+
 ```javascript title="Parse A BIP-21 Request"
 import { parseBip21Request } from '@tetherto/wdk-utils'
 
 const result = parseBip21Request(
-  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Coffee&message=Thanks'
+  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Caf%C3%A9&message=Thanks'
 )
 ```
 
@@ -53843,7 +54071,7 @@ const result = parseBip21Request(
 
 #### `encodeBip21Request(request)`
 
-Encode a BIP-21 Bitcoin payment URI from a request object. The helper validates the Bitcoin address and amount before returning the URI.
+Encode a BIP-21 Bitcoin payment URI from a request object. The helper validates the Bitcoin address and amount, then percent-encodes the query values before returning the URI. Pass the original `label` and `message` text; do not pre-encode these fields.
 
 ```javascript title="Encode A BIP-21 Request"
 import { encodeBip21Request } from '@tetherto/wdk-utils'
@@ -53880,6 +54108,8 @@ const looksLikeRequest = isEip681Request(
 #### `parseEip681Request(input)`
 
 Parse a supported EIP-681 transfer request. The published runtime supports `transfer` requests, accepts `value` as an alias for `uint256`, and normalizes scientific-notation amounts into integer `amountSmallest` strings.
+
+Raw non-ASCII characters anywhere in the query return `INVALID_FORMAT`, including in parameters the parser otherwise ignores. Percent-encode non-ASCII query text before parsing. `isEip681Request()` only checks the request shape; a positive detection result does not prove that the query is valid.
 
 ```javascript title="Parse An EIP-681 Request"
 import { parseEip681Request } from '@tetherto/wdk-utils'
@@ -53950,6 +54180,7 @@ import {
   validateLightningAddress,
   validateSolanaAddress,
   validateSparkAddress,
+  validateTonAddress,
   validateTronAddress,
   validateUmaAddress,
   resolveUmaUsername
@@ -54031,15 +54262,17 @@ import {
 ## Runtime notes
 
 - `@tetherto/wdk-utils` exports plain functions. There is no client object to initialize.
-- The package publishes a default module entrypoint through `index.js` and a Bare runtime entrypoint through `bare.js`. The dependency versions currently resolved for a fresh beta.11 installation require Bare `1.28.0` or later.
-- `validateAddress()` dispatches the CAIP-2 namespaces `bip122`, `eip155`, `solana`, `spark`, and `tron` to their chain validators. Unsupported namespaces return `UNSUPPORTED_CHAIN`, and malformed chain IDs return `INVALID_CHAIN_ID`.
+- The package publishes a default module entrypoint through `index.js` and a Bare runtime entrypoint through `bare.js`. With `bare-module` 6.4.0, the beta.12 dependency tree requires Bare `1.29.4` or later.
+- `validateAddress()` dispatches the CAIP-2 namespaces `bip122`, `eip155`, `solana`, `spark`, `ton`, and `tron` to their chain validators. Unsupported namespaces return `UNSUPPORTED_CHAIN`, and malformed chain IDs return `INVALID_CHAIN_ID`.
 - For `bip122` and `spark`, the chain reference selects the expected network. A missing, unknown, or incompatible reference returns `NETWORK_MISMATCH`. Other supported namespaces validate the address format but do not enforce the reference value.
 - Successful Bitcoin and Spark validators return `compatibleNetworks`, because some address formats are valid on more than one network. WDK Utils validates structure and network compatibility, not account existence, ownership, or recipient intent.
+- `validateTonAddress()` accepts raw TON addresses and user-friendly base64/base64url addresses. It checks the checksum only for user-friendly inputs and does not enforce mainnet/testnet compatibility. See [TON validation](/tools/wdk-utils/api-reference#validatetonaddressaddress) for result types and failures.
 - `validateSolanaAddress()` accepts base58-encoded 32-byte public keys, including off-curve program-derived addresses. Solana has no address checksum, so the helper cannot detect every mistyped address.
 - `splitMnemonic()` accepts valid 12-, 15-, 18-, 21-, or 24-word English BIP-39 phrases. It returns hex-encoded Shamir shares and supports threshold schemes from 2-of-2 through 255-of-255.
 - `combineMnemonic()` verifies an embedded 32-bit integrity checksum before returning the reconstructed phrase. The checksum normally detects accidental corruption, but it can collide and does not authenticate shares.
 - `encrypt()` requires `globalThis.crypto.getRandomValues`. In Node.js, `splitMnemonic()` uses the dependency's `node:crypto` implementation; browser and React Native paths require `globalThis.crypto.getRandomValues`. In React Native, load `react-native-get-random-values` before importing `@tetherto/wdk-utils` when the runtime does not provide secure random bytes. In Bare, import from the package root so the Bare entrypoint provides the Node-compatible crypto path; do not load the React Native polyfill.
 - `parseBip21Request()` accepts `bitcoin:` URIs with a validated Bitcoin address and optional `amount`, `label`, and `message` parameters.
+- `parseBip21Request()` and `parseEip681Request()` reject raw non-ASCII query text with `INVALID_FORMAT`. Percent-encode query values, for example `Caf%C3%A9` for `Café`. The BIP-21 encoder handles encoding for its `label` and `message` fields.
 - `encodeBip21Request()` validates the Bitcoin address and amount before returning a `bitcoin:` URI.
 - `encrypt()` returns a versioned payload with hex-encoded `salt`, `iv`, `tag`, and `ciphertext` fields plus the scrypt cost parameters used for key derivation.
 - `decrypt()` reads the scrypt cost parameters from the encrypted payload when they are present.
@@ -54079,6 +54312,17 @@ const tron = validateTronAddress('TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH')
 const uma = validateUmaAddress('$you@uma.money')
 ```
 
+Validate a TON address using [`validateTonAddress()`](/tools/wdk-utils/api-reference#validatetonaddressaddress). This address is a format-validation fixture; a successful result does not verify the account or its owner:
+
+```javascript title="Validate A TON Address"
+import { validateTonAddress } from '@tetherto/wdk-utils'
+
+const result = validateTonAddress(
+  'EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF'
+)
+// { success: true, type: 'ton' }
+```
+
 You can decode BOLT11 invoice details before presenting a payment request:
 
 ```javascript title="Decode A BOLT11 Invoice"
@@ -54089,19 +54333,19 @@ const invoice = decodeBolt11(
 )
 ```
 
-You can parse and encode a BIP-21 Bitcoin payment request:
+Parse a BIP-21 Bitcoin payment request with a percent-encoded label, or pass the original label to `encodeBip21Request()` to encode it:
 
 ```javascript title="Handle A BIP-21 Request"
 import { encodeBip21Request, parseBip21Request } from '@tetherto/wdk-utils'
 
 const parsed = parseBip21Request(
-  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Coffee'
+  'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.001&label=Caf%C3%A9'
 )
 
 const encoded = encodeBip21Request({
   address: '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
   amount: '0.001',
-  label: 'Coffee'
+  label: 'Café'
 })
 ```
 
@@ -54172,7 +54416,7 @@ You need:
 - A recovery policy that defines the total number of shares (`n`) and the threshold needed to recover (`k`). Both values must be integers, `2 <= k <= n <= 255`.
 - A secure way to distribute and retain each share separately, plus a tamper-evident record for authenticating the share bytes during recovery.
 - Cryptographically secure randomness. Node.js uses its `node:crypto` implementation. Browser and React Native paths must provide `globalThis.crypto.getRandomValues`; React Native runtimes may need a polyfill.
-- Bare `1.28.0` or later when using the package's Bare entrypoint. That entrypoint loads `bare-node-runtime/global`, and the dependency versions currently resolved for a fresh beta.11 installation enforce this minimum.
+- Bare `1.29.4` or later when using the package's Bare entrypoint. That entrypoint loads `bare-node-runtime/global`; the beta.12 dependency tree with `bare-module` 6.4.0 declares this minimum.
 
 <Callout type="warn">
 The helper receives only the mnemonic words. It does not include an optional BIP-39 passphrase, derivation path, network, account index, or other wallet metadata. Preserve everything your wallet needs for recovery through a separate protected process.
@@ -54400,7 +54644,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - **Opt-in handle diagnostics**: Use `options.handleLeakCheck` to inspect suspend-to-idle delays in generated HRPC worklets.
 
 <Callout type="info">
-`v1.0.0-beta.12` adds generic modules and their method allowlists to JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The new `options.handleLeakCheck` diagnostic is generated only for HRPC.
+`v1.0.0-beta.13` supports generic modules and their method allowlists in JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The `options.handleLeakCheck` diagnostic is generated only for HRPC.
 </Callout>
 
 ## Why this matters
@@ -54410,7 +54654,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - Transport-specific defaults produce a JavaScript HRPC bundle for React Native Core or native addon artifacts for JSON-RPC hosts; JavaScript-engine compatibility is configured separately.
 
 <Callout type="warn">
-`options.handleLeakCheck` is opt-in and reports active handles without closing them. JSON-RPC entrypoints do not enable this diagnostic in beta.12; see [configuration](/tools/worklet-bundler/configuration#configure-suspend-diagnostics) for the transport boundary.
+`options.handleLeakCheck` is opt-in and reports active handles without closing them. JSON-RPC entrypoints do not enable this diagnostic in beta.13; see [configuration](/tools/worklet-bundler/configuration#configure-suspend-diagnostics) for the transport boundary.
 </Callout>
 
 <Cards>
@@ -54483,19 +54727,19 @@ interface WdkBundleConfig {
 }
 ```
 
-`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to both HRPC and JSON-RPC. These inline helper shapes are present in the config declaration but are not named exports from the beta.12 npm entrypoint.
+`allowedMethods` is keyed by network. Its direct `methods` array restricts account calls, while `protocols` nests restrictions by protocol type and protocol name. `allowedModuleMethods` is keyed by generic-module name and applies to both HRPC and JSON-RPC. These inline helper shapes are present in the config declaration but are not named exports from the beta.13 npm entrypoint.
 
 Every omitted map, level, or `methods` field remains unrestricted. An explicit `methods: []` denies every method on that exact surface. Both generated contexts receive `allowedMethods` and `allowedModuleMethods`.
 
-Beta.12 generates `modules` for both transports. Use Pear Worklet beta.13 for JSON-RPC module calls and events. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
+Beta.13 generates `modules` for both transports. Use Pear Worklet beta.13 for JSON-RPC module calls and events. JSON-RPC defaults addon linking to `true`; HRPC defaults it to `false`. `options.convertEsmToCjs` defaults to `false` for both transports and must be enabled explicitly for targets whose Bare engine cannot load ESM.
 
 <Callout type="warn">
-Beta.12 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
+Beta.13 declares `output.types`, `options.minify`, and `options.sourceMaps`, but its bundle generator does not honor those fields. Declarations are always written to `./.wdk/index.d.ts`; `minify` and `sourceMaps` do not control `bare-pack` output. ESM-to-CJS conversion minifies independently.
 </Callout>
 
 `options.handleLeakCheck` is optional and applies only to generated HRPC entrypoints. Set `true` to use Pear Worklet beta.13's default `1000` ms interval, or a positive number to pass as `tickIntervalMs`. Omit it to disable diagnostics; `false`, zero, negative numbers, and strings fail `loadConfig()` validation. The interval controls repeated sampling after an immediate suspend snapshot, not a one-time delay.
 
-Generation checks whether the installed Pear Worklet diagnostic subpath resolves, warning and skipping it if unavailable. The helper logs through `console.warn` until Bare `idle` or `resume`; it does not close handles. JSON-RPC generation accepts the option but does not emit diagnostic registration in beta.12.
+Generation checks whether the installed Pear Worklet diagnostic subpath resolves, warning and skipping it if unavailable. The helper logs through `console.warn` until Bare `idle` or `resume`; it does not close handles. JSON-RPC generation accepts the option but does not emit diagnostic registration in beta.13.
 
 #### `ResolvedConfig`
 
@@ -54619,7 +54863,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `silent`
 - `skipTypes`
 - `skipGeneration`: Reuse an existing generated entrypoint. If `config.options.convertEsmToCjs` changed, regenerate the entrypoint first so its `.mjs` loader behavior matches the bundle conversion.
-- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.12 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
+- `deferOptionalPeers?` (`boolean`): When omitted or `true`, pass missing peers marked optional through `bare-pack --defer`. Beta.13 checks root, nested, scoped, and symlinked package trees before treating an optional peer as missing. Set this option to `false` to require absent optional imports at build time.
 
 `deferOptionalPeers` is a per-run API option. It is not a `WdkBundleConfig` field and cannot be set in `wdk.config.js`.
 
@@ -54633,7 +54877,7 @@ Use `generateBundle()` when you want the same bundle workflow that powers the CL
 - `error?`
 - `missingModule?`
 
-In beta.12, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
+In beta.13, `typesPath` can reflect a configured `output.types` path even though the declaration file is still written to `./.wdk/index.d.ts`.
 
 ```typescript title="Generate A Bundle Programmatically"
 import { generateBundle, loadConfig } from '@tetherto/wdk-worklet-bundler'
@@ -54652,11 +54896,11 @@ Use `generateSourceFiles()` when you want the generated entrypoint without the f
 
 Use `generateEntryPoint()` when you need the generated HRPC Bare entrypoint written to a chosen output directory. This path includes configured generic modules, both method-allowlist maps, module lifecycle/event wiring, and the optional `handleLeakCheck` diagnostic.
 
-Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.12 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.12 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
+Starting in beta.3, the generated entrypoint suspends and resumes both the `bare-http1` and `bare-https` global agents when the Bare runtime emits `suspend` and `resume`. Beta.13 also logs the generated worklet's Bare `suspend`, `resume`, and `idle` events. When `options.convertEsmToCjs` is enabled, beta.13 also emits the matching runtime `.mjs`-as-CommonJS loader patch.
 
 #### `generateJsonRpcEntryPoint(config, outputDir)`
 
-Generate the framed JSON-RPC entrypoint used by native hosts. Beta.12 includes wallet, protocol, and generic-module managers plus both method-allowlist maps. With Pear Worklet beta.13, it supports module calls/events and forwards Bare `suspend` and `resume` to the module runtime. It does not generate HRPC's HTTP-agent lifecycle hooks or the `handleLeakCheck` diagnostic. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
+Generate the framed JSON-RPC entrypoint used by native hosts. Beta.13 includes wallet, protocol, and generic-module managers plus both method-allowlist maps. With Pear Worklet beta.13, it supports module calls/events and forwards Bare `suspend` and `resume` to the module runtime. It does not generate HRPC's HTTP-agent lifecycle hooks or the `handleLeakCheck` diagnostic. When `options.convertEsmToCjs` is enabled, it emits the same `.mjs` loader patch as the HRPC generator.
 
 #### `linkAddons(config, options?)`
 
@@ -54685,11 +54929,11 @@ convertBundleEsmToCjs('./.wdk-bundle/wdk-worklet.bundle.js', {
 })
 ```
 
-The beta.12 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
+The beta.13 converter accepts raw `.bundle` data and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by bare-pack. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported. The converter transforms `.js`, `.mjs`, and `.cjs` files, lowers dynamic imports, removes `"type": "module"` from bundled package manifests, recomputes offsets with `bare-bundle`, restores the original wrapper, and calls `validateBundle()` before returning. It throws if any source transformation or final validation fails.
 
 This helper rewrites only the packed bundle. For `.mjs` files to load as CommonJS at runtime, generate the HRPC or JSON-RPC entrypoint with `options.convertEsmToCjs: true` before packing, or provide equivalent loader behavior yourself. Do not convert a bundle while reusing an entrypoint generated with conversion disabled.
 
-The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.12 package entrypoint.
+The inline `options` shape has `minify?: boolean` and `verbose?: boolean`. `ConvertOptions` appears in the generated declaration as the parameter shape but is not a named export from the beta.13 package entrypoint.
 
 #### `validateBundle(bundlePath)`
 
@@ -54718,7 +54962,7 @@ The published CLI exposes these commands through `wdk-worklet-bundler`:
 For the end-to-end config workflow and transport defaults, see the [Worklet Bundler configuration guide](/tools/worklet-bundler/configuration).
 
 <Callout type="warn">
-Beta.12 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
+Beta.13 applies `--transport` after `loadConfig()` resolves output paths. The flag changes entrypoint generation but does not recompute the default bundle filename. Set `transport` in `wdk.config.js`, or configure `output.bundle` explicitly when using the flag.
 </Callout>
 
 ***
@@ -54741,10 +54985,10 @@ Install the bundler as a development dependency and Pear Worklet as a runtime de
 
 ```bash title="Install The Bundler And Runtime"
 npm install @tetherto/pear-wrk-wdk@1.0.0-beta.13
-npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.12
+npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.13
 ```
 
-Worklet Bundler beta.12 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
+Worklet Bundler beta.13 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
 
 ## Create `wdk.config.js`
 
@@ -54908,11 +55152,11 @@ Use `modules` for named generic packages that expose a module factory. Each entr
 
 The factory receives `{ seed, config, capabilities, emit }` and can return the module instance or a promise for it. A module that needs the seed must consume it synchronously rather than retain it. The build-time name, such as `preferences`, must match the key in the host's runtime module config.
 
-Beta.12 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
+Beta.13 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 ### `transport` (optional)
 
-Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.12, ESM-to-CJS conversion is an independent, explicit option for both transports.
+Choose `hrpc` or `jsonrpc`. HRPC is the default and is the transport used by React Native Core. JSON-RPC produces a length-prefixed bundle for a native host and enables addon linking by default. In beta.13, ESM-to-CJS conversion is an independent, explicit option for both transports.
 
 ### `preloadModules` (optional)
 
@@ -54923,7 +55167,7 @@ Use `preloadModules` for native addons or other modules that must be required be
 Supported output fields are:
 
 - `bundle`: Bundle path. Defaults to `./.wdk-bundle/wdk-worklet.bundle.js` for HRPC and `./.wdk-bundle/wdk-worklet.bundle` for JSON-RPC.
-- `types`: Declared in the beta.12 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
+- `types`: Declared in the beta.13 config type, but the generator does not honor a custom value and always writes declarations to `./.wdk/index.d.ts`.
 - `addons.ios`, `addons.macos`, `addons.android`: Platform addon directories. Defaults are `./ios-addons`, `./mac-addons`, and `./android-addons`.
 - `addonsYml`: BareKit Swift dependency file. Defaults to `./ios-addons/addons.yml` and is generated when iOS addons are linked.
 
@@ -54931,8 +55175,8 @@ Supported output fields are:
 
 The published config type supports these build options:
 
-- `minify` (`boolean`): Declared in the beta.12 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
-- `sourceMaps` (`boolean`): Declared in the beta.12 config type but not read by the bundle path, so it does not produce source maps.
+- `minify` (`boolean`): Declared in the beta.13 config type but not read by the bundle path. ESM-to-CJS conversion minifies independently of this field.
+- `sourceMaps` (`boolean`): Declared in the beta.13 config type but not read by the bundle path, so it does not produce source maps.
 - `targets` (`string[]`): Override the default Bare build hosts. The shipped defaults cover iOS arm64 and simulator targets plus Android arm, arm64, ia32, and x64 hosts.
 - `linkAddons` (`boolean`): Link native addons with `bare-link`. Defaults to `true` for JSON-RPC and `false` for HRPC.
 - `platforms` (`('ios' | 'macos' | 'android')[]`): Addon platforms. Defaults to all three when addon linking is active.
@@ -54961,7 +55205,7 @@ This emits `registerHandleLeakCheck({ tickIntervalMs: 5000 })`. The diagnostic l
 If the installed Pear Worklet package does not expose `@tetherto/pear-wrk-wdk/diagnostics/handle-leak-check`, generation warns and omits the diagnostic. If the export exists but its optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable, the runtime helper does nothing.
 
 <Callout type="warn">
-Beta.12 emits this diagnostic only for HRPC. Setting `options.handleLeakCheck` in a JSON-RPC config passes validation but does not emit diagnostic registration. Custom JSON-RPC entrypoints can register the [Pear Worklet helper](/tools/pear-wrk-wdk/configuration#inspect-suspend-delays) themselves.
+Beta.13 emits this diagnostic only for HRPC. Setting `options.handleLeakCheck` in a JSON-RPC config passes validation but does not emit diagnostic registration. Custom JSON-RPC entrypoints can register the [Pear Worklet helper](/tools/pear-wrk-wdk/configuration#inspect-suspend-delays) themselves.
 </Callout>
 
 ### Configure ESM-to-CJS conversion
@@ -54979,14 +55223,14 @@ module.exports = {
 }
 ```
 
-In the normal `generate` or `generateBundle()` path, beta.12 uses one flag for both build-time conversion and the generated runtime loader:
+In the normal `generate` or `generateBundle()` path, beta.13 uses one flag for both build-time conversion and the generated runtime loader:
 
 - After `bare-pack`, it converts `.js`, `.mjs`, and `.cjs` files to CommonJS, lowers dynamic `import()`, removes `"type": "module"` from bundled package manifests, and rebuilds bundle offsets with `bare-bundle`.
 - It preserves raw bundles and the default UTF-8 CommonJS, ESM, or JSON string wrappers produced by supported `bare-pack` output suffixes. Wrappers created with a non-UTF-8 `--encoding`, such as Base64, are not supported.
 - It validates the rewritten file map, offsets, lengths, CommonJS syntax, entrypoint, package manifests, and absence of dynamic imports before generation succeeds.
 - The generated HRPC or JSON-RPC entrypoint routes `.mjs` files through the CommonJS loader only when conversion is enabled.
 
-There is no beta.12 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
+There is no beta.13 CLI flag that overrides this setting. Set `options.convertEsmToCjs` in the config used for the build.
 
 ## Configure JSON-RPC and native addons
 
@@ -55028,11 +55272,11 @@ npx wdk-worklet-bundler validate
 
 ## Handle peer dependencies
 
-Worklet Bundler beta.12 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
+Worklet Bundler beta.13 separates required peers from peers explicitly marked optional through `peerDependenciesMeta`:
 
 - During bundle generation, missing required peers are offered for installation. In a non-interactive environment without `--install`, the CLI prints the exact manual install command and continues; `bare-pack` can still fail if the bundle needs that peer. The peer scan is skipped by `--source-only`.
 - Missing optional peers are not prompted for or installed. By default, the bundler passes each one to `bare-pack --defer`, so an unused optional feature does not block the build.
-- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.12 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
+- Optional peers detected anywhere in the scanned package tree are not deferred. Beta.13 matches package names across root, nested, scoped, and symlinked package trees; install a peer in an ancestor `node_modules` visible to the package that imports it, because the same package name elsewhere in the tree can suppress deferral without making that import resolvable. A peer that is required anywhere else in the scanned dependency tree is treated as required and is not deferred.
 
 Use `--no-defer-optional-peers` when the app uses an optional feature and you want a missing peer to fail during the build:
 
@@ -55054,11 +55298,11 @@ Use `generate` to build the worklet artifact:
 npx wdk-worklet-bundler generate --install
 ```
 
-`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.12, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
+`generate --install` can auto-install missing configured wallet, protocol, generic, preload, and Pear Worklet runtime dependencies after the package manager is detected from the project root. In beta.13, the Pear Worklet runtime is included for both HRPC and JSON-RPC, so the generated entrypoint's runtime dependency is surfaced during validation and installation instead of failing later in `bare-pack`.
 
 Use `--source-only` when you want the generated `.wdk/wdk-worklet.generated.js` entrypoint and related artifacts without running `bare-pack`. This mode also skips bundle conversion. If `options.convertEsmToCjs` is `true` and you run `bare-pack` yourself, convert the packed bundle with `convertBundleEsmToCjs()` before deployment; the source-only entrypoint already contains the matching `.mjs` loader patch. Keep the same conversion setting when generating the entrypoint and converting the bundle.
 
-The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.12, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
+The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`, `--skip-link-addons`, `--platforms ios,macos,android`, and `--no-defer-optional-peers`. Set `transport` in `wdk.config.js` when you rely on its transport-specific default bundle path. In beta.13, `--transport` changes the generated transport after output paths have already been resolved, so it does not switch `.js` HRPC output to the extensionless JSON-RPC default, or vice versa. If you use the flag, set `output.bundle` explicitly to the intended path.
 
 `--skip-generation` reuses an existing generated entrypoint. If `options.convertEsmToCjs` changed since that entrypoint was created, regenerate without `--skip-generation` before building so the runtime `.mjs` loader matches the bundle conversion setting.
 
@@ -55066,13 +55310,13 @@ The `generate` command also accepts `--transport hrpc|jsonrpc`, `--link-addons`,
 
 Generated HRPC and JSON-RPC entrypoints forward Bare `suspend` and `resume` events to the configured generic modules' optional lifecycle methods. Pear Worklet closes modules during full disposal or reinitialization; targeted wallet disposal leaves them running.
 
-HRPC entrypoints additionally suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare `suspend`, `resume`, and `idle` events. JSON-RPC beta.12 does not include that HTTP-agent handling. These lifecycle hooks require no diagnostic flag; `options.handleLeakCheck` only adds HRPC handle reporting.
+HRPC entrypoints additionally suspend and resume both the `bare-http1` and `bare-https` global agents and log Bare `suspend`, `resume`, and `idle` events. JSON-RPC beta.13 does not include that HTTP-agent handling. These lifecycle hooks require no diagnostic flag; `options.handleLeakCheck` only adds HRPC handle reporting.
 
 ## Troubleshooting
 
 - If `loadConfig()` cannot find a config file, run `npx wdk-worklet-bundler init` or pass `--config \<path\>`.
 - If `validate` or `generate` reports missing modules, use `generate --install` or inspect the install command from the exported helper APIs in the [API Reference](/tools/worklet-bundler/api-reference).
-- When `bare-pack` reports an unresolved package subpath, beta.12 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
+- When `bare-pack` reports an unresolved package subpath, beta.13 reduces scoped or unscoped subpaths to the installable package root and prints an install command for the package manager detected from the project root. It prints no install hint when the reported specifier is not an installable package, such as a relative or absolute path, private import, URL or builtin-prefixed specifier, or bare scope.
 - If you need to inspect generated source before bundling, use `generate --source-only` and review the files in `.wdk/`. For a CommonJS-only target, pack and convert that source as described above before running it.
 
 ***

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -5873,6 +5873,13 @@ Stay up to date with the latest improvements, new features, and bug fixes across
 
 ---
 
+### September 11, 2026
+
+**Changes**
+- **pear-wrk-wdk** ([v1.0.0-beta.14](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.14)): [Breaking] Remove `CallMethodOptions.transformResult`; transform responses in the host. Zero the retained seed buffer on full disposal and seed replacement; targeted disposal and config-only reinitialization retain it. Add named-field log redaction, default unknown log levels to `ERROR`, and omit native parser details from invalid-JSON field errors. Normalize generic-module void results to `null`, fix HRPC module-event forwarding, and update optional `bare-walk-handles` to `^2.1.0`.
+
+---
+
 ### September 08, 2026
 
 **What's New**
@@ -50566,7 +50573,7 @@ Description: HRPC and framed JSON-RPC infrastructure for running WDK inside a Ba
 
 Pear Worklet WDK is the low-level transport and handler layer for running WDK inside a Bare worklet. It provides an `HRPC` client and server helper, a separate framed JSON-RPC server entrypoint for native hosts, and request payloads for WDK, wallet, protocol, and generic-module operations.
 
-Powered by `@tetherto/pear-wrk-wdk`.
+Powered by `@tetherto/pear-wrk-wdk`. These pages cover `v1.0.0-beta.14`.
 
 ## Features
 
@@ -50588,7 +50595,7 @@ Powered by `@tetherto/pear-wrk-wdk`.
 - You can host the same wallet and protocol handlers behind HRPC or a native JSON-RPC bridge, within each transport's supported method set
 
 <Callout type="info">
-Use this package when you need direct control over the worklet host and RPC layer. If you want generated worklet entry files instead, start with [`@tetherto/wdk-worklet-bundler`](https://github.com/tetherto/wdk-worklet-bundler).
+Use this package when you need direct control over the worklet host and RPC layer. If you want generated worklet entry files instead, start with [Worklet Bundler](/tools/worklet-bundler).
 </Callout>
 
 <Callout type="info">
@@ -50596,7 +50603,7 @@ The top-level package exports the `HRPC` runtime value. Import `registerRpcHandl
 </Callout>
 
 <Callout type="warn">
-In `v1.0.0-beta.13`, a missing wallet or protocol method returns `BAD_REQUEST` even if the caller supplies `options.defaultValue`. Handle unsupported methods in the host. The package does not export a pre-built WDK bundle.
+Since beta.13, a missing wallet or protocol method returns `BAD_REQUEST` even if the caller supplies `options.defaultValue`. Beta.14 also removes `options.transformResult`. Handle unsupported methods and transform returned values in the host. The package does not export a pre-built WDK bundle.
 </Callout>
 
 <Cards>
@@ -50684,9 +50691,9 @@ Returns:
 - `encryptedSeed?` (`string`): Base64-encoded encrypted seed buffer.
 - `config` (`string`): JSON stringified `WdkWorkletConfig`.
 
-The handler requires `encryptionKey` and `encryptedSeed` to be passed together or omitted together. When a seeded WDK instance already exists, the runtime disposes it and closes its generic modules before re-registering the wallets and optional protocols in `config`.
+The handler requires `encryptionKey` and `encryptedSeed` to be passed together or omitted together. When a seeded WDK instance already exists, the runtime closes its generic modules and calls `wdk.dispose()` before validating the new config. In beta.14, a replacement seed pair then causes the old retained buffer to be zeroed before the new seed is decrypted. Config-only reinitialization reuses the existing WDK object and seed buffer.
 
-In beta.13, generic modules on either transport are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules.
+Generic modules on either transport are constructed from `context.moduleManagers` and `config.modules` only when that request includes the encrypted seed pair. A seedless reinitialization closes existing module instances without reconstructing them. Supply both seed fields on every initialization that must construct or reconstruct modules. See [initialization and cleanup limits](/tools/pear-wrk-wdk/configuration#initialization-rules).
 
 #### `resetWdkWallets`
 
@@ -50727,7 +50734,9 @@ Returns:
 
 - `args` (`DisposeRequest`): Optional `blockchains` array. Omit it or pass an empty array for a full disposal.
 
-A full disposal closes all generic modules and clears the WDK instance. A non-empty `blockchains` array disposes only those wallets and leaves generic modules running.
+A full disposal closes all generic modules and clears the WDK instance. Beta.14 also zeroes and releases `context.wdkSeedBuffer`. After module shutdown completes, this cleanup runs even if `wdk.dispose()` throws. A non-empty `blockchains` array disposes only those wallets and retains the instance, seed buffer, and generic modules.
+
+HRPC sends this request without awaiting a response and returns `void`. JSON-RPC returns `{ status: 'disposed' }` inside its response `result` when the handler completes successfully. See [disposal limits](/tools/pear-wrk-wdk/configuration#dispose-wdk).
 
 #### `callMethod`
 
@@ -50742,6 +50751,8 @@ A full disposal closes all generic modules and clears the WDK instance. A non-em
 When `RpcContext.allowedMethods` defines the target surface, `methodName` must appear in its `methods` array. Account restrictions are keyed by network; protocol restrictions are nested by network, protocol type, and protocol name. Omitted surfaces remain unrestricted, while `methods: []` denies every call on that exact surface. Denied calls fail before dispatch with the runtime code `METHOD_NOT_ALLOWED`.
 
 A missing wallet or protocol method fails with `BAD_REQUEST`. Beta.13 removes the `options.defaultValue` fallback from both runtime dispatch and `CallMethodOptions`; callers must handle unsupported methods themselves.
+
+Beta.14 removes `options.transformResult` from `CallMethodOptions` and no longer invokes it in the handler. Transform results after receiving them in the host. Invalid JSON in `args` or `options` still fails with `BAD_REQUEST`, but no longer includes the native JSON parser's error detail.
 
 #### `registerWallet`
 
@@ -50762,19 +50773,21 @@ Returns:
 
 #### `callModule`
 
-Call one method on a configured generic module. Both HRPC and JSON-RPC support this operation in beta.13.
+Call one method on a configured generic module. Both HRPC and JSON-RPC support this operation since beta.13.
 
 - `module` (`string`): Module name shared by `RpcContext.moduleManagers` and `WdkWorkletConfig.modules`.
 - `method` (`string`): Non-empty method name on the constructed module instance.
-- `args?` (`string`): Optional JSON string of arguments. Arrays are spread as positional arguments; a non-array value is passed as one argument.
+- `args?` (`string`): Optional JSON string of arguments. Arrays are spread as positional arguments; omitted or decoded `null` arguments call the method with no arguments. Other values are passed as one argument.
 
-HRPC returns `CallModuleResponse` with optional `result`, a JSON string. JSON-RPC decodes that string and returns the value at `response.result.result`. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization. Return a JSON-serializable value, or `null` for no result; an `undefined` result cannot be decoded by the JSON-RPC transport.
+HRPC returns `CallModuleResponse` with optional `result`, a JSON string. JSON-RPC decodes that string and returns the value at `response.result.result`. The runtime awaits promises, materializes values with `.toArray()`, and recursively converts `Uint8Array` values to hex before serialization. In beta.14, a top-level `undefined` or `null` result becomes the HRPC string `"null"` and the decoded JSON-RPC value `null`. Other falsy results such as `false`, `0`, and `''` are preserved. This module normalization does not apply to wallet or protocol `callMethod()` results.
 
 When `RpcContext.allowedModuleMethods` defines the target module, `method` must appear in that module's `methods` array. Omitted modules remain unrestricted, while `methods: []` denies every method on that module. A denied call fails with `METHOD_NOT_ALLOWED` before instance lookup or dispatch.
 
 #### `moduleEvent`
 
 Send an HRPC module event to the host. JSON-RPC forwards the same event as a `moduleEvent` notification with decoded `params.payload`; it has no request `id`.
+
+Beta.14 fixes HRPC event forwarding from hosted modules by preserving the RPC receiver when sending `moduleEvent()`. The event payload shape is unchanged.
 
 - `module` (`string`): Module name.
 - `event` (`string`): Event name.
@@ -50837,9 +50850,13 @@ Registers the host-side handler used to receive `moduleEvent()` messages.
 Import this helper from `@tetherto/pear-wrk-wdk/worklet`. It registers the package's server-side handlers on the provided RPC instance.
 
 - `rpc` (`any`): RPC server instance that supports the generated handler registration methods.
-- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. Generic modules on either transport can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime` and `moduleInstances`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts generic-module dispatch on both transports.
+- `context` (`RpcContext`): Runtime context containing `wdk`, `WDK`, `walletManagers`, `protocolManagers`, and `wdkLoadError`. Generic modules on either transport can additionally supply `moduleManagers` and `capabilities`; the runtime manages `moduleRuntime`, `moduleInstances`, and, in beta.14, `wdkSeedBuffer`. Optional `allowedMethods` restricts wallet and protocol dispatch on HRPC and JSON-RPC, while `allowedModuleMethods` restricts generic-module dispatch on both transports.
 
 ### Types
+
+#### `RpcContext.wdkSeedBuffer`
+
+`wdkSeedBuffer?: Buffer | null` is a runtime-managed field added in beta.14. It retains the decrypted buffer passed to the WDK constructor so the runtime can zero it on full disposal or seed replacement. Do not populate it manually. Targeted wallet disposal and config-only reinitialization retain it. See [initialization rules](/tools/pear-wrk-wdk/configuration#initialization-rules) for failure-path limits.
 
 #### `RpcContext` Method Restrictions
 
@@ -50869,7 +50886,7 @@ interface RpcContext {
 
 The four allowlist helper interfaces are exported types in beta.13. Every omitted level remains unrestricted. Use an explicit empty `methods` array to deny all dynamic calls on one exact surface.
 
-The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.13 published error-code declaration does not include that member. Treat the literal runtime code as authoritative for this release.
+The runtime exposes `METHOD_NOT_ALLOWED` for denied calls, but the beta.14 published error-code declaration still does not include that member. Treat the literal runtime code as authoritative for this release.
 
 #### `WdkWorkletConfig`
 
@@ -50952,7 +50969,6 @@ enum ProtocolType {
 }
 
 interface CallMethodOptions {
-  transformResult: Function
   protocolType: ProtocolType
   protocolName: string
 }
@@ -50960,7 +50976,7 @@ interface CallMethodOptions {
 
 The published declarations include `ProtocolType`, but the top-level JavaScript entry does not export that enum value at runtime. Pass the corresponding string literal, such as `'swidge'`, in serialized request options.
 
-The published `CallMethodOptions` declaration marks every remaining field as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used. `transformResult` is a function-valued internal handler option; it cannot be sent through JSON serialization. Do not place a function in serialized request options.
+The published `CallMethodOptions` declaration marks both fields as required. The request's `options` string remains optional at runtime, and the handler reads fields only when their behavior is used. Beta.14 removes the former function-valued `transformResult` field; apply transformations in the host after decoding the response.
 
 ### Diagnostic export: `registerHandleLeakCheck(options?)`
 
@@ -50990,7 +51006,7 @@ registerJsonRpcHandlers(ipc, context)
 
 The server reads UTF-8 JSON-RPC 2.0 messages framed with a four-byte unsigned big-endian payload length. Every request requires an ID, and an ID cannot be reused while its earlier request is still in flight. Malformed frames are dropped without a response. The package does not export a JSON-RPC client or native-host helper.
 
-Beta.13 supports these JSON-RPC method names:
+Beta.14 supports these JSON-RPC method names:
 
 - `workletStart`
 - `generateEntropyAndEncrypt`
@@ -51008,7 +51024,7 @@ JSON-RPC does not support `resetWdkWallets` in this release. Use HRPC for select
 The transports share the wallet/protocol handler and module runtime. Both support the `swidge` protocol type, enforce `RpcContext.allowedMethods`, and enforce `allowedModuleMethods` for generic-module calls. JSON-RPC `callModule` parameters match `CallModuleRequest`, including its JSON-string `args`. Results use `response.result.result`; events arrive as `moduleEvent` notifications with `params: { module, event, payload }` and a decoded payload. See the [JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 <Callout type="warn">
-Beta.13 removes JSON-RPC parameters and results from INFO request/response logs and logs wallet-call arguments at DEBUG. Mnemonic validation errors identify invalid word positions without echoing the words. This does not provide general secret redaction: DEBUG arguments, module errors, and application logs can still contain sensitive values. Production defaults to ERROR logging; avoid sensitive values in custom logs and errors.
+Beta.14 redacts named secret fields in object arguments to the package logger. It does not scrub raw strings, typed-array arguments, or formatted Error stacks. Production defaults to ERROR logging; see [logging configuration and limits](/tools/pear-wrk-wdk/configuration#configure-logging).
 </Callout>
 
 Mnemonic strings, encryption-key strings, and encrypted payload strings cannot be zeroed in JavaScript. Discard references promptly and never log them. The runtime validates imported mnemonics for 12 or 24 English BIP-39 words and clears temporary byte buffers where possible.
@@ -51025,7 +51041,7 @@ Mnemonic strings, encryption-key strings, and encrypted payload strings cannot b
 URL: https://docs.wdk.tether.io/tools/pear-wrk-wdk/configuration
 Description: Configure Pear Worklet HRPC and JSON-RPC contexts, WDK payloads, and generic modules
 
-This page explains how to [build the worklet context](#worklet-context), [shape the worklet config payload](#worklet-config-payload), [initialize WDK](#initialize-wdk), [call generic modules](#call-generic-module-methods), [choose a transport](#json-rpc-transport), and [inspect suspend delays](#inspect-suspend-delays).
+This page explains how to configure a beta.14 worklet context, initialize and dispose WDK, call wallet and generic-module methods, and configure logging and suspend diagnostics. Use the table of contents to find each task.
 
 ## Worklet Context
 
@@ -51160,7 +51176,7 @@ const context = {
 Omitting a module or its `methods` field leaves that module unrestricted. Set `methods: []` to deny every dynamic call on it.
 
 <Callout type="warn">
-These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.13 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration omits that new member; handle the literal runtime code until the declaration is corrected.
+These maps are not default-deny. List every dynamic surface exposed to an untrusted host. The beta.14 runtime reports denied calls with `METHOD_NOT_ALLOWED`, but the published error-code declaration still omits that member; handle the literal runtime code until the declaration is corrected.
 </Callout>
 
 ## Worklet Config Payload
@@ -51202,7 +51218,7 @@ const workletConfig = {
 - `modules` is optional and contains runtime config for named generic modules. Each key must match a `moduleManagers` key in the worklet context and the corresponding build-time Worklet Bundler module name.
 - `resetWdkWallets()` reads only the `networks` portion of the decoded config.
 
-JSON-RPC generic modules require Pear Worklet beta.13. Supply the same `moduleManagers`, `allowedModuleMethods`, and runtime `modules` config used by HRPC. If generating the entrypoint, use Worklet Bundler beta.12 with Pear Worklet beta.13.
+JSON-RPC generic-module support was introduced in Pear Worklet beta.13. Supply the same `moduleManagers`, `allowedModuleMethods`, and runtime `modules` config used by HRPC. For generated entrypoints, use [Worklet Bundler beta.13 with Pear Worklet beta.14](/tools/worklet-bundler/configuration#install-the-packages).
 
 ## Initialize WDK
 
@@ -51224,9 +51240,25 @@ await hrpc.initializeWDK({
 
 - Pass both `encryptionKey` and `encryptedSeed`, or omit both together.
 - On first initialization, the worklet must receive an encrypted seed pair so it can create `context.wdk`.
-- If `context.wdk` already exists, a later `initializeWDK()` call disposes the existing instance and closes its generic modules before re-registering wallets and protocols from the new config.
-- In beta.13, generic modules on either transport are constructed only when that `initializeWDK()` request includes both `encryptionKey` and `encryptedSeed`. A seedless reinitialization closes existing module instances but does not rebuild them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
+- If `context.wdk` already exists, reinitialization closes its generic modules and calls `wdk.dispose()` before validating the new config. With both seed fields present, beta.14 then zeroes the old retained seed buffer before attempting replacement. Validate the replacement payload before sending it; a failed replacement does not restore the old seed.
+- Without a seed pair, reinitialization reuses the existing WDK object and retained seed to re-register wallets and protocols. It closes generic modules without rebuilding them, even when `config.modules` is present. Supply the seed pair on every initialization that must construct or reconstruct modules.
 - Module `close()` is called during full disposal or reinitialization. Targeted blockchain disposal leaves generic modules running. Optional `suspend()` and `resume()` methods run only when the host forwards Bare lifecycle events; the manual context above does so.
+
+The runtime manages the decrypted buffer through `context.wdkSeedBuffer`; do not set this field yourself. If the WDK constructor throws, beta.14 zeroes the newly decrypted buffer. Later wallet or protocol registration failures retain the new instance and seed, so handle those failures and dispose the instance when abandoning initialization.
+
+## Dispose WDK
+
+Send a full disposal request when the worklet should release its WDK instance:
+
+```javascript title="Dispose The Worklet WDK"
+hrpc.dispose({})
+```
+
+A full disposal closes generic modules, disposes WDK, and zeroes and releases its retained seed buffer. Once module shutdown completes, the instance and buffer are cleared even if `wdk.dispose()` throws. HRPC `dispose()` is one-way and returns `void`; its return does not acknowledge cleanup completion.
+
+To dispose only selected wallets, pass a non-empty `blockchains` array, such as `hrpc.dispose({ blockchains: ['ethereum'] })`. This retains the WDK instance, seed buffer, and generic modules. An omitted or empty array requests full disposal.
+
+This cleanup covers the buffer retained by the worklet runtime. It cannot erase JavaScript strings or copies retained by application or module code.
 
 ## Reset Selected Wallets
 
@@ -51272,10 +51304,13 @@ const result = await hrpc.callMethod({
 - `args` is optional and must be a JSON string when provided.
 - `options` is optional and must be a JSON string when provided.
 - When `args` decodes to an array, the handler spreads the values as positional method arguments.
-- When `args` decodes to an object or primitive, the handler passes it as a single argument.
+- Omitted or decoded `null` arguments call the method with no arguments. Other objects or primitives are passed as one argument.
 - Set `options.protocolType` to `swap`, `swidge`, `bridge`, `lending`, or `fiat` to call a protocol wrapper. Every protocol call requires a non-empty `options.protocolName`.
 - When `context.allowedMethods` contains the target account or protocol surface, `methodName` must appear in that exact surface's `methods` array.
 - In beta.13, a missing wallet or protocol method fails with `BAD_REQUEST`. The removed `options.defaultValue` field no longer supplies a fallback; catch unsupported-method errors in the host.
+- Beta.14 removes `options.transformResult` from the declarations and ignores it during dispatch. Transform the returned value in the host instead.
+
+Invalid JSON in `config`, `args`, or `options` fails with `BAD_REQUEST`. Beta.14 reports a message such as `args must be valid JSON` without the native parser's error detail.
 
 ## Call Generic Module Methods
 
@@ -51291,7 +51326,9 @@ const response = await hrpc.callModule({
 const theme = response.result ? JSON.parse(response.result) : undefined
 ```
 
-`args` is an optional JSON string. Arrays are spread into positional arguments; a non-array value is passed as one argument. Promise results are awaited, `.toArray()` results are materialized, and `Uint8Array` values are normalized to hex before the response is serialized.
+`args` is an optional JSON string. Arrays are spread into positional arguments; omitted or decoded `null` arguments call the method with no arguments. Other values are passed as one argument. Promise results are awaited, `.toArray()` results are materialized, and `Uint8Array` values are normalized to hex before the response is serialized.
+
+In beta.14, a module method that returns `undefined` or `null` produces the JSON string `"null"` in the HRPC response. JSON-RPC decodes it to `response.result.result === null`. This normalization applies to `callModule()`, not wallet or protocol `callMethod()` results.
 
 When `context.allowedModuleMethods` contains the target module, `method` must appear in its `methods` array. A denied call returns `METHOD_NOT_ALLOWED` before module instance lookup or dispatch.
 
@@ -51342,8 +51379,14 @@ A declared module event arrives as a notification without an `id`; `params.paylo
 
 Manual JSON-RPC entrypoints must forward Bare `suspend` and `resume` events to `context.moduleRuntime` as shown in the HRPC context example. Registering JSON-RPC handlers alone does not install those lifecycle listeners.
 
+## Configure Logging
+
+Set `LOG_LEVEL` in the worklet environment before loading the package. Accepted values are `DEBUG`, `INFO`, `WARN`, `ERROR`, and `NONE`; beta.14 trims whitespace and ignores case. An unrecognized value falls back to `ERROR`. With `LOG_LEVEL` unset or empty, `NODE_ENV=development` selects `DEBUG`; other environments default to `ERROR`.
+
+At every enabled level, the package logger replaces object fields named `mnemonic`, `encryptionKey`, `encryptedSeed`, `encryptedSeedBuffer`, `encryptedEntropy`, `encryptedEntropyBuffer`, or `seed` with `[redacted]`. Matching is case-sensitive. Nested objects at depth three are replaced with `[object]`.
+
 <Callout type="warn">
-Beta.13 omits JSON-RPC parameters and results from its INFO request/response logs and moves wallet-call arguments to DEBUG. DEBUG can still expose sensitive arguments, and module errors or application logs are not generally redacted. Keep production logging at its default ERROR level and avoid sensitive values in custom logs and error messages.
+This is field-based redaction, not a general secret filter. Raw strings, serialized JSON, typed-array arguments, and formatted Error stacks are not scrubbed. Wallet-call arguments can appear at DEBUG, and module error messages and application logs can still expose sensitive values. Keep production logging at `ERROR` and avoid secrets in custom logs and errors.
 </Callout>
 
 ## Inspect Suspend Delays
@@ -51358,7 +51401,7 @@ registerHandleLeakCheck({ tickIntervalMs: 1000 })
 
 The helper logs a handle snapshot immediately on `suspend`, then repeats every `tickIntervalMs` milliseconds until `idle` or `resume`. The default interval is `1000` ms. Its timer is unreferenced so the diagnostic itself does not keep the event loop active. It reports handles; it does not close them or suspend modules.
 
-Provide a positive interval; the beta.13 helper passes the value to the timer without validating it. Registration is a no-op if the optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable. Diagnostic output uses `console.warn` regardless of `LOG_LEVEL`, so register it only when you need handle diagnostics.
+Provide a positive interval; the beta.14 helper passes the value to the timer without validating it. Registration is a no-op if the optional `bare-walk-handles` dependency or Bare lifecycle events are unavailable. Diagnostic output uses `console.warn` regardless of `LOG_LEVEL`, so register it only when you need handle diagnostics.
 
 ***
 
@@ -54644,7 +54687,7 @@ Worklet Bundler packages selected WDK wallet, protocol, and optional generic mod
 - **Opt-in handle diagnostics**: Use `options.handleLeakCheck` to inspect suspend-to-idle delays in generated HRPC worklets.
 
 <Callout type="info">
-`v1.0.0-beta.13` supports generic modules and their method allowlists in JSON-RPC entrypoints, including module suspend/resume forwarding. Use Pear Worklet `v1.0.0-beta.13` for JSON-RPC module calls and events. The `options.handleLeakCheck` diagnostic is generated only for HRPC.
+`v1.0.0-beta.13` supports generic modules and their method allowlists in JSON-RPC entrypoints, including module suspend/resume forwarding. The [installation example](/tools/worklet-bundler/configuration#install-the-packages) pairs it with Pear Worklet `v1.0.0-beta.14` for runtime module calls and events. The `options.handleLeakCheck` diagnostic is generated only for HRPC.
 </Callout>
 
 ## Why this matters
@@ -54984,11 +55027,11 @@ This page shows how to install `@tetherto/wdk-worklet-bundler` and its Pear runt
 Install the bundler as a development dependency and Pear Worklet as a runtime dependency in the host project:
 
 ```bash title="Install The Bundler And Runtime"
-npm install @tetherto/pear-wrk-wdk@1.0.0-beta.13
+npm install @tetherto/pear-wrk-wdk@1.0.0-beta.14
 npm install --save-dev @tetherto/wdk-worklet-bundler@1.0.0-beta.13
 ```
 
-Worklet Bundler beta.13 generates entrypoints that import Pear Worklet. Use Pear Worklet beta.13 for JSON-RPC generic-module calls and events, and for the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
+Worklet Bundler beta.13 generates entrypoints that import Pear Worklet. These examples pair it with Pear Worklet beta.14 for generic-module calls and events, seed-buffer cleanup, and the diagnostic export used by `options.handleLeakCheck`. The bundler checks whether the runtime package is installed; it does not enforce this version pairing.
 
 ## Create `wdk.config.js`
 
@@ -55152,7 +55195,7 @@ Use `modules` for named generic packages that expose a module factory. Each entr
 
 The factory receives `{ seed, config, capabilities, emit }` and can return the module instance or a promise for it. A module that needs the seed must consume it synchronously rather than retain it. The build-time name, such as `preferences`, must match the key in the host's runtime module config.
 
-Beta.13 generates these modules for both transports. With Pear Worklet beta.13, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
+Beta.13 generates these modules for both transports. With Pear Worklet beta.14, JSON-RPC initialization constructs them from the encrypted seed pair and matching runtime `modules` config. Module calls retain JSON-string `args`; results and event payloads are decoded JSON values. See the [Pear Worklet JSON-RPC examples](/tools/pear-wrk-wdk/configuration#json-rpc-transport).
 
 ### `transport` (optional)
 
@@ -55181,7 +55224,7 @@ The published config type supports these build options:
 - `linkAddons` (`boolean`): Link native addons with `bare-link`. Defaults to `true` for JSON-RPC and `false` for HRPC.
 - `platforms` (`('ios' | 'macos' | 'android')[]`): Addon platforms. Defaults to all three when addon linking is active.
 - `swiftTarget` (`string`): Xcode target written to `addons.yml`. Defaults to `app`.
-- `handleLeakCheck` (`number | true`, HRPC only): Opt in to repeated handle snapshots while suspended. `true` uses Pear Worklet beta.13's default `1000` ms interval; a positive number sets the interval in milliseconds. Omit the field to disable it. `false`, zero, negative numbers, and strings fail config validation.
+- `handleLeakCheck` (`number | true`, HRPC only): Opt in to repeated handle snapshots while suspended. `true` uses Pear Worklet's default `1000` ms interval; a positive number sets the interval in milliseconds. Omit the field to disable it. `false`, zero, negative numbers, and strings fail config validation.
 - `convertEsmToCjs` (`boolean`): Convert the bundle for a Bare port whose JavaScript engine cannot load ES modules, such as JSC or QuickJS. Defaults to `false` for both transports. Leave it off only when every target uses an ESM-capable engine such as V8.
 
 ### Configure suspend diagnostics

--- a/skills/wdk/references/protocol-bridge.md
+++ b/skills/wdk/references/protocol-bridge.md
@@ -25,12 +25,16 @@ import Usdt0ProtocolEvm from '@tetherto/wdk-protocol-bridge-usdt0-evm'
 
 ## Choose the account flow
 
+From `1.0.0-beta.9`, the constructor accepts shared `IWalletAccountReadOnly` and `IWalletAccount` interfaces. Runtime use still requires EVM-compatible account operations and the account's internal `_config.provider`; implementing the shared interface alone is insufficient. Read-only accounts can quote. Execution additionally requires a callable `sendTransaction()`.
+
 | Account | Approval behavior | Submission |
 |---|---|---|
 | Standard `WalletAccountEvm` | Call `account.approve()` for the source-chain OFT or bridge spender before `bridge()`. | Approval and bridge are separate EVM transactions. |
 | `WalletAccountEvmErc4337` | Do not call `account.approve()` separately. The protocol builds an approval to the transaction-value helper. | Approval and helper bridge call are submitted in one UserOperation. |
 
 ERC-4337 helper bridging is available from Ethereum, Arbitrum, Plasma, and Polygon. Other supported EVM source chains require a standard account.
+
+Helper selection and batching use the bridge package's concrete ERC-4337 classes. Beta.9 pins `@tetherto/wdk-wallet-evm-erc-4337` to beta.11. An account from a separate package copy, including a separately installed beta.18, can take the single-transaction path instead. Verify dependency resolution and class identity before relying on automatic approval batching; see the [account requirements](https://docs.wallet.tether.io/sdk/bridge-modules/bridge-usdt0-evm/api-reference#account-requirements).
 
 ## Standard account quick reference
 
@@ -85,7 +89,7 @@ The returned hash identifies the single UserOperation containing the approval an
 
 ### ERC-4337 fee-unit limitation
 
-In `1.0.0-beta.7`:
+In `1.0.0-beta.9`:
 
 - `bridgeFee` is in bridged-token base units.
 - `fee` is in source-native base units for native gas, paymaster-token base units for token-paid gas, or zero for sponsored gas.
@@ -99,7 +103,7 @@ Do not interpret that sum as one currency or configure an ERC-4337 cap until the
 
 **Additional destination keys:** `solana`, `ton`, `tron`
 
-For Solana, TON, and TRON targets, beta.7 skips a source chain's ordinary `oftContract` during auto-resolution. The bundled source-side candidates are:
+For Solana, TON, and TRON targets, beta.9 skips a source chain's ordinary `oftContract` during auto-resolution. The bundled source-side candidates are:
 
 - USD₮0 legacy mesh: Ethereum, Arbitrum, Celo.
 - XAU₮0 OFT: Ethereum, Arbitrum, Avalanche, Celo, HyperEVM, Ink, Monad, Plasma, Polygon, Stable.

--- a/skills/wdk/references/protocol-lending.md
+++ b/skills/wdk/references/protocol-lending.md
@@ -23,19 +23,21 @@ import AaveProtocolEvm from '@tetherto/wdk-protocol-lending-aave-evm'
 ## Quick Reference
 
 ```javascript
+// Ethereum account; complete Pool approval before supply or repayment
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDt, 6 decimals
 const aave = new AaveProtocolEvm(evmAccount)
 
-// Supply collateral
-await aave.supply({ token: '0x...', amount: 1000000n })
+// Supply tokens
+await aave.supply({ token: USDT, amount: 1000000n })
 
-// Borrow against collateral
-await aave.borrow({ token: '0x...', amount: 500000n })
+// Borrow only when eligible collateral provides enough borrowing power
+await aave.borrow({ token: USDT, amount: 500000n })
 
 // Repay borrowed amount
-await aave.repay({ token: '0x...', amount: 500000n })
+await aave.repay({ token: USDT, amount: 500000n })
 
-// Withdraw collateral
-await aave.withdraw({ token: '0x...', amount: 1000000n })
+// Withdraw supplied tokens when the remaining position permits it
+await aave.withdraw({ token: USDT, amount: 1000000n })
 
 // Check account health
 const data = await aave.getAccountData()
@@ -47,23 +49,26 @@ const data = await aave.getAccountData()
 
 | Method | Description |
 |--------|-------------|
-| `supply({token, amount})` | Deposit tokens as collateral |
+| `supply({token, amount})` | Deposit tokens into the reserve |
 | `withdraw({token, amount})` | Withdraw supplied tokens |
 | `borrow({token, amount})` | Borrow tokens against collateral |
 | `repay({token, amount})` | Repay borrowed tokens |
-| `setUseReserveAsCollateral({token, useAsCollateral})` | Toggle collateral status |
-| `setUserEMode({categoryId})` | Set efficiency mode for correlated assets |
+| `setUseReserveAsCollateral(token, useAsCollateral, config?)` | Toggle collateral status |
+| `setUserEMode(categoryId, config?)` | Set efficiency mode for correlated assets |
 
 ## Read Methods
 
 | Method | Description |
 |--------|-------------|
 | `getAccountData()` | Get position summary (health factor, LTV, etc.) |
-| `getConfig()` | Get protocol configuration |
+| `quoteSupply(options, config?)` / `quoteRepay(options, config?)` | Estimate supply or repayment fees |
+| `quoteBorrow(options, config?)` / `quoteWithdraw(options, config?)` | Estimate borrowing or withdrawal fees |
 
 ## Key Concepts
 
 - **Health Factor**: Must stay > 1.0 to avoid liquidation. Below 1.0 = position can be liquidated.
 - **LTV (Loan-to-Value)**: Maximum borrowing power relative to collateral.
 - **eMode (Efficiency Mode)**: Higher LTV for correlated assets (e.g., stablecoins).
-- May internally handle `approve()` for supply/repay operations.
+- Supply and repayment require sufficient Pool allowance. Approvals and any required reset are caller-owned, separate operations.
+- Accepts shared wallet interfaces, but requires an EVM provider in `account._config.provider` and the account methods each operation calls. Writes require a callable `sendTransaction()`.
+- Operation config is forwarded to the account; fees retain that account's gas-payment denomination.

--- a/skills/wdk/references/protocol-swap.md
+++ b/skills/wdk/references/protocol-swap.md
@@ -25,24 +25,29 @@ import VeloraProtocolEvm from '@tetherto/wdk-protocol-swap-velora-evm'
 ### Velora (EVM)
 
 ```javascript
+// Standard EVM account on Ethereum; complete input-token approval first
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7' // USDt, 6 decimals
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' // 18 decimals
 const velora = new VeloraProtocolEvm(evmAccount, { swapMaxFee: 200000000000000n })
 
 // Quote first
 const quote = await velora.quoteSwap({
-  tokenIn: '0x...',
-  tokenOut: '0x...',
+  tokenIn: USDT,
+  tokenOut: WETH,
   tokenInAmount: 1000000n
 })
 
 // Then swap (requires human confirmation)
 await velora.swap({
-  tokenIn: '0x...',
-  tokenOut: '0x...',
+  tokenIn: USDT,
+  tokenOut: WETH,
   tokenInAmount: 1000000n
 })
 ```
 
-- May internally handle `approve()` + reset allowance
+- Complete input-token approval to the current Velora spender separately; the protocol does not approve or reset allowances.
+- `swap()` forwards the same config and one transaction to account quote/send methods; `quoteSwap()` forwards config to account quoting without a concrete-class check.
+- Per-call `swapMaxFee` applies to standard and smart accounts. It rejects fees equal to or above the cap, in the account quote's units; `quoteSwap()` does not enforce this cap.
 - Works with both wallet-evm and wallet-evm-erc-4337 accounts
 
 ## Common Interface
@@ -51,4 +56,3 @@ await velora.swap({
 |--------|-------------|
 | `swap({tokenIn, tokenOut, tokenInAmount})` | Execute swap (⚠️ write method) |
 | `quoteSwap({tokenIn, tokenOut, tokenInAmount})` | Get swap quote with expected output |
-| `getConfig()` | Get protocol configuration |

--- a/skills/wdk/references/wallet-evm.md
+++ b/skills/wdk/references/wallet-evm.md
@@ -75,6 +75,7 @@ const wallet = new WalletManagerEvm(seedPhrase, {
 - `getPaymasterTokenBalance()` for fee balance
 - **Batch transactions**: `sendTransaction([tx1, tx2])` — multiple operations in one call
 - `signTransaction(tx)` signs one `UserOperationV7`; the signed result can be quoted and submitted through `sendTransaction()`.
+- The first UserOperation chain lookup checks the provider against constructor `chainId` and caches success. Sponsored quotes and already-signed quote/send paths skip this check; recreate the account when changing networks.
 - Signed UserOperations preserve their nonce and fee-mode configuration. Submit promptly through the same account and do not mutate them.
 - Signed UserOperation submission does not reapply `transactionMaxFee`. In paymaster-token mode, a signed-operation quote is a buffered native-gas ceiling in wei, not a token-denominated charge.
 - Quote-cache keys omit fee-mode configuration. Use the same mode, paymaster token, paymaster endpoints, and sponsorship policy for a quote and its matching send, sign, or transfer.
@@ -86,6 +87,7 @@ const wallet = new WalletManagerEvm(seedPhrase, {
 const wallet = new WalletManagerEvmErc4337(seedPhrase, {
   provider: 'https://arb1.arbitrum.io/rpc',
   chainId: 42161,
+  safeModulesVersion: '0.3.0',
   bundlerUrl: 'https://api.candide.dev/public/v3/42161',
   paymasterUrl: 'https://api.candide.dev/public/v3/42161',
   paymasterAddress: '0x8b1f6cb5d062aa2ce8d581942bbb960420d875ba',
@@ -100,7 +102,9 @@ const wallet = new WalletManagerEvmErc4337(seedPhrase, {
 
 - Uses EIP-7702 delegation and ERC-4337 UserOperations while retaining the EOA address.
 - Supports sponsored mode and paymaster-token mode.
+- `entryPointVersion` accepts `'0.8'` (default) or `'0.9'`. Match the delegation implementation, bundler, and paymaster to that version.
+- Optional `chainId` checks the provider's first UserOperation chain lookup and caches success. Owned-account quotes and sends check even sponsored or signed inputs; read-only sponsored quotes skip it. The check does not validate an externally signed payload's chain or EntryPoint.
 - Owned account paymaster-token quotes are cached for up to 2 minutes.
 - Before reusing a cached UserOperation, the account validates its EntryPoint nonce and re-quotes if the nonce moved.
 - A send that needs a fresh EIP-7702 authorization rebuilds the UserOperation instead of reusing the cached one.
-- Quote-cache keys omit fee-mode configuration. Use the same mode, paymaster token, paymaster endpoints, and sponsorship policy for a quote and its matching send or transfer.
+- Quote-cache keys include the transaction, sponsorship mode, paymaster token, expected paymaster address, and sponsorship policy. Changing a keyed field creates a fresh quote.

--- a/skills/wdk/references/wallet-evm.md
+++ b/skills/wdk/references/wallet-evm.md
@@ -73,6 +73,7 @@ const wallet = new WalletManagerEvm(seedPhrase, {
 - **Gasless** via UserOperations + Paymaster
 - Fees paid in **paymaster token** (e.g., USD₮) instead of native ETH
 - `getPaymasterTokenBalance()` for fee balance
+- [`WalletAccountReadOnlyEvmErc4337.fromSafeAddress()`](https://docs.wallet.tether.io/sdk/wallet-modules/wallet-evm-erc-4337/guides/manage-accounts#read-a-known-safe-address) monitors a supplied Safe address without its owner or a seed. It cannot sign, send, or verify owner signatures. Non-sponsored quotes require a deployed Safe; a sponsored zero-fee quote does not establish deployment or eligibility.
 - **Batch transactions**: `sendTransaction([tx1, tx2])` — multiple operations in one call
 - `signTransaction(tx)` signs one `UserOperationV7`; the signed result can be quoted and submitted through `sendTransaction()`.
 - The first UserOperation chain lookup checks the provider against constructor `chainId` and caches success. Sponsored quotes and already-signed quote/send paths skip this check; recreate the account when changing networks.


### PR DESCRIPTION
## Summary

- Add Pear Worklet beta.14 seed-buffer cleanup and logging limits, generic-module result and event fixes, and migration away from `transformResult`. Update the Bundler runtime installation pair.
- Document expanded Core policy coverage and migration, known-Safe monitoring, TON address validation, payment-URI encoding, and the scrypt fix.
- Update Aave and Velora account compatibility, per-call configuration, approval prerequisites, and fee-unit guidance. Refresh React Native beta.19 setup and Bundler beta.13 references.
- Retain the September 2–3 coverage for EntryPoint selection, provider-chain checks, bridge account requirements, JSON-RPC modules and lifecycle handling. Refresh guides, API references, skill references and generated LLM documents within the existing navigation.
- Include the dependency updates from #247, #253, #254, #255 and #256: fast-uri 3.1.7, the AI SDK group, baseline-browser-mapping 2.11.22, Sharp 0.35.4 and Next.js 16.3.4.

<details>
<summary>Published release coverage</summary>

| Published (UTC) | Package | Version |
|---|---|---|
| September 11, 2026 | pear-wrk-wdk | [1.0.0-beta.14](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.14) |
| September 8, 2026 | @tetherto/wdk | [1.0.0-beta.17](https://github.com/tetherto/wdk/releases/tag/v1.0.0-beta.17) |
| September 8, 2026 | lending-aave-evm | [1.0.0-beta.7](https://github.com/tetherto/wdk-protocol-lending-aave-evm/releases/tag/v1.0.0-beta.7) |
| September 8, 2026 | react-native-core | [1.0.0-beta.19](https://github.com/tetherto/wdk-react-native-core/releases/tag/v1.0.0-beta.19) |
| September 8, 2026 | swap-velora-evm | [1.0.0-beta.8](https://github.com/tetherto/wdk-protocol-swap-velora-evm/releases/tag/v1.0.0-beta.8) |
| September 8, 2026 | wallet-evm-erc-4337 | [1.0.0-beta.19](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.19) |
| September 8, 2026 | wdk-utils | [1.0.0-beta.12](https://github.com/tetherto/wdk-utils/releases/tag/v1.0.0-beta.12) |
| September 8, 2026 | worklet-bundler | [1.0.0-beta.13](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.13) |
| September 3, 2026 | worklet-bundler | [1.0.0-beta.12](https://github.com/tetherto/wdk-worklet-bundler/releases/tag/v1.0.0-beta.12) |
| September 3, 2026 | bridge-usdt0-evm | [1.0.0-beta.9](https://github.com/tetherto/wdk-protocol-bridge-usdt0-evm/releases/tag/v1.0.0-beta.9) |
| September 3, 2026 | wallet-evm-7702-gasless | [1.0.0-beta.5](https://github.com/tetherto/wdk-wallet-evm-7702-gasless/releases/tag/v1.0.0-beta.5) |
| September 3, 2026 | wallet-evm-erc-4337 | [1.0.0-beta.18](https://github.com/tetherto/wdk-wallet-evm-erc-4337/releases/tag/v1.0.0-beta.18) |
| September 2, 2026 | pear-wrk-wdk | [1.0.0-beta.13](https://github.com/tetherto/pear-wrk-wdk/releases/tag/v1.0.0-beta.13) |

</details>

## Validation

- Node 22.22.2 / npm 10.9.7: clean `npm ci` with cached private SEO packages, `npm run build:static`, `LINK_CHECK_EXTERNAL=false npm run quality`, and the separate `npm run check:links` external-link check.
- Dependency-tree verification and native Sharp image test passed. Generated documentation and search parity passed for all 346 routes.

